### PR TITLE
fix: clear stale passkey removal state

### DIFF
--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -3536,9 +3536,9 @@ ${encryptionKey.replace('key_', '')}
                                   await deletePasskeyCredential(credentialId)
                                 if (ok) {
                                   toast({
-                                    title: 'Passkey removed',
+                                    title: 'Passkey recovery removed',
                                     description:
-                                      'That platform can no longer unlock your chats with this passkey.',
+                                      'That platform can no longer recover your cloud encryption key with this bundle.',
                                   })
                                   await refreshPasskeyBundles()
                                   if (onRefreshBundleState) {

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -237,6 +237,11 @@ const backupWarningDismissedFlag = createStorageFlag(
   SETTINGS_BACKUP_WARNING_DISMISSED,
 )
 
+const passkeyBackedUpFlag = createStorageFlag(
+  () => localStorage,
+  SECRET_PASSKEY_BACKED_UP,
+)
+
 export function usePasskeyBackup({
   encryptionKey,
   initialized,
@@ -961,13 +966,28 @@ export function usePasskeyBackup({
 
   // --- Passkey initialization (runs once after cloud sync init completes) ---
   useEffect(() => {
-    if (!initialized || !isSignedIn || hasInitializedPasskeyRef.current) return
+    const initializationUserId = user?.id
+    const initializationEncryptionKey = encryptionKey
+    if (
+      !initialized ||
+      !isSignedIn ||
+      !initializationUserId ||
+      hasInitializedPasskeyRef.current
+    ) {
+      return
+    }
     hasInitializedPasskeyRef.current = true
+
+    const isCurrentInitialization = () =>
+      isMountedRef.current &&
+      userRef.current?.id === initializationUserId &&
+      encryptionKeyRef.current === initializationEncryptionKey
 
     const initializePasskey = async () => {
       const prfSupported = await isPrfSupported()
+      if (!isCurrentInitialization()) return
 
-      if (encryptionKey) {
+      if (initializationEncryptionKey) {
         // A local key that derives a different key id than the
         // enclave's registered one can never write or migrate — this
         // device is stale and needs to converge onto the registered
@@ -976,6 +996,7 @@ export function usePasskeyBackup({
         // key entry when it was adopted bundleless (e.g. by the
         // migration path on another device).
         const validation = await validateCurrentPrimaryKey()
+        if (!isCurrentInitialization()) return
         if (!validation.canWrite && validation.remoteState === 'exists') {
           let hasRemoteBundles = false
           try {
@@ -985,7 +1006,7 @@ export function usePasskeyBackup({
             // Transient enclave failure: fall through to the manual
             // prompt, which is dismissible and retried next visit.
           }
-          if (!isMountedRef.current) return
+          if (!isCurrentInitialization()) return
           if (hasRemoteBundles && prfSupported) {
             if (!passkeyRecoveryDismissedFlag.isSet()) {
               setState((prev) => ({
@@ -1005,7 +1026,7 @@ export function usePasskeyBackup({
           }
           return
         }
-        if (!isMountedRef.current) return
+        if (!isCurrentInitialization()) return
       }
 
       if (!prfSupported) {
@@ -1015,9 +1036,9 @@ export function usePasskeyBackup({
         // offer the manual-backup fallback. If remote data exists, they need
         // the manual recovery flow to decrypt it. Users who already have a
         // local key stay silent — local storage works fine even without PRF.
-        if (!encryptionKey) {
+        if (!initializationEncryptionKey) {
           const remoteState = await inspectRemoteEncryptedState()
-          if (!isMountedRef.current) return
+          if (!isCurrentInitialization()) return
           if (remoteState === 'empty') {
             if (!backupWarningDismissedFlag.isSet()) {
               setState((prev) => ({
@@ -1059,10 +1080,11 @@ export function usePasskeyBackup({
         return
       }
 
-      if (encryptionKey) {
+      if (initializationEncryptionKey) {
         // User has local keys — check for existing backup
         const localCredentialId = getLocalPasskeyCredentialId()
         const deviceState = await getPasskeyDeviceState(localCredentialId)
+        if (!isCurrentInitialization()) return
 
         if (deviceState === 'this-device') {
           // This device already has its own bundle — show green badge,
@@ -1097,15 +1119,13 @@ export function usePasskeyBackup({
           deviceState === 'empty' &&
           !passkeyFlowInProgressRef.current
         ) {
-          localStorage.removeItem(SECRET_PASSKEY_BACKED_UP)
-          if (isMountedRef.current) {
-            setState((prev) => ({
-              ...prev,
-              passkeySetupAvailable: true,
-              passkeyAddDeviceAvailable: false,
-              passkeyActive: false,
-            }))
-          }
+          passkeyBackedUpFlag.clear()
+          setState((prev) => ({
+            ...prev,
+            passkeySetupAvailable: true,
+            passkeyAddDeviceAvailable: false,
+            passkeyActive: false,
+          }))
         }
       } else {
         // No localStorage keys — check backend state but do not auto-prompt
@@ -1113,6 +1133,7 @@ export function usePasskeyBackup({
         // UI state flag instead and let the user trigger the WebAuthn call
         // explicitly from a confirmation or recovery modal.
         const credentialState = await getPasskeyCredentialState()
+        if (!isCurrentInitialization()) return
 
         if (credentialState === 'exists') {
           // If the user explicitly dismissed the recovery prompt on a
@@ -1129,6 +1150,7 @@ export function usePasskeyBackup({
           }
         } else if (credentialState === 'empty') {
           const remoteState = await inspectRemoteEncryptedState()
+          if (!isCurrentInitialization()) return
 
           if (remoteState === 'empty') {
             if (isMountedRef.current && !firstTimePromptDismissedFlag.isSet()) {
@@ -1187,7 +1209,7 @@ export function usePasskeyBackup({
     }
 
     initializePasskey()
-  }, [initialized, isSignedIn, encryptionKey])
+  }, [initialized, isSignedIn, encryptionKey, user?.id])
 
   // Clear the persistent "recovery dismissed" flag and the session
   // first-time-prompt flag once the user has a key again (via passkey
@@ -1668,7 +1690,7 @@ export function usePasskeyBackup({
         passkeyActive: false,
       }))
     } else if (deviceState === 'empty') {
-      localStorage.removeItem(SECRET_PASSKEY_BACKED_UP)
+      passkeyBackedUpFlag.clear()
       setState((prev) => ({
         ...prev,
         passkeySetupAvailable: true,

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -977,17 +977,9 @@ export function usePasskeyBackup({
       return
     }
     const initializedSnapshot = initializedPasskeySnapshotRef.current
-    if (
-      initializedSnapshot?.userId === initializationUserId &&
-      initializedSnapshot.encryptionKey === initializationEncryptionKey
-    ) {
-      return
-    }
-    if (
-      initializedSnapshot &&
-      initializedSnapshot.userId !== initializationUserId &&
-      initializedSnapshot.encryptionKey === initializationEncryptionKey
-    ) {
+    // The same key was either initialized for this user or is still awaiting
+    // account-scoped cleanup from the previous user.
+    if (initializedSnapshot?.encryptionKey === initializationEncryptionKey) {
       return
     }
     const initializationSnapshot: PasskeyInitializationSnapshot = {

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -260,6 +260,8 @@ export function usePasskeyBackup({
   const passkeyFlowInProgressRef = useRef(false)
   const userRef = useRef(user)
   userRef.current = user
+  const encryptionKeyRef = useRef(encryptionKey)
+  encryptionKeyRef.current = encryptionKey
   const onEncryptionKeyRecoveredRef = useRef(onEncryptionKeyRecovered)
   onEncryptionKeyRecoveredRef.current = onEncryptionKeyRecovered
   const hasInitializedPasskeyRef = useRef(false)
@@ -1095,11 +1097,13 @@ export function usePasskeyBackup({
           deviceState === 'empty' &&
           !passkeyFlowInProgressRef.current
         ) {
+          localStorage.removeItem(SECRET_PASSKEY_BACKED_UP)
           if (isMountedRef.current) {
             setState((prev) => ({
               ...prev,
               passkeySetupAvailable: true,
               passkeyAddDeviceAvailable: false,
+              passkeyActive: false,
             }))
           }
         }
@@ -1634,9 +1638,18 @@ export function usePasskeyBackup({
   const refreshBundleState = useCallback(async (): Promise<void> => {
     if (!encryptionKey) return
     if (passkeyFlowInProgressRef.current) return
+    const refreshUserId = userRef.current?.id
+    const refreshEncryptionKey = encryptionKey
+    if (!refreshUserId) return
     const localCredentialId = getLocalPasskeyCredentialId()
     const deviceState = await getPasskeyDeviceState(localCredentialId)
-    if (!isMountedRef.current) return
+    if (
+      !isMountedRef.current ||
+      userRef.current?.id !== refreshUserId ||
+      encryptionKeyRef.current !== refreshEncryptionKey
+    ) {
+      return
+    }
 
     if (deviceState === 'this-device') {
       localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
@@ -1655,10 +1668,12 @@ export function usePasskeyBackup({
         passkeyActive: false,
       }))
     } else if (deviceState === 'empty') {
+      localStorage.removeItem(SECRET_PASSKEY_BACKED_UP)
       setState((prev) => ({
         ...prev,
         passkeySetupAvailable: true,
         passkeyAddDeviceAvailable: false,
+        passkeyActive: false,
       }))
     }
   }, [encryptionKey])

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -972,7 +972,7 @@ export function usePasskeyBackup({
 
   // --- Passkey initialization (runs once after cloud sync init completes) ---
   useEffect(() => {
-    const initializationUserId = user?.id
+    const initializationUserId = userRef.current?.id
     const initializationEncryptionKey = encryptionKey
     if (!initialized || !isSignedIn || !initializationUserId) {
       return
@@ -1222,7 +1222,7 @@ export function usePasskeyBackup({
     }
 
     initializePasskey()
-  }, [initialized, isSignedIn, encryptionKey, user?.id])
+  }, [initialized, isSignedIn, encryptionKey])
 
   // Clear the persistent "recovery dismissed" flag and the session
   // first-time-prompt flag once the user has a key again (via passkey

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -103,6 +103,11 @@ type GeneratedPasskeyKey = {
   credentialId: string
 }
 
+type PasskeyInitializationSnapshot = {
+  userId: string
+  encryptionKey: string | null
+}
+
 type ApplyRecoveredKeyBundleResult =
   | { mode: CloudKeyAuthorizationMode }
   | { mode: null; reason: PasskeyRecoveryFailure }
@@ -269,7 +274,8 @@ export function usePasskeyBackup({
   encryptionKeyRef.current = encryptionKey
   const onEncryptionKeyRecoveredRef = useRef(onEncryptionKeyRecovered)
   onEncryptionKeyRecoveredRef.current = onEncryptionKeyRecovered
-  const hasInitializedPasskeyRef = useRef(false)
+  const initializedPasskeySnapshotRef =
+    useRef<PasskeyInitializationSnapshot | null>(null)
   const previousUserIdRef = useRef<string | null | undefined>(undefined)
 
   // Cleanup on unmount
@@ -298,7 +304,7 @@ export function usePasskeyBackup({
       return
     }
     if (currentUserId !== null && currentUserId !== previousUserIdRef.current) {
-      hasInitializedPasskeyRef.current = false
+      initializedPasskeySnapshotRef.current = null
       passkeyRecoveryDismissedFlag.clear()
       firstTimePromptDismissedFlag.clear()
       setupWarningDismissedFlag.clear()
@@ -968,20 +974,27 @@ export function usePasskeyBackup({
   useEffect(() => {
     const initializationUserId = user?.id
     const initializationEncryptionKey = encryptionKey
+    if (!initialized || !isSignedIn || !initializationUserId) {
+      return
+    }
+    const initializedSnapshot = initializedPasskeySnapshotRef.current
     if (
-      !initialized ||
-      !isSignedIn ||
-      !initializationUserId ||
-      hasInitializedPasskeyRef.current
+      initializedSnapshot?.userId === initializationUserId &&
+      initializedSnapshot.encryptionKey === initializationEncryptionKey
     ) {
       return
     }
-    hasInitializedPasskeyRef.current = true
+    const initializationSnapshot: PasskeyInitializationSnapshot = {
+      userId: initializationUserId,
+      encryptionKey: initializationEncryptionKey,
+    }
+    initializedPasskeySnapshotRef.current = initializationSnapshot
 
     const isCurrentInitialization = () =>
       isMountedRef.current &&
-      userRef.current?.id === initializationUserId &&
-      encryptionKeyRef.current === initializationEncryptionKey
+      initializedPasskeySnapshotRef.current === initializationSnapshot &&
+      userRef.current?.id === initializationSnapshot.userId &&
+      encryptionKeyRef.current === initializationSnapshot.encryptionKey
 
     const initializePasskey = async () => {
       const prfSupported = await isPrfSupported()

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -304,7 +304,6 @@ export function usePasskeyBackup({
       return
     }
     if (currentUserId !== null && currentUserId !== previousUserIdRef.current) {
-      initializedPasskeySnapshotRef.current = null
       passkeyRecoveryDismissedFlag.clear()
       firstTimePromptDismissedFlag.clear()
       setupWarningDismissedFlag.clear()
@@ -972,7 +971,7 @@ export function usePasskeyBackup({
 
   // --- Passkey initialization (runs once after cloud sync init completes) ---
   useEffect(() => {
-    const initializationUserId = userRef.current?.id
+    const initializationUserId = user?.id
     const initializationEncryptionKey = encryptionKey
     if (!initialized || !isSignedIn || !initializationUserId) {
       return
@@ -980,6 +979,13 @@ export function usePasskeyBackup({
     const initializedSnapshot = initializedPasskeySnapshotRef.current
     if (
       initializedSnapshot?.userId === initializationUserId &&
+      initializedSnapshot.encryptionKey === initializationEncryptionKey
+    ) {
+      return
+    }
+    if (
+      initializedSnapshot &&
+      initializedSnapshot.userId !== initializationUserId &&
       initializedSnapshot.encryptionKey === initializationEncryptionKey
     ) {
       return
@@ -1222,7 +1228,7 @@ export function usePasskeyBackup({
     }
 
     initializePasskey()
-  }, [initialized, isSignedIn, encryptionKey])
+  }, [initialized, isSignedIn, encryptionKey, user?.id])
 
   // Clear the persistent "recovery dismissed" flag and the session
   // first-time-prompt flag once the user has a key again (via passkey

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -450,9 +450,7 @@ describe('usePasskeyBackup', () => {
 
     await waitFor(() => expect(mocks.getPasskeyDeviceState).toHaveBeenCalled())
     rerender({ encryptionKey: 'key_2' })
-    await act(async () => {
-      await result.current.refreshBundleState()
-    })
+    await waitFor(() => expect(result.current.passkeyActive).toBe(true))
 
     await act(async () => {
       resolveOldState('empty')
@@ -474,6 +472,31 @@ describe('usePasskeyBackup', () => {
 
     expect(localStorage.getItem(SECRET_PASSKEY_BACKED_UP)).toBeNull()
     expect(result.current.passkeyActive).toBe(false)
+  })
+
+  it('does not initialize twice for equivalent rerenders', async () => {
+    mocks.getPasskeyDeviceState.mockResolvedValue('this-device')
+    const { rerender } = renderHook(
+      ({ user }) =>
+        usePasskeyBackup({
+          ...baseOptions,
+          user,
+          encryptionKey: 'key_current',
+        }),
+      { initialProps: { user: { id: 'user_1' } as any } },
+    )
+
+    await waitFor(() =>
+      expect(mocks.getPasskeyDeviceState).toHaveBeenCalledTimes(1),
+    )
+    rerender({ user: { id: 'user_1' } as any })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(mocks.isPrfSupported).toHaveBeenCalledTimes(1)
+    expect(mocks.validateCurrentPrimaryKey).toHaveBeenCalledTimes(1)
+    expect(mocks.getPasskeyDeviceState).toHaveBeenCalledTimes(1)
   })
 
   it.each([

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -424,6 +424,7 @@ describe('usePasskeyBackup', () => {
     })
 
     expect(mocks.getPasskeyDeviceState).toHaveBeenCalledTimes(1)
+    expect(mocks.isPrfSupported).toHaveBeenCalledTimes(1)
     expect(localStorage.getItem(SECRET_PASSKEY_BACKED_UP)).toBe('true')
     expect(result.current.passkeyActive).toBe(false)
     expect(result.current.passkeySetupAvailable).toBe(false)
@@ -432,7 +433,29 @@ describe('usePasskeyBackup', () => {
     await waitFor(() => expect(result.current.passkeyActive).toBe(true))
 
     expect(mocks.getPasskeyDeviceState).toHaveBeenCalledTimes(2)
+    expect(mocks.isPrfSupported).toHaveBeenCalledTimes(2)
     expect(result.current.passkeySetupAvailable).toBe(false)
+  })
+
+  it('initializes once when the signed-in user finishes hydrating', async () => {
+    mocks.getPasskeyDeviceState.mockResolvedValue('this-device')
+    const { result, rerender } = renderHook(
+      ({ userId }) =>
+        usePasskeyBackup({
+          ...baseOptions,
+          user: userId ? ({ id: userId } as any) : null,
+          encryptionKey: 'key_current',
+        }),
+      { initialProps: { userId: null as string | null } },
+    )
+
+    expect(mocks.getPasskeyDeviceState).not.toHaveBeenCalled()
+    rerender({ userId: 'user_1' })
+    await waitFor(() => expect(result.current.passkeyActive).toBe(true))
+
+    expect(mocks.isPrfSupported).toHaveBeenCalledTimes(1)
+    expect(mocks.validateCurrentPrimaryKey).toHaveBeenCalledTimes(1)
+    expect(mocks.getPasskeyDeviceState).toHaveBeenCalledTimes(1)
   })
 
   it('ignores stale empty initialization after encryption key rotation', async () => {

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -1,4 +1,7 @@
-import { SETTINGS_MANUAL_RECOVERY_DISMISSED } from '@/constants/storage-keys'
+import {
+  SECRET_PASSKEY_BACKED_UP,
+  SETTINGS_MANUAL_RECOVERY_DISMISSED,
+} from '@/constants/storage-keys'
 import { usePasskeyBackup } from '@/hooks/use-passkey-backup'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -332,6 +335,79 @@ describe('usePasskeyBackup', () => {
 
     expect(enrolled).toBe(false)
     expect(mocks.storeEncryptedKeys).not.toHaveBeenCalled()
+  })
+
+  it('clears stale recovery state when no passkey bundles remain', async () => {
+    localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
+    mocks.getLocalPasskeyCredentialId.mockReturnValue('cred-local')
+    mocks.getPasskeyDeviceState
+      .mockResolvedValueOnce('this-device')
+      .mockResolvedValueOnce('empty')
+    const { result } = renderHook(() =>
+      usePasskeyBackup({
+        ...baseOptions,
+        initialized: false,
+        encryptionKey: 'key_current',
+      }),
+    )
+
+    await act(async () => {
+      await result.current.refreshBundleState()
+      await result.current.refreshBundleState()
+    })
+
+    expect(localStorage.getItem(SECRET_PASSKEY_BACKED_UP)).toBeNull()
+    expect(result.current.passkeyActive).toBe(false)
+    expect(result.current.passkeySetupAvailable).toBe(true)
+  })
+
+  it.each([
+    {
+      name: 'signed-in user changes',
+      initial: { userId: 'user_1', encryptionKey: 'key_1' },
+      next: { userId: 'user_2', encryptionKey: 'key_1' },
+    },
+    {
+      name: 'encryption key rotates',
+      initial: { userId: 'user_1', encryptionKey: 'key_1' },
+      next: { userId: 'user_1', encryptionKey: 'key_2' },
+    },
+  ])('ignores an old empty refresh when $name', async ({ initial, next }) => {
+    let resolveOldState!: (state: 'empty') => void
+    const oldState = new Promise<'empty'>((resolve) => {
+      resolveOldState = resolve
+    })
+    mocks.getLocalPasskeyCredentialId.mockReturnValue('cred-local')
+    mocks.getPasskeyDeviceState
+      .mockReturnValueOnce(oldState)
+      .mockResolvedValueOnce('this-device')
+    const { result, rerender } = renderHook(
+      ({ userId, encryptionKey }) =>
+        usePasskeyBackup({
+          ...baseOptions,
+          initialized: false,
+          user: { id: userId } as any,
+          encryptionKey,
+        }),
+      { initialProps: initial },
+    )
+
+    let staleRefresh!: Promise<void>
+    await act(async () => {
+      staleRefresh = result.current.refreshBundleState()
+      await Promise.resolve()
+    })
+    rerender(next)
+    localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
+    await act(async () => {
+      await result.current.refreshBundleState()
+      resolveOldState('empty')
+      await staleRefresh
+    })
+
+    expect(localStorage.getItem(SECRET_PASSKEY_BACKED_UP)).toBe('true')
+    expect(result.current.passkeyActive).toBe(true)
+    expect(result.current.passkeySetupAvailable).toBe(false)
   })
 
   describe('addPasskeyToThisDevice legacy promotion', () => {

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -393,7 +393,7 @@ describe('usePasskeyBackup', () => {
     expect(result.current.passkeySetupAvailable).toBe(true)
   })
 
-  it('ignores stale empty initialization after a same-tab user switch', async () => {
+  it('waits for a key change before initializing a switched user', async () => {
     let resolveOldState!: (state: 'empty') => void
     const oldState = new Promise<'empty'>((resolve) => {
       resolveOldState = resolve
@@ -416,16 +416,22 @@ describe('usePasskeyBackup', () => {
     )
 
     await waitFor(() => expect(mocks.getPasskeyDeviceState).toHaveBeenCalled())
-    rerender({ userId: 'user_2', encryptionKey: 'key_2' })
-    await waitFor(() => expect(result.current.passkeyActive).toBe(true))
+    rerender({ userId: 'user_2', encryptionKey: 'key_1' })
 
     await act(async () => {
       resolveOldState('empty')
       await oldState
     })
 
+    expect(mocks.getPasskeyDeviceState).toHaveBeenCalledTimes(1)
     expect(localStorage.getItem(SECRET_PASSKEY_BACKED_UP)).toBe('true')
-    expect(result.current.passkeyActive).toBe(true)
+    expect(result.current.passkeyActive).toBe(false)
+    expect(result.current.passkeySetupAvailable).toBe(false)
+
+    rerender({ userId: 'user_2', encryptionKey: 'key_2' })
+    await waitFor(() => expect(result.current.passkeyActive).toBe(true))
+
+    expect(mocks.getPasskeyDeviceState).toHaveBeenCalledTimes(2)
     expect(result.current.passkeySetupAvailable).toBe(false)
   })
 

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -361,6 +361,121 @@ describe('usePasskeyBackup', () => {
     expect(result.current.passkeySetupAvailable).toBe(true)
   })
 
+  it('updates empty refresh state when marker removal throws', async () => {
+    localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
+    mocks.getLocalPasskeyCredentialId.mockReturnValue('cred-local')
+    mocks.getPasskeyDeviceState
+      .mockResolvedValueOnce('this-device')
+      .mockResolvedValueOnce('empty')
+    const { result } = renderHook(() =>
+      usePasskeyBackup({
+        ...baseOptions,
+        initialized: false,
+        encryptionKey: 'key_current',
+      }),
+    )
+
+    await act(async () => {
+      await result.current.refreshBundleState()
+    })
+    const removeItem = vi
+      .spyOn(Storage.prototype, 'removeItem')
+      .mockImplementationOnce(() => {
+        throw new Error('storage unavailable')
+      })
+
+    await act(async () => {
+      await result.current.refreshBundleState()
+    })
+    removeItem.mockRestore()
+
+    expect(result.current.passkeyActive).toBe(false)
+    expect(result.current.passkeySetupAvailable).toBe(true)
+  })
+
+  it('ignores stale empty initialization after a same-tab user switch', async () => {
+    let resolveOldState!: (state: 'empty') => void
+    const oldState = new Promise<'empty'>((resolve) => {
+      resolveOldState = resolve
+    })
+    localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
+    mocks.getLocalPasskeyCredentialId.mockReturnValue('cred-local')
+    mocks.getPasskeyDeviceState
+      .mockReturnValueOnce(oldState)
+      .mockResolvedValueOnce('this-device')
+    const { result, rerender } = renderHook(
+      ({ userId, encryptionKey }) =>
+        usePasskeyBackup({
+          ...baseOptions,
+          user: { id: userId } as any,
+          encryptionKey,
+        }),
+      {
+        initialProps: { userId: 'user_1', encryptionKey: 'key_1' },
+      },
+    )
+
+    await waitFor(() => expect(mocks.getPasskeyDeviceState).toHaveBeenCalled())
+    rerender({ userId: 'user_2', encryptionKey: 'key_2' })
+    await waitFor(() => expect(result.current.passkeyActive).toBe(true))
+
+    await act(async () => {
+      resolveOldState('empty')
+      await oldState
+    })
+
+    expect(localStorage.getItem(SECRET_PASSKEY_BACKED_UP)).toBe('true')
+    expect(result.current.passkeyActive).toBe(true)
+    expect(result.current.passkeySetupAvailable).toBe(false)
+  })
+
+  it('ignores stale empty initialization after encryption key rotation', async () => {
+    let resolveOldState!: (state: 'empty') => void
+    const oldState = new Promise<'empty'>((resolve) => {
+      resolveOldState = resolve
+    })
+    localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
+    mocks.getLocalPasskeyCredentialId.mockReturnValue('cred-local')
+    mocks.getPasskeyDeviceState
+      .mockReturnValueOnce(oldState)
+      .mockResolvedValueOnce('this-device')
+    const { result, rerender } = renderHook(
+      ({ encryptionKey }) =>
+        usePasskeyBackup({
+          ...baseOptions,
+          encryptionKey,
+        }),
+      { initialProps: { encryptionKey: 'key_1' } },
+    )
+
+    await waitFor(() => expect(mocks.getPasskeyDeviceState).toHaveBeenCalled())
+    rerender({ encryptionKey: 'key_2' })
+    await act(async () => {
+      await result.current.refreshBundleState()
+    })
+
+    await act(async () => {
+      resolveOldState('empty')
+      await oldState
+    })
+
+    expect(localStorage.getItem(SECRET_PASSKEY_BACKED_UP)).toBe('true')
+    expect(result.current.passkeyActive).toBe(true)
+    expect(result.current.passkeySetupAvailable).toBe(false)
+  })
+
+  it('applies final-empty initialization for the current account and key', async () => {
+    localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
+    const { result } = renderHook(() =>
+      usePasskeyBackup({ ...baseOptions, encryptionKey: 'key_current' }),
+    )
+
+    await waitFor(() => expect(result.current.passkeySetupAvailable).toBe(true))
+
+    expect(localStorage.getItem(SECRET_PASSKEY_BACKED_UP)).toBeNull()
+    expect(result.current.passkeyActive).toBe(false)
+  })
+
   it.each([
     {
       name: 'signed-in user changes',


### PR DESCRIPTION
## Summary
- clear the passkey-active flag and persisted backup marker when no recovery bundles remain
- ignore stale bundle refreshes after a user switch or encryption-key rotation
- make removal confirmation describe Tinfoil recovery rather than OS credential deletion

## Scope
- 19 production lines across the settings copy and existing passkey hook
- no inventory redesign, legacy UI, account cleanup, ceremony, login, setup, recovery, CEK, or PRF-cache changes

## Testing
- 1,992 unit tests
- typecheck and lint
- focused final-bundle, user-switch, and key-rotation refresh tests