### PR TITLE
fix: enforce Premium project access

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -116,6 +116,7 @@ import {
 import { TfTinSad } from '@tinfoilsh/tinfoil-icons'
 import dynamic from 'next/dynamic'
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { SubscribePromptModal } from '../modals/subscribe-prompt-modal'
@@ -319,6 +320,7 @@ export function ChatInterface({
   suppressIntroModals = false,
 }: ChatInterfaceProps) {
   const { toast } = useToast()
+  const router = useRouter()
   const indexedDBBlockedToastShownRef = useRef(false)
 
   useEffect(() => {
@@ -673,6 +675,12 @@ export function ChatInterface({
   const userEmail = user?.primaryEmailAddress?.emailAddress || ''
 
   const isPremium = chat_subscription_active ?? false
+
+  useEffect(() => {
+    if (!router.isReady || router.query.upgrade !== 'projects') return
+    setIsSubscribePromptOpen(true)
+    void router.replace('/chat', undefined, { shallow: true })
+  }, [router])
 
   // Load projects for move to project functionality
   const { projects } = useProjects({
@@ -2288,6 +2296,10 @@ export function ChatInterface({
   }, [passkeyActive, setupPasskey])
 
   const handleCreateProject = useCallback(async () => {
+    if (!isPremium) {
+      setIsSubscribePromptOpen(true)
+      return
+    }
     invalidateFavoriteNavigation()
     try {
       const name = `My Project #${projects.length + 1}`
@@ -2313,6 +2325,7 @@ export function ChatInterface({
     createNewChat,
     enterProjectMode,
     invalidateFavoriteNavigation,
+    isPremium,
     projects.length,
     toast,
   ])
@@ -2324,6 +2337,22 @@ export function ChatInterface({
     createNewChat(false, true)
     exitProjectMode()
   }, [createNewChat, exitProjectMode])
+
+  useEffect(() => {
+    if (isPremium || (!isProjectMode && !currentChat.projectId)) return
+    setPendingProjectUpload(null)
+    setShowAddToProjectModal(false)
+    createNewChat(false, true)
+    exitProjectMode()
+    clearUrl()
+  }, [
+    clearUrl,
+    createNewChat,
+    currentChat.projectId,
+    exitProjectMode,
+    isPremium,
+    isProjectMode,
+  ])
 
   const handleToggleTemporaryMode = useCallback(() => {
     invalidateFavoriteNavigation()
@@ -2462,6 +2491,10 @@ export function ChatInterface({
   // Handler for moving a chat to a project via drag and drop
   const handleMoveChatToProject = useCallback(
     async (chatId: string, projectId: string) => {
+      if (!isPremium) {
+        setIsSubscribePromptOpen(true)
+        return
+      }
       try {
         // Update local storage first (optimistic)
         await indexedDBStorage.updateChatProject(chatId, projectId)
@@ -2499,12 +2532,16 @@ export function ChatInterface({
         })
       }
     },
-    [currentChat.id, createNewChat, reloadChats, toast],
+    [currentChat.id, createNewChat, isPremium, reloadChats, toast],
   )
 
   // Handler for removing a chat from a project via drag and drop
   const handleRemoveChatFromProject = useCallback(
     async (chatId: string): Promise<void> => {
+      if (!isPremium) {
+        setIsSubscribePromptOpen(true)
+        return
+      }
       try {
         await chatStorage.removeChatFromProject(chatId)
 
@@ -2531,7 +2568,7 @@ export function ChatInterface({
         })
       }
     },
-    [reloadChats, toast],
+    [isPremium, reloadChats, toast],
   )
 
   // Handler for deleting every chat that belongs to a project. Reloads from
@@ -2539,6 +2576,10 @@ export function ChatInterface({
   // page refresh.
   const handleDeleteProjectChats = useCallback(
     async (projectId: string): Promise<void> => {
+      if (!isPremium) {
+        setIsSubscribePromptOpen(true)
+        return
+      }
       try {
         const deletedChatIds =
           await chatStorage.deleteChatsByProjectWithIds(projectId)
@@ -2557,7 +2598,7 @@ export function ChatInterface({
         throw error
       }
     },
-    [reloadChats, unpinChats],
+    [isPremium, reloadChats, unpinChats],
   )
 
   // Handler for converting a local-only chat to cloud chat via drag and drop
@@ -2675,9 +2716,13 @@ export function ChatInterface({
     return pinnedChatIds
       .map((chatId) => chatsById.get(chatId))
       .filter((chat): chat is Chat =>
-        Boolean(chat && isResolvedFavoriteChat(chat)),
+        Boolean(
+          chat &&
+          isResolvedFavoriteChat(chat) &&
+          (isPremium || !chat.projectId),
+        ),
       )
-  }, [chats, pinnedChatIds])
+  }, [chats, isPremium, pinnedChatIds])
 
   // Handler for converting a cloud chat to local-only via drag and drop
   const handleConvertChatToLocal = useCallback(

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -427,7 +427,8 @@ export function ChatInterface({
 
   // Track whether we've loaded the initial chat from URL (to prevent URL flickering)
   const initialUrlChatLoadedRef = useRef(false)
-  const { chat_subscription_active } = useSubscriptionStatus()
+  const { isLoading: isSubscriptionLoading, chat_subscription_active } =
+    useSubscriptionStatus()
 
   // Initialize cloud sync and passkey backup as two separate hooks.
   // usePasskeyBackup depends on useCloudSync's `initialized` and `encryptionKey`,
@@ -674,7 +675,7 @@ export function ChatInterface({
 
   const userEmail = user?.primaryEmailAddress?.emailAddress || ''
 
-  const isPremium = chat_subscription_active ?? false
+  const isPremium = !isSubscriptionLoading && chat_subscription_active
 
   useEffect(() => {
     if (!router.isReady || router.query.upgrade !== 'projects') return
@@ -2339,7 +2340,12 @@ export function ChatInterface({
   }, [createNewChat, exitProjectMode])
 
   useEffect(() => {
-    if (isPremium || (!isProjectMode && !currentChat.projectId)) return
+    if (
+      isSubscriptionLoading ||
+      isPremium ||
+      (!isProjectMode && !currentChat.projectId)
+    )
+      return
     setPendingProjectUpload(null)
     setShowAddToProjectModal(false)
     createNewChat(false, true)
@@ -2352,6 +2358,7 @@ export function ChatInterface({
     exitProjectMode,
     isPremium,
     isProjectMode,
+    isSubscriptionLoading,
   ])
 
   const handleToggleTemporaryMode = useCallback(() => {
@@ -2496,6 +2503,11 @@ export function ChatInterface({
         return
       }
       try {
+        const chat = await chatStorage.getChat(chatId)
+        if (chat?.isLocalOnly) {
+          await chatStorage.convertChatToCloud(chatId)
+        }
+
         // Update local storage first (optimistic)
         await indexedDBStorage.updateChatProject(chatId, projectId)
 

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -89,7 +89,6 @@ import { chatEvents } from '@/services/storage/chat-events'
 import { chatStorage } from '@/services/storage/chat-storage'
 import {
   INDEXED_DB_UPGRADE_BLOCKED_EVENT,
-  indexedDBStorage,
   isIndexedDBUpgradeBlocked,
 } from '@/services/storage/indexed-db'
 import { sessionChatStorage } from '@/services/storage/session-storage'
@@ -2503,17 +2502,7 @@ export function ChatInterface({
         return
       }
       try {
-        const chat = await chatStorage.getChat(chatId)
-        if (chat?.isLocalOnly) {
-          await chatStorage.convertChatToCloud(chatId)
-        }
-
-        // Update local storage first (optimistic)
-        await indexedDBStorage.updateChatProject(chatId, projectId)
-
-        // Update cloud storage, then re-upload encrypted blob to keep it consistent
-        await cloudSync.updateChatProject(chatId, projectId)
-        await cloudSync.backupChat(chatId)
+        await chatStorage.moveChatToProject(chatId, projectId)
 
         // Reload chats to update the UI
         await reloadChats()

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1821,16 +1821,6 @@ export function ChatSidebar({
                                       onMoveChatToProject &&
                                       !project.decryptionFailed
                                     ) {
-                                      // Convert local chat to cloud first if needed
-                                      const chat = chats.find(
-                                        (c) => c.id === chatId,
-                                      )
-                                      if (
-                                        chat?.isLocalOnly &&
-                                        onConvertChatToCloud
-                                      ) {
-                                        await onConvertChatToCloud(chatId)
-                                      }
                                       await onMoveChatToProject(
                                         chatId,
                                         project.id,
@@ -2412,11 +2402,6 @@ export function ChatSidebar({
                         onMoveToProject={
                           onMoveChatToProject
                             ? async (chatId, projectId) => {
-                                // Convert local chat to cloud first if needed
-                                const chat = chats.find((c) => c.id === chatId)
-                                if (chat?.isLocalOnly && onConvertChatToCloud) {
-                                  await onConvertChatToCloud(chatId)
-                                }
                                 await onMoveChatToProject(chatId, projectId)
                               }
                             : undefined

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -683,9 +683,13 @@ export function ChatSidebar({
     return pinnedChatIds
       .map((chatId) => chatsById.get(chatId))
       .filter((chat): chat is Chat =>
-        Boolean(chat && isResolvedFavoriteChat(chat)),
+        Boolean(
+          chat &&
+          isResolvedFavoriteChat(chat) &&
+          (isPremium || !chat.projectId),
+        ),
       )
-  }, [chats, pinnedChatIds])
+  }, [chats, isPremium, pinnedChatIds])
 
   const { isFavoriteDropTarget, favoriteDropTargetProps } =
     useFavoriteDropTarget({
@@ -782,7 +786,7 @@ export function ChatSidebar({
     !!isSignedIn &&
     cloudSyncEnabled &&
     !(localOnlyModeEnabled && activeTab === 'local')
-  const chatSearch = useChatSearch(chatSearchTerm, searchEnabled)
+  const chatSearch = useChatSearch(chatSearchTerm, searchEnabled, isPremium)
   const isSearchActive = searchEnabled && chatSearchTerm.trim().length > 0
 
   const searchResultChats = useMemo((): ChatItemData[] => {
@@ -801,6 +805,7 @@ export function ChatSidebar({
       title: r.title,
       updatedAt: r.updatedAt,
       messageCount: r.messageCount,
+      projectId: r.projectId,
     }))
   }, [
     isSearchActive,

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -120,6 +120,11 @@ import { normalizeChatFont, type ChatFont } from './hooks/use-chat-font'
 import { MfaSettingsCard } from './mfa-settings-card'
 import { NativeBackupExport } from './native-backup-export'
 import { NativeBackupRestore } from './native-backup-restore'
+import {
+  canDeleteAllProjects,
+  canTransferProjectData,
+  filterExportableChats,
+} from './settings-project-policy'
 import type { Attachment, Chat } from './types'
 
 const CHARS = '0123456789ABCDEF!@#$%^&*()_+<>?/'
@@ -1397,6 +1402,16 @@ export function SettingsModal({
     const file = e.target.files?.[0]
     if (!file) return
 
+    if (!isPremium && file.name.toLowerCase().endsWith('.zip')) {
+      toast({
+        title: 'Premium required',
+        description: 'Backups containing projects require Premium',
+        variant: 'destructive',
+      })
+      e.target.value = ''
+      return
+    }
+
     if (shouldImportOffDevice()) {
       await importOffDevice('tinfoil', file, 'Tinfoil')
       e.target.value = ''
@@ -1460,6 +1475,16 @@ export function SettingsModal({
   ) => {
     const file = e.target.files?.[0]
     if (!file) return
+
+    if (!isPremium && file.name.toLowerCase().endsWith('.zip')) {
+      toast({
+        title: 'Premium required',
+        description: 'Claude archives containing projects require Premium',
+        variant: 'destructive',
+      })
+      e.target.value = ''
+      return
+    }
 
     if (shouldImportOffDevice()) {
       await importOffDevice('claude', file, 'Claude')
@@ -1757,10 +1782,9 @@ export function SettingsModal({
       }
 
       // Filter out blank chats and chats that failed decryption
-      const exportableChats = Array.from(chatsById.values()).filter(
-        (chat) =>
-          !chat.isBlankChat &&
-          (chat.messageCount ?? chat.messages?.length ?? 0) > 0,
+      const exportableChats = filterExportableChats(
+        Array.from(chatsById.values()),
+        Boolean(isPremium),
       )
 
       setIsPreparingExport(false)
@@ -1883,6 +1907,14 @@ export function SettingsModal({
   }
 
   const downloadProjectsForClaude = async () => {
+    if (!isPremium) {
+      toast({
+        title: 'Premium required',
+        description: 'Project export is only available for premium users',
+        variant: 'destructive',
+      })
+      return
+    }
     setIsExporting(true)
     setExportType('projects')
     setProjectExportResult(null)
@@ -2694,8 +2726,8 @@ ${encryptionKey.replace('key_', '')}
                         </div>
                       </div>
 
-                      {/* Delete all projects (signed-in premium users only) */}
-                      {isSignedIn && isPremium && (
+                      {/* Delete all projects remains available for account data control. */}
+                      {canDeleteAllProjects(Boolean(isSignedIn)) && (
                         <div
                           className={cn(
                             'rounded-lg border border-border-subtle p-4',
@@ -3273,11 +3305,18 @@ ${encryptionKey.replace('key_', '')}
                       />
                     )}
                     <NativeBackupExport
-                      available={Boolean(isSignedIn && encryptionKey)}
+                      available={Boolean(
+                        isSignedIn &&
+                        canTransferProjectData(Boolean(isPremium)) &&
+                        encryptionKey,
+                      )}
                     />
                     <NativeBackupRestore
                       available={Boolean(
-                        isSignedIn && user?.id && encryptionKey,
+                        isSignedIn &&
+                        canTransferProjectData(Boolean(isPremium)) &&
+                        user?.id &&
+                        encryptionKey,
                       )}
                       ownerId={user?.id}
                       onChatsUpdated={onChatsUpdated}
@@ -4035,7 +4074,7 @@ ${encryptionKey.replace('key_', '')}
                           3
                         </div>
                         <div className="font-aeonik-fono text-sm text-content-muted">
-                          {shouldImportOffDevice()
+                          {isPremium && shouldImportOffDevice()
                             ? 'Download the ZIP file you receive by email.'
                             : 'Download and unzip the file you receive by email.'}
                         </div>
@@ -4052,7 +4091,7 @@ ${encryptionKey.replace('key_', '')}
                           4
                         </div>
                         <div className="font-aeonik-fono text-sm text-content-muted">
-                          {shouldImportOffDevice() ? (
+                          {isPremium && shouldImportOffDevice() ? (
                             <>
                               Select the ZIP export with the Conversations
                               button to include attachments. Use{' '}
@@ -4061,7 +4100,7 @@ ${encryptionKey.replace('key_', '')}
                               </code>{' '}
                               only for project imports.
                             </>
-                          ) : (
+                          ) : isPremium ? (
                             <>
                               Select{' '}
                               <code className="rounded bg-surface-chat px-1.5 py-0.5 font-mono text-xs">
@@ -4073,6 +4112,14 @@ ${encryptionKey.replace('key_', '')}
                               </code>{' '}
                               from the unzipped folder.
                             </>
+                          ) : (
+                            <>
+                              Select{' '}
+                              <code className="rounded bg-surface-chat px-1.5 py-0.5 font-mono text-xs">
+                                conversations.json
+                              </code>{' '}
+                              from the unzipped folder.
+                            </>
                           )}
                         </div>
                       </div>
@@ -4080,20 +4127,24 @@ ${encryptionKey.replace('key_', '')}
                         ref={claudeConversationsFileInputRef}
                         type="file"
                         accept={
-                          shouldImportOffDevice() ? '.json,.zip' : '.json'
+                          isPremium && shouldImportOffDevice()
+                            ? '.json,.zip'
+                            : '.json'
                         }
                         onChange={handleImportClaudeConversations}
                         className="hidden"
                         disabled={isImporting}
                       />
-                      <input
-                        ref={claudeProjectsFileInputRef}
-                        type="file"
-                        accept=".json"
-                        onChange={handleImportClaudeProjects}
-                        className="hidden"
-                        disabled={isImporting || !isPremium}
-                      />
+                      {isPremium && (
+                        <input
+                          ref={claudeProjectsFileInputRef}
+                          type="file"
+                          accept=".json"
+                          onChange={handleImportClaudeProjects}
+                          className="hidden"
+                          disabled={isImporting}
+                        />
+                      )}
                       <div className="mt-2 flex gap-2">
                         <button
                           onClick={() =>
@@ -4113,29 +4164,26 @@ ${encryptionKey.replace('key_', '')}
                           <ArrowUpTrayIcon className="h-4 w-4" />
                           Conversations
                         </button>
-                        <button
-                          onClick={() =>
-                            claudeProjectsFileInputRef.current?.click()
-                          }
-                          disabled={isImporting || !isPremium}
-                          className={cn(
-                            'flex flex-1 items-center justify-center gap-2 rounded-lg border border-border-subtle px-4 py-2.5 text-sm font-medium transition-colors',
-                            isImporting || !isPremium
-                              ? 'cursor-not-allowed opacity-50'
-                              : 'hover:bg-surface-chat',
-                            isDarkMode
-                              ? 'bg-surface-chat text-content-primary'
-                              : 'bg-surface-sidebar text-content-primary',
-                          )}
-                        >
-                          <ArrowUpTrayIcon className="h-4 w-4" />
-                          Projects
-                          {!isPremium && (
-                            <span className="ml-1 rounded-full bg-brand-accent-light/20 px-1.5 py-px text-[10px] font-medium text-brand-accent-light">
-                              Premium
-                            </span>
-                          )}
-                        </button>
+                        {isPremium && (
+                          <button
+                            onClick={() =>
+                              claudeProjectsFileInputRef.current?.click()
+                            }
+                            disabled={isImporting}
+                            className={cn(
+                              'flex flex-1 items-center justify-center gap-2 rounded-lg border border-border-subtle px-4 py-2.5 text-sm font-medium transition-colors',
+                              isImporting
+                                ? 'cursor-not-allowed opacity-50'
+                                : 'hover:bg-surface-chat',
+                              isDarkMode
+                                ? 'bg-surface-chat text-content-primary'
+                                : 'bg-surface-sidebar text-content-primary',
+                            )}
+                          >
+                            <ArrowUpTrayIcon className="h-4 w-4" />
+                            Projects
+                          </button>
+                        )}
                       </div>
                     </div>
                   </div>
@@ -4158,7 +4206,7 @@ ${encryptionKey.replace('key_', '')}
                       <input
                         ref={tinfoilFileInputRef}
                         type="file"
-                        accept=".json,.zip"
+                        accept={isPremium ? '.json,.zip' : '.json'}
                         onChange={handleImportTinfoil}
                         className="hidden"
                         disabled={isImporting}

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -24,7 +24,10 @@ import { useSyncHealthAttention } from '@/hooks/use-sync-health'
 import { useToast } from '@/hooks/use-toast'
 import { authTokenManager } from '@/services/auth'
 import { buildChatExport } from '@/services/chat-export/export-archive'
-import { parseLocalTinfoilExport } from '@/services/chat-import/local-tinfoil-import'
+import {
+  parseLocalTinfoilExportForAccess,
+  PremiumProjectImportRequiredError,
+} from '@/services/chat-import/local-tinfoil-import'
 import { runOffDeviceImport } from '@/services/chat-import/off-device-import'
 import { hasPrimaryKey } from '@/services/cloud/cek-encoding'
 import { validateCurrentPrimaryKey } from '@/services/cloud/cloud-key-preflight'
@@ -1402,17 +1405,7 @@ export function SettingsModal({
     const file = e.target.files?.[0]
     if (!file) return
 
-    if (!isPremium && file.name.toLowerCase().endsWith('.zip')) {
-      toast({
-        title: 'Premium required',
-        description: 'Backups containing projects require Premium',
-        variant: 'destructive',
-      })
-      e.target.value = ''
-      return
-    }
-
-    if (shouldImportOffDevice()) {
+    if (isPremium && shouldImportOffDevice()) {
       await importOffDevice('tinfoil', file, 'Tinfoil')
       e.target.value = ''
       return
@@ -1426,17 +1419,29 @@ export function SettingsModal({
     localTinfoilImportAbortControllerRef.current = abortController
 
     try {
-      const chats = await parseLocalTinfoilExport(file, {
-        ...getParseOptions(),
-        signal: abortController.signal,
-      })
+      const { chats, skippedProjectChats } =
+        await parseLocalTinfoilExportForAccess(
+          file,
+          {
+            ...getParseOptions(),
+            signal: abortController.signal,
+          },
+          Boolean(isPremium),
+        )
       const { imported, errors } = await saveImportedChats(chats)
+      const projectErrors =
+        skippedProjectChats > 0
+          ? [
+              `Skipped ${skippedProjectChats} project chat${skippedProjectChats === 1 ? '' : 's'}. Premium is required to import project chats.`,
+            ]
+          : []
+      const importErrors = [...errors, ...projectErrors]
 
       setImportResult({
-        success: errors.length === 0,
+        success: importErrors.length === 0,
         chatsImported: imported,
         projectsImported: 0,
-        errors,
+        errors: importErrors,
       })
 
       if (onChatsUpdated) {
@@ -1444,11 +1449,18 @@ export function SettingsModal({
       }
 
       toast({
-        title: 'Import complete',
-        description: `Imported ${imported} chat${imported !== 1 ? 's' : ''} from Tinfoil`,
+        title:
+          skippedProjectChats > 0
+            ? 'Chats imported; project chats skipped'
+            : 'Import complete',
+        description:
+          skippedProjectChats > 0
+            ? `Imported ${imported} chat${imported !== 1 ? 's' : ''}. Premium is required to import the ${skippedProjectChats} project chat${skippedProjectChats === 1 ? '' : 's'}.`
+            : `Imported ${imported} chat${imported !== 1 ? 's' : ''} from Tinfoil`,
       })
     } catch (err) {
       if (abortController.signal.aborted) return
+      const projectOnly = err instanceof PremiumProjectImportRequiredError
       setImportResult({
         success: false,
         chatsImported: 0,
@@ -1456,8 +1468,10 @@ export function SettingsModal({
         errors: [err instanceof Error ? err.message : 'Failed to parse file'],
       })
       toast({
-        title: 'Import failed',
-        description: 'Could not parse the Tinfoil export file',
+        title: projectOnly ? 'Premium required' : 'Import failed',
+        description: projectOnly
+          ? err.message
+          : 'Could not parse the Tinfoil export file',
         variant: 'destructive',
       })
     } finally {
@@ -4206,7 +4220,7 @@ ${encryptionKey.replace('key_', '')}
                       <input
                         ref={tinfoilFileInputRef}
                         type="file"
-                        accept={isPremium ? '.json,.zip' : '.json'}
+                        accept=".json,.zip"
                         onChange={handleImportTinfoil}
                         className="hidden"
                         disabled={isImporting}

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -126,6 +126,7 @@ import { NativeBackupRestore } from './native-backup-restore'
 import {
   canDeleteAllProjects,
   canTransferProjectData,
+  countExcludedProjectChats,
   filterExportableChats,
 } from './settings-project-policy'
 import type { Attachment, Chat } from './types'
@@ -1796,12 +1797,24 @@ export function SettingsModal({
       }
 
       // Filter out blank chats and chats that failed decryption
+      const allChats = Array.from(chatsById.values())
+      const hasPremiumProjectAccess = Boolean(isPremium)
       const exportableChats = filterExportableChats(
-        Array.from(chatsById.values()),
-        Boolean(isPremium),
+        allChats,
+        hasPremiumProjectAccess,
+      )
+      const excludedProjectChats = countExcludedProjectChats(
+        allChats,
+        hasPremiumProjectAccess,
       )
 
       setIsPreparingExport(false)
+      if (excludedProjectChats > 0) {
+        toast({
+          title: 'Project chats not included',
+          description: `${excludedProjectChats} project chat${excludedProjectChats === 1 ? '' : 's'} could not be exported. Premium is required to export project chats.`,
+        })
+      }
       await downloadChats(exportableChats)
     } catch (error) {
       logError('Failed to prepare chats for export', error, {

--- a/src/components/chat/settings-project-policy.ts
+++ b/src/components/chat/settings-project-policy.ts
@@ -1,0 +1,21 @@
+import type { Chat } from './types'
+
+export function canDeleteAllProjects(isSignedIn: boolean): boolean {
+  return isSignedIn
+}
+
+export function canTransferProjectData(isPremium: boolean): boolean {
+  return isPremium
+}
+
+export function filterExportableChats(
+  chats: Chat[],
+  isPremium: boolean,
+): Chat[] {
+  return chats.filter(
+    (chat) =>
+      !chat.isBlankChat &&
+      (isPremium || !chat.projectId) &&
+      (chat.messageCount ?? chat.messages?.length ?? 0) > 0,
+  )
+}

--- a/src/components/chat/settings-project-policy.ts
+++ b/src/components/chat/settings-project-policy.ts
@@ -8,14 +8,25 @@ export function canTransferProjectData(isPremium: boolean): boolean {
   return isPremium
 }
 
+function hasExportableMessages(chat: Chat): boolean {
+  return !chat.isBlankChat && chat.messages.length > 0
+}
+
 export function filterExportableChats(
   chats: Chat[],
   isPremium: boolean,
 ): Chat[] {
   return chats.filter(
-    (chat) =>
-      !chat.isBlankChat &&
-      (isPremium || !chat.projectId) &&
-      (chat.messageCount ?? chat.messages?.length ?? 0) > 0,
+    (chat) => hasExportableMessages(chat) && (isPremium || !chat.projectId),
   )
+}
+
+export function countExcludedProjectChats(
+  chats: Chat[],
+  isPremium: boolean,
+): number {
+  if (isPremium) return 0
+  return chats.filter(
+    (chat) => Boolean(chat.projectId) && hasExportableMessages(chat),
+  ).length
 }

--- a/src/components/project/premium-project-route.tsx
+++ b/src/components/project/premium-project-route.tsx
@@ -19,12 +19,12 @@ export function PremiumProjectRoute({
   const { isLoading, chat_subscription_active } = useSubscriptionStatus()
 
   useEffect(() => {
-    if (!isLoading && !chat_subscription_active) {
+    if (router.isReady && !isLoading && !chat_subscription_active) {
       void router.replace('/chat?upgrade=projects')
     }
   }, [chat_subscription_active, isLoading, router])
 
-  if (isLoading || !chat_subscription_active) return null
+  if (!router.isReady || isLoading || !chat_subscription_active) return null
 
   return (
     <ProjectProvider initialProjectId={projectId}>

--- a/src/components/project/premium-project-route.tsx
+++ b/src/components/project/premium-project-route.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { ChatInterface } from '@/components/chat'
+import { useSubscriptionStatus } from '@/hooks/use-subscription-status'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { ProjectProvider } from './project-provider'
+
+interface PremiumProjectRouteProps {
+  projectId: string | null
+  chatId?: string | null
+}
+
+export function PremiumProjectRoute({
+  projectId,
+  chatId = null,
+}: PremiumProjectRouteProps) {
+  const router = useRouter()
+  const { isLoading, chat_subscription_active } = useSubscriptionStatus()
+
+  useEffect(() => {
+    if (!isLoading && !chat_subscription_active) {
+      void router.replace('/chat?upgrade=projects')
+    }
+  }, [chat_subscription_active, isLoading, router])
+
+  if (isLoading || !chat_subscription_active) return null
+
+  return (
+    <ProjectProvider initialProjectId={projectId}>
+      <ChatInterface initialProjectId={projectId} initialChatId={chatId} />
+    </ProjectProvider>
+  )
+}

--- a/src/components/project/premium-project-route.tsx
+++ b/src/components/project/premium-project-route.tsx
@@ -22,7 +22,7 @@ export function PremiumProjectRoute({
     if (router.isReady && !isLoading && !chat_subscription_active) {
       void router.replace('/chat?upgrade=projects')
     }
-  }, [chat_subscription_active, isLoading, router])
+  }, [chat_subscription_active, isLoading, router, router.isReady])
 
   if (!router.isReady || isLoading || !chat_subscription_active) return null
 

--- a/src/components/project/project-provider.tsx
+++ b/src/components/project/project-provider.tsx
@@ -5,6 +5,7 @@ import {
   UI_EXPAND_PROJECTS_ON_MOUNT,
 } from '@/constants/storage-keys'
 import { useMemory } from '@/hooks/use-memory'
+import { useSubscriptionStatus } from '@/hooks/use-subscription-status'
 import { projectStorage } from '@/services/cloud/project-storage'
 import { projectEvents } from '@/services/project/project-events'
 import { projectCache } from '@/services/storage/project-cache'
@@ -41,6 +42,9 @@ export function ProjectProvider({
   initialProjectId,
 }: ProjectProviderProps) {
   const { isSignedIn, isLoaded, userId } = useAuth()
+  const { chat_subscription_active } = useSubscriptionStatus()
+  const hasPremiumAccessRef = useRef(chat_subscription_active)
+  hasPremiumAccessRef.current = chat_subscription_active
   const [activeProject, setActiveProject] = useState<Project | null>(null)
   const [projectDocuments, setProjectDocuments] = useState<ProjectDocument[]>(
     [],
@@ -60,6 +64,12 @@ export function ProjectProvider({
   const documentMutationGenerationRef = useRef(0)
 
   const isProjectMode = activeProject !== null
+
+  const requirePremiumAccess = useCallback(() => {
+    if (!hasPremiumAccessRef.current) {
+      throw new Error('Premium project access is required')
+    }
+  }, [])
 
   const resetProjectSessionState = useCallback(() => {
     projectLoadGenerationRef.current += 1
@@ -102,10 +112,15 @@ export function ProjectProvider({
     }
   }, [isLoaded, isSignedIn, resetProjectSessionState])
 
+  useEffect(() => {
+    if (!chat_subscription_active) resetProjectSessionState()
+  }, [chat_subscription_active, resetProjectSessionState])
+
   // Memory callbacks for useMemory hook
   const memoryCallbacks = useMemo(
     () => ({
       onSave: async (memory: MemoryState) => {
+        requirePremiumAccess()
         if (!activeProject) return
         const cacheSessionGeneration = projectCache.captureGeneration()
         const updatedProjectFromStorage = await projectStorage.updateProject(
@@ -143,12 +158,12 @@ export function ProjectProvider({
         }
       },
     }),
-    [activeProject, userId],
+    [activeProject, requirePremiumAccess, userId],
   )
 
   const { processMessages, loadMemory } = useMemory({
     callbacks: memoryCallbacks,
-    enabled: !!activeProject,
+    enabled: !!activeProject && chat_subscription_active,
   })
 
   // Load memory when project changes
@@ -187,6 +202,7 @@ export function ProjectProvider({
       projectName?: string,
       options?: EnterProjectModeOptions,
     ): Promise<boolean> => {
+      if (!hasPremiumAccessRef.current) return false
       const generation = projectLoadGenerationRef.current + 1
       const cacheGeneration = projectCache.captureGeneration()
       projectLoadGenerationRef.current = generation
@@ -248,6 +264,7 @@ export function ProjectProvider({
         )
 
         if (
+          !hasPremiumAccessRef.current ||
           !canCommitProjectLoad(
             generation,
             projectLoadGenerationRef.current,
@@ -300,6 +317,7 @@ export function ProjectProvider({
     if (
       initialProjectId &&
       isSignedIn &&
+      chat_subscription_active &&
       !initialProjectLoadedRef.current &&
       !activeProject
     ) {
@@ -310,7 +328,13 @@ export function ProjectProvider({
         }
       })
     }
-  }, [initialProjectId, isSignedIn, activeProject, enterProjectMode])
+  }, [
+    initialProjectId,
+    isSignedIn,
+    chat_subscription_active,
+    activeProject,
+    enterProjectMode,
+  ])
 
   const exitProjectMode = useCallback(() => {
     resetProjectSessionState()
@@ -326,6 +350,7 @@ export function ProjectProvider({
 
   const createProject = useCallback(
     async (data: CreateProjectData): Promise<Project> => {
+      requirePremiumAccess()
       setLoading(true)
       setError(null)
       const cacheSessionGeneration = projectCache.captureGeneration()
@@ -363,11 +388,12 @@ export function ProjectProvider({
         setLoading(false)
       }
     },
-    [userId],
+    [requirePremiumAccess, userId],
   )
 
   const updateProject = useCallback(
     async (id: string, data: UpdateProjectData) => {
+      requirePremiumAccess()
       setError(null)
       const cacheSessionGeneration = projectCache.captureGeneration()
 
@@ -414,11 +440,12 @@ export function ProjectProvider({
         throw err
       }
     },
-    [activeProject, userId],
+    [activeProject, requirePremiumAccess, userId],
   )
 
   const deleteProject = useCallback(
     async (id: string) => {
+      requirePremiumAccess()
       setError(null)
       const cacheSessionGeneration = projectCache.captureGeneration()
 
@@ -455,11 +482,12 @@ export function ProjectProvider({
         throw err
       }
     },
-    [activeProject, exitProjectMode, userId],
+    [activeProject, exitProjectMode, requirePremiumAccess, userId],
   )
 
   const uploadDocument = useCallback(
     async (file: File, content: string): Promise<ProjectDocument> => {
+      requirePremiumAccess()
       if (!activeProject) {
         throw new Error('No active project')
       }
@@ -503,11 +531,12 @@ export function ProjectProvider({
         throw err
       }
     },
-    [activeProject],
+    [activeProject, requirePremiumAccess],
   )
 
   const removeDocument = useCallback(
     async (docId: string) => {
+      requirePremiumAccess()
       if (!activeProject) {
         throw new Error('No active project')
       }
@@ -550,10 +579,11 @@ export function ProjectProvider({
         throw err
       }
     },
-    [activeProject, projectDocuments],
+    [activeProject, projectDocuments, requirePremiumAccess],
   )
 
   const refreshDocuments = useCallback(async () => {
+    requirePremiumAccess()
     if (!activeProject) return
     const projectId = activeProject.id
     const generation = documentRefreshGenerationRef.current + 1
@@ -591,15 +621,16 @@ export function ProjectProvider({
         metadata: { projectId },
       })
     }
-  }, [activeProject])
+  }, [activeProject, requirePremiumAccess])
 
   const updateProjectMemory = useCallback(
     async (memory: Fact[]) => {
+      requirePremiumAccess()
       if (!activeProject) return
 
       await updateProject(activeProject.id, { memory })
     },
-    [activeProject, updateProject],
+    [activeProject, requirePremiumAccess, updateProject],
   )
 
   const addUploadingFile = useCallback((file: UploadingFile) => {
@@ -611,13 +642,13 @@ export function ProjectProvider({
   }, [])
 
   const getProjectSystemPrompt = useCallback((): string => {
-    if (!activeProject) return ''
+    if (!chat_subscription_active || !activeProject) return ''
     return buildProjectContext(activeProject, projectDocuments)
-  }, [activeProject, projectDocuments])
+  }, [activeProject, chat_subscription_active, projectDocuments])
 
   const getContextUsage = useCallback(
     (modelContextLimit: number): ProjectContextUsage => {
-      if (!activeProject) {
+      if (!chat_subscription_active || !activeProject) {
         return {
           systemInstructions: 0,
           documents: [],
@@ -656,14 +687,14 @@ export function ProjectProvider({
         availableForChat: Math.max(0, modelContextLimit - totalUsed),
       }
     },
-    [activeProject, projectDocuments],
+    [activeProject, chat_subscription_active, projectDocuments],
   )
 
   const contextValue: ProjectContextValue = useMemo(
     () => ({
-      activeProject,
-      isProjectMode,
-      projectDocuments,
+      activeProject: chat_subscription_active ? activeProject : null,
+      isProjectMode: chat_subscription_active && isProjectMode,
+      projectDocuments: chat_subscription_active ? projectDocuments : [],
       loading,
       loadingProject,
       error,
@@ -684,6 +715,7 @@ export function ProjectProvider({
     }),
     [
       activeProject,
+      chat_subscription_active,
       isProjectMode,
       projectDocuments,
       loading,

--- a/src/components/project/project-provider.tsx
+++ b/src/components/project/project-provider.tsx
@@ -42,9 +42,11 @@ export function ProjectProvider({
   initialProjectId,
 }: ProjectProviderProps) {
   const { isSignedIn, isLoaded, userId } = useAuth()
-  const { chat_subscription_active } = useSubscriptionStatus()
-  const hasPremiumAccessRef = useRef(chat_subscription_active)
-  hasPremiumAccessRef.current = chat_subscription_active
+  const { isLoading: isSubscriptionLoading, chat_subscription_active } =
+    useSubscriptionStatus()
+  const hasPremiumAccess = !isSubscriptionLoading && chat_subscription_active
+  const hasPremiumAccessRef = useRef(hasPremiumAccess)
+  hasPremiumAccessRef.current = hasPremiumAccess
   const [activeProject, setActiveProject] = useState<Project | null>(null)
   const [projectDocuments, setProjectDocuments] = useState<ProjectDocument[]>(
     [],
@@ -113,8 +115,14 @@ export function ProjectProvider({
   }, [isLoaded, isSignedIn, resetProjectSessionState])
 
   useEffect(() => {
-    if (!chat_subscription_active) resetProjectSessionState()
-  }, [chat_subscription_active, resetProjectSessionState])
+    if (!isSubscriptionLoading && !chat_subscription_active) {
+      resetProjectSessionState()
+    }
+  }, [
+    chat_subscription_active,
+    isSubscriptionLoading,
+    resetProjectSessionState,
+  ])
 
   // Memory callbacks for useMemory hook
   const memoryCallbacks = useMemo(
@@ -163,7 +171,7 @@ export function ProjectProvider({
 
   const { processMessages, loadMemory } = useMemory({
     callbacks: memoryCallbacks,
-    enabled: !!activeProject && chat_subscription_active,
+    enabled: !!activeProject && hasPremiumAccess,
   })
 
   // Load memory when project changes
@@ -317,7 +325,7 @@ export function ProjectProvider({
     if (
       initialProjectId &&
       isSignedIn &&
-      chat_subscription_active &&
+      hasPremiumAccess &&
       !initialProjectLoadedRef.current &&
       !activeProject
     ) {
@@ -331,7 +339,7 @@ export function ProjectProvider({
   }, [
     initialProjectId,
     isSignedIn,
-    chat_subscription_active,
+    hasPremiumAccess,
     activeProject,
     enterProjectMode,
   ])
@@ -642,13 +650,13 @@ export function ProjectProvider({
   }, [])
 
   const getProjectSystemPrompt = useCallback((): string => {
-    if (!chat_subscription_active || !activeProject) return ''
+    if (!hasPremiumAccess || !activeProject) return ''
     return buildProjectContext(activeProject, projectDocuments)
-  }, [activeProject, chat_subscription_active, projectDocuments])
+  }, [activeProject, hasPremiumAccess, projectDocuments])
 
   const getContextUsage = useCallback(
     (modelContextLimit: number): ProjectContextUsage => {
-      if (!chat_subscription_active || !activeProject) {
+      if (!hasPremiumAccess || !activeProject) {
         return {
           systemInstructions: 0,
           documents: [],
@@ -687,14 +695,14 @@ export function ProjectProvider({
         availableForChat: Math.max(0, modelContextLimit - totalUsed),
       }
     },
-    [activeProject, chat_subscription_active, projectDocuments],
+    [activeProject, hasPremiumAccess, projectDocuments],
   )
 
   const contextValue: ProjectContextValue = useMemo(
     () => ({
-      activeProject: chat_subscription_active ? activeProject : null,
-      isProjectMode: chat_subscription_active && isProjectMode,
-      projectDocuments: chat_subscription_active ? projectDocuments : [],
+      activeProject: hasPremiumAccess ? activeProject : null,
+      isProjectMode: hasPremiumAccess && isProjectMode,
+      projectDocuments: hasPremiumAccess ? projectDocuments : [],
       loading,
       loadingProject,
       error,
@@ -715,7 +723,7 @@ export function ProjectProvider({
     }),
     [
       activeProject,
-      chat_subscription_active,
+      hasPremiumAccess,
       isProjectMode,
       projectDocuments,
       loading,

--- a/src/hooks/use-chat-search.ts
+++ b/src/hooks/use-chat-search.ts
@@ -31,7 +31,11 @@ export interface ChatSearchState {
  * settle and re-runs the current term so results fill in without any
  * user action.
  */
-export function useChatSearch(term: string, enabled: boolean): ChatSearchState {
+export function useChatSearch(
+  term: string,
+  enabled: boolean,
+  includeProjectChats = true,
+): ChatSearchState {
   const trimmed = term.trim()
   const active = enabled && trimmed.length > 0
 
@@ -59,7 +63,10 @@ export function useChatSearch(term: string, enabled: boolean): ChatSearchState {
         if (cancelled) return
         setAvailable(outcome.available)
         setIsIndexing(outcome.indexing)
-        const chats = await resolveSearchResultChats(outcome.results)
+        const chats = await resolveSearchResultChats(
+          outcome.results,
+          includeProjectChats,
+        )
         if (cancelled) return
         setResults(chats)
         setIsSearching(false)
@@ -92,7 +99,7 @@ export function useChatSearch(term: string, enabled: boolean): ChatSearchState {
       cancelled = true
       clearTimeout(timer)
     }
-  }, [trimmed, active, refreshNonce])
+  }, [trimmed, active, includeProjectChats, refreshNonce])
 
   return { results, isSearching, isIndexing, available }
 }

--- a/src/pages/project/[[...slug]].tsx
+++ b/src/pages/project/[[...slug]].tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { ChatInterface } from '@/components/chat'
-import { ProjectProvider } from '@/components/project'
+import { PremiumProjectRoute } from '@/components/project/premium-project-route'
 import { useRouter } from 'next/router'
 
 export default function ProjectCatchAllPage() {
@@ -16,14 +15,10 @@ export default function ProjectCatchAllPage() {
 
   return (
     <div className="h-screen font-aeonik">
-      <ProjectProvider
-        initialProjectId={typeof projectId === 'string' ? projectId : null}
-      >
-        <ChatInterface
-          initialProjectId={typeof projectId === 'string' ? projectId : null}
-          initialChatId={typeof chatId === 'string' ? chatId : null}
-        />
-      </ProjectProvider>
+      <PremiumProjectRoute
+        projectId={typeof projectId === 'string' ? projectId : null}
+        chatId={typeof chatId === 'string' ? chatId : null}
+      />
     </div>
   )
 }

--- a/src/pages/project/[projectId]/chat/[chatId].tsx
+++ b/src/pages/project/[projectId]/chat/[chatId].tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { ChatInterface } from '@/components/chat'
-import { ProjectProvider } from '@/components/project'
+import { PremiumProjectRoute } from '@/components/project/premium-project-route'
 import { useRouter } from 'next/router'
 
 export default function ProjectChatPage() {
@@ -13,9 +12,7 @@ export default function ProjectChatPage() {
 
   return (
     <div className="h-screen font-aeonik">
-      <ProjectProvider initialProjectId={projectId}>
-        <ChatInterface initialChatId={chatId} initialProjectId={projectId} />
-      </ProjectProvider>
+      <PremiumProjectRoute projectId={projectId} chatId={chatId} />
     </div>
   )
 }

--- a/src/pages/project/[projectId]/index.tsx
+++ b/src/pages/project/[projectId]/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { ChatInterface } from '@/components/chat'
-import { ProjectProvider } from '@/components/project'
+import { PremiumProjectRoute } from '@/components/project/premium-project-route'
 import { useRouter } from 'next/router'
 
 export default function ProjectPage() {
@@ -11,9 +10,7 @@ export default function ProjectPage() {
 
   return (
     <div className="h-screen font-aeonik">
-      <ProjectProvider initialProjectId={projectId}>
-        <ChatInterface initialProjectId={projectId} />
-      </ProjectProvider>
+      <PremiumProjectRoute projectId={projectId} />
     </div>
   )
 }

--- a/src/services/chat-import/local-tinfoil-import.ts
+++ b/src/services/chat-import/local-tinfoil-import.ts
@@ -65,6 +65,18 @@ export class LocalImportWorkerTimeoutError extends Error {
   }
 }
 
+export class PremiumProjectImportRequiredError extends Error {
+  readonly projectChatCount: number
+
+  constructor(projectChatCount: number) {
+    super(
+      `This backup contains only project chats. Premium is required to import ${projectChatCount === 1 ? 'it' : 'them'}.`,
+    )
+    this.name = 'PremiumProjectImportRequiredError'
+    this.projectChatCount = projectChatCount
+  }
+}
+
 function getAbortError(signal: AbortSignal): Error {
   return signal.reason instanceof Error
     ? signal.reason
@@ -238,14 +250,25 @@ function importAttachment(
   return imported
 }
 
-export async function parseLocalTinfoilExport(
+export interface LocalTinfoilImportResult {
+  chats: Chat[]
+  skippedProjectChats: number
+}
+
+async function parseLocalTinfoilExportWithProjectPolicy(
   file: File,
   options: LocalTinfoilImportOptions,
-): Promise<Chat[]> {
+  includeProjectChats: boolean,
+): Promise<LocalTinfoilImportResult> {
   const { conversations, entries } = await readExport(file, options.signal)
   const chats: Chat[] = []
+  let skippedProjectChats = 0
 
   for (const conversation of conversations) {
+    if (!includeProjectChats && conversation.projectId) {
+      skippedProjectChats += 1
+      continue
+    }
     const messages: Message[] = []
 
     for (const exportedMessage of conversation.chat_messages ?? []) {
@@ -279,9 +302,8 @@ export async function parseLocalTinfoilExport(
 
     if (messages.length > 0) {
       const createdAt = new Date(conversation.created_at)
-      // Local import does not restore projects, and the sidebar hides
-      // chats whose projectId has no matching project, so drop the
-      // exported project association.
+      // Conversation imports do not restore project hierarchy, so eligible
+      // imported chats enter the root chat list.
       chats.push({
         id: options.generateChatId(createdAt),
         title: conversation.name || 'Imported Chat',
@@ -293,5 +315,33 @@ export async function parseLocalTinfoilExport(
     }
   }
 
-  return chats
+  if (!includeProjectChats && chats.length === 0 && skippedProjectChats > 0) {
+    throw new PremiumProjectImportRequiredError(skippedProjectChats)
+  }
+
+  return { chats, skippedProjectChats }
+}
+
+export async function parseLocalTinfoilExport(
+  file: File,
+  options: LocalTinfoilImportOptions,
+): Promise<Chat[]> {
+  const result = await parseLocalTinfoilExportWithProjectPolicy(
+    file,
+    options,
+    true,
+  )
+  return result.chats
+}
+
+export function parseLocalTinfoilExportForAccess(
+  file: File,
+  options: LocalTinfoilImportOptions,
+  hasPremiumProjectAccess: boolean,
+): Promise<LocalTinfoilImportResult> {
+  return parseLocalTinfoilExportWithProjectPolicy(
+    file,
+    options,
+    hasPremiumProjectAccess,
+  )
 }

--- a/src/services/chat-import/local-tinfoil-import.ts
+++ b/src/services/chat-import/local-tinfoil-import.ts
@@ -255,6 +255,15 @@ export interface LocalTinfoilImportResult {
   skippedProjectChats: number
 }
 
+function hasImportableMessages(
+  conversation: TinfoilExportedConversation,
+): boolean {
+  return (conversation.chat_messages ?? []).some(
+    (message) =>
+      Boolean(message.text?.trim()) || (message.attachments?.length ?? 0) > 0,
+  )
+}
+
 async function parseLocalTinfoilExportWithProjectPolicy(
   file: File,
   options: LocalTinfoilImportOptions,
@@ -266,7 +275,7 @@ async function parseLocalTinfoilExportWithProjectPolicy(
 
   for (const conversation of conversations) {
     if (!includeProjectChats && conversation.projectId) {
-      skippedProjectChats += 1
+      if (hasImportableMessages(conversation)) skippedProjectChats += 1
       continue
     }
     const messages: Message[] = []

--- a/src/services/cloud/chat-search.ts
+++ b/src/services/cloud/chat-search.ts
@@ -207,6 +207,7 @@ export interface SearchResultChat {
   title: string
   updatedAt?: string
   messageCount: number
+  projectId?: string
 }
 
 /**
@@ -218,17 +219,20 @@ export interface SearchResultChat {
  */
 export async function resolveSearchResultChats(
   results: SearchQueryResult[],
+  includeProjectChats = true,
 ): Promise<SearchResultChat[]> {
   const byId = new Map<string, SearchResultChat>()
   const missing: string[] = []
   for (const r of results) {
     const local = await chatStorage.getChat(r.id)
     if (local) {
+      if (!includeProjectChats && local.projectId) continue
       byId.set(r.id, {
         id: local.id,
         title: local.title,
         updatedAt: local.updatedAt,
         messageCount: local.messages.length,
+        projectId: local.projectId,
       })
     } else {
       missing.push(r.id)
@@ -245,11 +249,13 @@ export async function resolveSearchResultChats(
             id: item.id,
             plaintext: new TextDecoder().decode(plaintextBytes),
           })
+          if (!includeProjectChats && chat.projectId) continue
           byId.set(item.id, {
             id: chat.id,
             title: chat.title,
             updatedAt: chat.updatedAt,
             messageCount: chat.messages.length,
+            projectId: chat.projectId,
           })
         } catch (err) {
           logError('search result chat decode failed', err, {

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -483,6 +483,45 @@ export class ChatStorageService {
     chatEvents.emit({ reason: 'save', ids: [chatId] })
   }
 
+  async moveChatToProject(chatId: string, projectId: string): Promise<void> {
+    await this.initialize()
+
+    const originalChat = await indexedDBStorage.getChat(chatId)
+    if (!originalChat) {
+      throw new Error('Chat not found')
+    }
+
+    let convertedToCloud = false
+    try {
+      if (originalChat.isLocalOnly) {
+        await this.convertChatToCloud(chatId)
+        convertedToCloud = true
+      }
+
+      await indexedDBStorage.updateChatProject(chatId, projectId)
+      await cloudSync.updateChatProject(chatId, projectId)
+      await cloudSync.backupChat(chatId)
+    } catch (error) {
+      if (convertedToCloud) {
+        try {
+          await this.convertChatToLocal(chatId)
+          await indexedDBStorage.saveChat(originalChat)
+        } catch (rollbackError) {
+          logError(
+            'Failed to restore local chat after project move',
+            rollbackError,
+            {
+              component: 'ChatStorageService',
+              action: 'moveChatToProject.rollback',
+              metadata: { chatId, projectId },
+            },
+          )
+        }
+      }
+      throw error
+    }
+  }
+
   async removeChatFromProject(chatId: string): Promise<void> {
     await this.initialize()
 

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -500,12 +500,14 @@ export class ChatStorageService {
 
       await indexedDBStorage.updateChatProject(chatId, projectId)
       await cloudSync.updateChatProject(chatId, projectId)
-      await cloudSync.backupChat(chatId)
+      await cloudSync.backupChatAndWait(chatId)
+      chatEvents.emit({ reason: 'save', ids: [chatId] })
     } catch (error) {
       if (convertedToCloud) {
         try {
           await this.convertChatToLocal(chatId)
           await indexedDBStorage.saveChat(originalChat)
+          chatEvents.emit({ reason: 'save', ids: [chatId] })
         } catch (rollbackError) {
           logError(
             'Failed to restore local chat after project move',

--- a/tests/components/chat/settings-project-policy.test.ts
+++ b/tests/components/chat/settings-project-policy.test.ts
@@ -1,6 +1,7 @@
 import {
   canDeleteAllProjects,
   canTransferProjectData,
+  countExcludedProjectChats,
   filterExportableChats,
 } from '@/components/chat/settings-project-policy'
 import type { Chat } from '@/components/chat/types'
@@ -30,5 +31,28 @@ describe('settings project policy', () => {
     expect(filterExportableChats(chats, false)).toEqual([regularChat])
     expect(chats).toEqual([regularChat, projectChat])
     expect(filterExportableChats(chats, true)).toEqual(chats)
+  })
+
+  it('uses loaded messages instead of stale message counts for exports', () => {
+    const staleEmptyChat = {
+      ...regularChat,
+      id: 'chat-empty',
+      messages: [],
+      messageCount: 4,
+    }
+    const stalePopulatedChat = {
+      ...regularChat,
+      id: 'chat-populated',
+      messageCount: 0,
+    }
+
+    expect(
+      filterExportableChats([staleEmptyChat, stalePopulatedChat], true),
+    ).toEqual([stalePopulatedChat])
+  })
+
+  it('counts project chats omitted from a free-user export', () => {
+    expect(countExcludedProjectChats([regularChat, projectChat], false)).toBe(1)
+    expect(countExcludedProjectChats([regularChat, projectChat], true)).toBe(0)
   })
 })

--- a/tests/components/chat/settings-project-policy.test.ts
+++ b/tests/components/chat/settings-project-policy.test.ts
@@ -1,0 +1,34 @@
+import {
+  canDeleteAllProjects,
+  canTransferProjectData,
+  filterExportableChats,
+} from '@/components/chat/settings-project-policy'
+import type { Chat } from '@/components/chat/types'
+import { describe, expect, it } from 'vitest'
+
+const regularChat = {
+  id: 'chat-1',
+  title: 'Regular',
+  messages: [{ role: 'user', content: 'Hello' }],
+} as Chat
+const projectChat = {
+  ...regularChat,
+  id: 'chat-2',
+  title: 'Project',
+  projectId: 'project-1',
+} as Chat
+
+describe('settings project policy', () => {
+  it('keeps delete-all available while hiding project transfer controls', () => {
+    expect(canDeleteAllProjects(true)).toBe(true)
+    expect(canTransferProjectData(false)).toBe(false)
+  })
+
+  it('excludes project chats from free-user exports without deleting them', () => {
+    const chats = [regularChat, projectChat]
+
+    expect(filterExportableChats(chats, false)).toEqual([regularChat])
+    expect(chats).toEqual([regularChat, projectChat])
+    expect(filterExportableChats(chats, true)).toEqual(chats)
+  })
+})

--- a/tests/components/project/premium-project-route.test.tsx
+++ b/tests/components/project/premium-project-route.test.tsx
@@ -6,12 +6,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   isLoading: false,
   subscriptionActive: false,
-  routerReady: true,
-  replace: vi.fn(),
+  router: {
+    isReady: true,
+    replace: vi.fn(),
+  },
 }))
 
 vi.mock('next/router', () => ({
-  useRouter: () => ({ isReady: mocks.routerReady, replace: mocks.replace }),
+  useRouter: () => mocks.router,
 }))
 
 vi.mock('@/hooks/use-subscription-status', () => ({
@@ -34,13 +36,13 @@ describe('PremiumProjectRoute', () => {
     vi.clearAllMocks()
     mocks.isLoading = false
     mocks.subscriptionActive = false
-    mocks.routerReady = true
+    mocks.router.isReady = true
   })
 
   it('redirects free users to chat with the upgrade prompt marker', () => {
     render(<PremiumProjectRoute projectId="project-1" />)
 
-    expect(mocks.replace).toHaveBeenCalledWith('/chat?upgrade=projects')
+    expect(mocks.router.replace).toHaveBeenCalledWith('/chat?upgrade=projects')
     expect(screen.queryByText('Project chat')).not.toBeInTheDocument()
   })
 
@@ -49,7 +51,7 @@ describe('PremiumProjectRoute', () => {
     render(<PremiumProjectRoute projectId="project-1" />)
 
     expect(screen.getByText('Project chat')).toBeInTheDocument()
-    expect(mocks.replace).not.toHaveBeenCalled()
+    expect(mocks.router.replace).not.toHaveBeenCalled()
   })
 
   it('does not render or redirect while subscription status is loading', () => {
@@ -57,15 +59,26 @@ describe('PremiumProjectRoute', () => {
     render(<PremiumProjectRoute projectId="project-1" />)
 
     expect(screen.queryByText('Project chat')).not.toBeInTheDocument()
-    expect(mocks.replace).not.toHaveBeenCalled()
+    expect(mocks.router.replace).not.toHaveBeenCalled()
   })
 
   it('does not render project chat before route parameters are ready', () => {
     mocks.subscriptionActive = true
-    mocks.routerReady = false
+    mocks.router.isReady = false
     render(<PremiumProjectRoute projectId={null} />)
 
     expect(screen.queryByText('Project chat')).not.toBeInTheDocument()
-    expect(mocks.replace).not.toHaveBeenCalled()
+    expect(mocks.router.replace).not.toHaveBeenCalled()
+  })
+
+  it('redirects a free user when the router becomes ready', () => {
+    mocks.router.isReady = false
+    const view = render(<PremiumProjectRoute projectId={null} />)
+    expect(mocks.router.replace).not.toHaveBeenCalled()
+
+    mocks.router.isReady = true
+    view.rerender(<PremiumProjectRoute projectId={null} />)
+
+    expect(mocks.router.replace).toHaveBeenCalledWith('/chat?upgrade=projects')
   })
 })

--- a/tests/components/project/premium-project-route.test.tsx
+++ b/tests/components/project/premium-project-route.test.tsx
@@ -6,11 +6,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   isLoading: false,
   subscriptionActive: false,
+  routerReady: true,
   replace: vi.fn(),
 }))
 
 vi.mock('next/router', () => ({
-  useRouter: () => ({ replace: mocks.replace }),
+  useRouter: () => ({ isReady: mocks.routerReady, replace: mocks.replace }),
 }))
 
 vi.mock('@/hooks/use-subscription-status', () => ({
@@ -33,6 +34,7 @@ describe('PremiumProjectRoute', () => {
     vi.clearAllMocks()
     mocks.isLoading = false
     mocks.subscriptionActive = false
+    mocks.routerReady = true
   })
 
   it('redirects free users to chat with the upgrade prompt marker', () => {
@@ -47,6 +49,23 @@ describe('PremiumProjectRoute', () => {
     render(<PremiumProjectRoute projectId="project-1" />)
 
     expect(screen.getByText('Project chat')).toBeInTheDocument()
+    expect(mocks.replace).not.toHaveBeenCalled()
+  })
+
+  it('does not render or redirect while subscription status is loading', () => {
+    mocks.isLoading = true
+    render(<PremiumProjectRoute projectId="project-1" />)
+
+    expect(screen.queryByText('Project chat')).not.toBeInTheDocument()
+    expect(mocks.replace).not.toHaveBeenCalled()
+  })
+
+  it('does not render project chat before route parameters are ready', () => {
+    mocks.subscriptionActive = true
+    mocks.routerReady = false
+    render(<PremiumProjectRoute projectId={null} />)
+
+    expect(screen.queryByText('Project chat')).not.toBeInTheDocument()
     expect(mocks.replace).not.toHaveBeenCalled()
   })
 })

--- a/tests/components/project/premium-project-route.test.tsx
+++ b/tests/components/project/premium-project-route.test.tsx
@@ -1,0 +1,52 @@
+import { PremiumProjectRoute } from '@/components/project/premium-project-route'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  isLoading: false,
+  subscriptionActive: false,
+  replace: vi.fn(),
+}))
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+}))
+
+vi.mock('@/hooks/use-subscription-status', () => ({
+  useSubscriptionStatus: () => ({
+    isLoading: mocks.isLoading,
+    chat_subscription_active: mocks.subscriptionActive,
+  }),
+}))
+
+vi.mock('@/components/project/project-provider', () => ({
+  ProjectProvider: ({ children }: { children: ReactNode }) => children,
+}))
+
+vi.mock('@/components/chat', () => ({
+  ChatInterface: () => <div>Project chat</div>,
+}))
+
+describe('PremiumProjectRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.isLoading = false
+    mocks.subscriptionActive = false
+  })
+
+  it('redirects free users to chat with the upgrade prompt marker', () => {
+    render(<PremiumProjectRoute projectId="project-1" />)
+
+    expect(mocks.replace).toHaveBeenCalledWith('/chat?upgrade=projects')
+    expect(screen.queryByText('Project chat')).not.toBeInTheDocument()
+  })
+
+  it('renders project chat for Premium users', () => {
+    mocks.subscriptionActive = true
+    render(<PremiumProjectRoute projectId="project-1" />)
+
+    expect(screen.getByText('Project chat')).toBeInTheDocument()
+    expect(mocks.replace).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/project/project-provider-documents.test.tsx
+++ b/tests/components/project/project-provider-documents.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   loadMemory: vi.fn(),
   processMessages: vi.fn(),
   subscriptionActive: true,
+  subscriptionLoading: false,
   projectEventHandlers: new Map<string, (event: unknown) => void>(),
 }))
 
@@ -31,7 +32,7 @@ vi.mock('@/hooks/use-memory', () => ({
 
 vi.mock('@/hooks/use-subscription-status', () => ({
   useSubscriptionStatus: () => ({
-    isLoading: false,
+    isLoading: mocks.subscriptionLoading,
     chat_subscription_active: mocks.subscriptionActive,
   }),
 }))
@@ -108,6 +109,7 @@ describe('ProjectProvider documents', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.subscriptionActive = true
+    mocks.subscriptionLoading = false
     mocks.projectEventHandlers.clear()
     mocks.getProject.mockResolvedValue(project)
     mocks.listDocuments.mockResolvedValue({ documents: [listedDocument] })
@@ -136,6 +138,20 @@ describe('ProjectProvider documents', () => {
     expect(mocks.uploadDocument).not.toHaveBeenCalled()
   })
 
+  it('does not grant cached Premium access while entitlement is loading', async () => {
+    mocks.subscriptionLoading = true
+    mocks.subscriptionActive = true
+    const { result } = renderHook(() => useProject(), { wrapper })
+
+    await expect(result.current.enterProjectMode(project.id)).resolves.toBe(
+      false,
+    )
+    await expect(
+      result.current.createProject({ name: 'Blocked', description: '' }),
+    ).rejects.toThrow('Premium project access is required')
+    expect(mocks.getProject).not.toHaveBeenCalled()
+  })
+
   it('clears the active project when Premium access ends', async () => {
     const rendered = await renderInProject()
     expect(rendered.result.current.activeProject?.id).toBe(project.id)
@@ -152,6 +168,20 @@ describe('ProjectProvider documents', () => {
     await act(async () => {
       await rendered.result.current.enterProjectMode(project.id)
     })
+    expect(rendered.result.current.activeProject?.id).toBe(project.id)
+  })
+
+  it('waits for entitlement resolution before clearing project state', async () => {
+    const rendered = await renderInProject()
+
+    mocks.subscriptionLoading = true
+    mocks.subscriptionActive = false
+    rendered.rerender()
+    expect(rendered.result.current.activeProject).toBeNull()
+
+    mocks.subscriptionLoading = false
+    mocks.subscriptionActive = true
+    rendered.rerender()
     expect(rendered.result.current.activeProject?.id).toBe(project.id)
   })
 

--- a/tests/components/project/project-provider-documents.test.tsx
+++ b/tests/components/project/project-provider-documents.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   deleteDocument: vi.fn(),
   loadMemory: vi.fn(),
   processMessages: vi.fn(),
+  subscriptionActive: true,
   projectEventHandlers: new Map<string, (event: unknown) => void>(),
 }))
 
@@ -25,6 +26,13 @@ vi.mock('@/hooks/use-memory', () => ({
   useMemory: () => ({
     loadMemory: mocks.loadMemory,
     processMessages: mocks.processMessages,
+  }),
+}))
+
+vi.mock('@/hooks/use-subscription-status', () => ({
+  useSubscriptionStatus: () => ({
+    isLoading: false,
+    chat_subscription_active: mocks.subscriptionActive,
   }),
 }))
 
@@ -99,12 +107,52 @@ async function renderInProject() {
 describe('ProjectProvider documents', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.subscriptionActive = true
     mocks.projectEventHandlers.clear()
     mocks.getProject.mockResolvedValue(project)
     mocks.listDocuments.mockResolvedValue({ documents: [listedDocument] })
     mocks.getDocuments.mockResolvedValue(
       new Map([['doc-1', persistedDocument]]),
     )
+  })
+
+  it('blocks project loads and mutations without Premium access', async () => {
+    mocks.subscriptionActive = false
+    const { result } = renderHook(() => useProject(), { wrapper })
+
+    await expect(result.current.enterProjectMode(project.id)).resolves.toBe(
+      false,
+    )
+    await expect(
+      result.current.createProject({ name: 'Blocked', description: '' }),
+    ).rejects.toThrow('Premium project access is required')
+    await expect(
+      result.current.updateProject(project.id, { name: 'Blocked' }),
+    ).rejects.toThrow('Premium project access is required')
+    await expect(
+      result.current.uploadDocument(testFile, 'Blocked'),
+    ).rejects.toThrow('Premium project access is required')
+    expect(mocks.getProject).not.toHaveBeenCalled()
+    expect(mocks.uploadDocument).not.toHaveBeenCalled()
+  })
+
+  it('clears the active project when Premium access ends', async () => {
+    const rendered = await renderInProject()
+    expect(rendered.result.current.activeProject?.id).toBe(project.id)
+
+    mocks.subscriptionActive = false
+    rendered.rerender()
+
+    expect(rendered.result.current.activeProject).toBeNull()
+    expect(rendered.result.current.projectDocuments).toEqual([])
+    expect(rendered.result.current.getProjectSystemPrompt()).toBe('')
+
+    mocks.subscriptionActive = true
+    rendered.rerender()
+    await act(async () => {
+      await rendered.result.current.enterProjectMode(project.id)
+    })
+    expect(rendered.result.current.activeProject?.id).toBe(project.id)
   })
 
   it('keeps decoded document sizes after a refresh', async () => {

--- a/tests/services/chat-import/local-tinfoil-import.test.ts
+++ b/tests/services/chat-import/local-tinfoil-import.test.ts
@@ -6,6 +6,8 @@ import {
   LocalImportBackgroundProcessingUnavailableError,
   LocalImportWorkerTimeoutError,
   parseLocalTinfoilExport,
+  parseLocalTinfoilExportForAccess,
+  PremiumProjectImportRequiredError,
 } from '@/services/chat-import/local-tinfoil-import'
 import { parseTinfoilExportBytes } from '@/services/chat-import/local-tinfoil-import-parser'
 import { createFunctionalImportWorker } from './functional-import-worker'
@@ -421,6 +423,64 @@ describe('parseLocalTinfoilExport', () => {
         base64: 'AQIDBA==',
       },
     ])
+  })
+
+  it('allows free users to import a chat-only Tinfoil ZIP', async () => {
+    const archive = zipSync({
+      'conversations.json': strToU8(JSON.stringify(conversation())),
+    })
+    const file = new File([archive], 'tinfoil-chats.zip', {
+      type: 'application/zip',
+    })
+
+    const result = await parseLocalTinfoilExportForAccess(file, options, false)
+
+    expect(result.chats).toHaveLength(1)
+    expect(result.chats[0].title).toBe('Portable chat')
+    expect(result.skippedProjectChats).toBe(0)
+  })
+
+  it('imports ordinary chats and reports skipped project chats from mixed archives', async () => {
+    const data = [
+      ...conversation(),
+      {
+        ...conversation()[0],
+        uuid: 'project-chat',
+        name: 'Project chat',
+        projectId: 'project-123',
+      },
+    ]
+    const archive = zipSync({
+      'conversations.json': strToU8(JSON.stringify(data)),
+    })
+    const file = new File([archive], 'mixed-tinfoil-chats.zip', {
+      type: 'application/zip',
+    })
+
+    const result = await parseLocalTinfoilExportForAccess(file, options, false)
+
+    expect(result.chats.map((chat) => chat.title)).toEqual(['Portable chat'])
+    expect(result.skippedProjectChats).toBe(1)
+  })
+
+  it('returns a clear Premium error for project-only archives', async () => {
+    const data = conversation()
+    ;(data[0] as Record<string, unknown>).projectId = 'project-123'
+    const archive = zipSync({
+      'conversations.json': strToU8(JSON.stringify(data)),
+    })
+    const file = new File([archive], 'project-chats.zip', {
+      type: 'application/zip',
+    })
+
+    const result = parseLocalTinfoilExportForAccess(file, options, false)
+
+    await expect(result).rejects.toEqual(
+      expect.any(PremiumProjectImportRequiredError),
+    )
+    await expect(result).rejects.toThrow(
+      'This backup contains only project chats. Premium is required to import it.',
+    )
   })
 
   it('rejects ZIP exports with missing attachment entries', async () => {

--- a/tests/services/chat-import/local-tinfoil-import.test.ts
+++ b/tests/services/chat-import/local-tinfoil-import.test.ts
@@ -483,6 +483,30 @@ describe('parseLocalTinfoilExport', () => {
     )
   })
 
+  it('ignores empty project conversations without requiring Premium', async () => {
+    const data = conversation()
+    ;(data[0] as Record<string, unknown>).projectId = 'project-123'
+    ;(data[0] as Record<string, unknown>).chat_messages = [
+      {
+        uuid: 'empty-message',
+        text: '   ',
+        sender: 'human',
+        created_at: '2025-01-01T10:00:00.000Z',
+        attachments: [],
+      },
+    ]
+    const archive = zipSync({
+      'conversations.json': strToU8(JSON.stringify(data)),
+    })
+    const file = new File([archive], 'empty-project-chats.zip', {
+      type: 'application/zip',
+    })
+
+    await expect(
+      parseLocalTinfoilExportForAccess(file, options, false),
+    ).resolves.toEqual({ chats: [], skippedProjectChats: 0 })
+  })
+
   it('rejects ZIP exports with missing attachment entries', async () => {
     const archive = zipSync({
       'conversations.json': strToU8(

--- a/tests/services/cloud/chat-search.test.ts
+++ b/tests/services/cloud/chat-search.test.ts
@@ -261,4 +261,25 @@ describe('chat-search', () => {
     expect(chats).toHaveLength(1)
     expect(mockPull).not.toHaveBeenCalled()
   })
+
+  it('omits project chats from free-user search results', async () => {
+    mockGetChat.mockImplementation(async (id: string) => ({
+      id,
+      title: id,
+      messages: [{}],
+      projectId: id === 'project-chat' ? 'project-1' : undefined,
+    }))
+    const search = await importChatSearch()
+
+    const chats = await search.resolveSearchResultChats(
+      [
+        { id: 'project-chat', score: 2 },
+        { id: 'regular-chat', score: 1 },
+      ],
+      false,
+    )
+
+    expect(chats.map((chat) => chat.id)).toEqual(['regular-chat'])
+    expect(mockGetChat).toHaveBeenCalledWith('project-chat')
+  })
 })

--- a/tests/services/storage/chat-storage-pending-save.test.ts
+++ b/tests/services/storage/chat-storage-pending-save.test.ts
@@ -12,6 +12,8 @@ const {
   getAllChatIdsSpy,
   deleteAllChatsSpy,
   backupChatSpy,
+  backupChatNowSpy,
+  updateCloudChatProjectSpy,
   deleteChatsByProjectSpy,
   acknowledgePendingDeletesSpy,
   deleteRemoteProjectChatsSpy,
@@ -22,6 +24,7 @@ const {
   resetChatTimestampsSpy,
   updateChatLocalOnlySpy,
   updateChatProjectSpy,
+  enqueuePendingDeleteSpy,
   deleteChatWithPendingIntentSpy,
   deleteLocalChatSpy,
   deleteFromCloudSpy,
@@ -40,6 +43,8 @@ const {
   getAllChatIdsSpy: vi.fn(async () => [] as string[]),
   deleteAllChatsSpy: vi.fn(async () => 0),
   backupChatSpy: vi.fn(async () => {}),
+  backupChatNowSpy: vi.fn(async () => {}),
+  updateCloudChatProjectSpy: vi.fn(async () => {}),
   deleteChatsByProjectSpy: vi.fn(async () => [] as string[]),
   acknowledgePendingDeletesSpy: vi.fn(async () => {}),
   deleteRemoteProjectChatsSpy: vi.fn(async () => ({ deleted: 0 })),
@@ -53,6 +58,7 @@ const {
   resetChatTimestampsSpy: vi.fn(async () => {}),
   updateChatLocalOnlySpy: vi.fn(async () => {}),
   updateChatProjectSpy: vi.fn(async () => {}),
+  enqueuePendingDeleteSpy: vi.fn(async () => {}),
   deleteChatWithPendingIntentSpy: vi.fn(async () => true),
   deleteLocalChatSpy: vi.fn(async () => {}),
   deleteFromCloudSpy: vi.fn(async () => {}),
@@ -74,6 +80,7 @@ vi.mock('@/services/storage/indexed-db', () => ({
     resetChatTimestamps: resetChatTimestampsSpy,
     updateChatLocalOnly: updateChatLocalOnlySpy,
     updateChatProject: updateChatProjectSpy,
+    enqueuePendingDelete: enqueuePendingDeleteSpy,
     deleteChatWithPendingIntent: deleteChatWithPendingIntentSpy,
     deleteChat: deleteLocalChatSpy,
     deleteChatsByProject: deleteChatsByProjectSpy,
@@ -83,6 +90,8 @@ vi.mock('@/services/storage/indexed-db', () => ({
 vi.mock('@/services/cloud/cloud-sync', () => ({
   cloudSync: {
     backupChat: backupChatSpy,
+    backupChatNow: backupChatNowSpy,
+    updateChatProject: updateCloudChatProjectSpy,
     deleteFromCloud: deleteFromCloudSpy,
     hasPendingUpload: hasPendingUploadSpy,
     createAccountOperationGuard: createAccountOperationGuardSpy,
@@ -445,5 +454,40 @@ describe('chatStorage convertChatToLocal rollback', () => {
     )
     const restored = saveChatSpy.mock.calls[0][0] as Record<string, unknown>
     expect(restored.isLocalOnly).toBe(false)
+  })
+})
+
+describe('chatStorage project move rollback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user-1')
+  })
+
+  it('restores the original local chat when the project update fails', async () => {
+    const originalChat = makeChat({
+      title: 'Original local chat',
+      messages: [{ role: 'user', content: 'Keep this message' }],
+      isLocalOnly: true,
+      projectId: 'original-project',
+    })
+    const convertedChat = { ...originalChat, isLocalOnly: false }
+    getChatSpy
+      .mockResolvedValueOnce(originalChat as unknown)
+      .mockResolvedValueOnce(originalChat as unknown)
+      .mockResolvedValueOnce(convertedChat as unknown)
+    updateCloudChatProjectSpy.mockRejectedValueOnce(
+      new Error('project update failed'),
+    )
+
+    await expect(
+      chatStorage.moveChatToProject('rev_123_abc', 'target-project'),
+    ).rejects.toThrow('project update failed')
+
+    expect(backupChatNowSpy).toHaveBeenCalledWith('rev_123_abc', {
+      restoreDeleted: true,
+    })
+    expect(deleteFromCloudSpy).toHaveBeenCalledWith('rev_123_abc', 'delete-key')
+    expect(saveChatSpy).toHaveBeenLastCalledWith(originalChat)
+    expect(backupChatSpy).not.toHaveBeenCalled()
   })
 })

--- a/tests/services/storage/chat-storage-pending-save.test.ts
+++ b/tests/services/storage/chat-storage-pending-save.test.ts
@@ -13,6 +13,7 @@ const {
   deleteAllChatsSpy,
   backupChatSpy,
   backupChatNowSpy,
+  backupChatAndWaitSpy,
   updateCloudChatProjectSpy,
   deleteChatsByProjectSpy,
   acknowledgePendingDeletesSpy,
@@ -30,6 +31,7 @@ const {
   deleteFromCloudSpy,
   deleteAllCloudChatsSpy,
   isCloudAuthenticatedSpy,
+  chatEventsEmitSpy,
   hasPendingUploadSpy,
   isDeletedSpy,
   markAsDeletedSpy,
@@ -44,6 +46,7 @@ const {
   deleteAllChatsSpy: vi.fn(async () => 0),
   backupChatSpy: vi.fn(async () => {}),
   backupChatNowSpy: vi.fn(async () => {}),
+  backupChatAndWaitSpy: vi.fn(async () => {}),
   updateCloudChatProjectSpy: vi.fn(async () => {}),
   deleteChatsByProjectSpy: vi.fn(async () => [] as string[]),
   acknowledgePendingDeletesSpy: vi.fn(async () => {}),
@@ -64,6 +67,7 @@ const {
   deleteFromCloudSpy: vi.fn(async () => {}),
   deleteAllCloudChatsSpy: vi.fn(async () => ({ deleted: 0 })),
   isCloudAuthenticatedSpy: vi.fn(async () => false),
+  chatEventsEmitSpy: vi.fn(),
   hasPendingUploadSpy: vi.fn(() => false),
   isDeletedSpy: vi.fn((_id: unknown) => false),
   markAsDeletedSpy: vi.fn(),
@@ -91,6 +95,7 @@ vi.mock('@/services/cloud/cloud-sync', () => ({
   cloudSync: {
     backupChat: backupChatSpy,
     backupChatNow: backupChatNowSpy,
+    backupChatAndWait: backupChatAndWaitSpy,
     updateChatProject: updateCloudChatProjectSpy,
     deleteFromCloud: deleteFromCloudSpy,
     hasPendingUpload: hasPendingUploadSpy,
@@ -113,7 +118,7 @@ vi.mock('@/services/cloud/streaming-tracker', () => ({
   streamingTracker: { isStreaming: vi.fn(() => false) },
 }))
 vi.mock('@/services/storage/chat-events', () => ({
-  chatEvents: { emit: vi.fn() },
+  chatEvents: { emit: chatEventsEmitSpy },
 }))
 vi.mock('@/services/storage/deleted-chats-tracker', () => ({
   deletedChatsTracker: {
@@ -488,6 +493,48 @@ describe('chatStorage project move rollback', () => {
     })
     expect(deleteFromCloudSpy).toHaveBeenCalledWith('rev_123_abc', 'delete-key')
     expect(saveChatSpy).toHaveBeenLastCalledWith(originalChat)
-    expect(backupChatSpy).not.toHaveBeenCalled()
+    expect(chatEventsEmitSpy).toHaveBeenLastCalledWith({
+      reason: 'save',
+      ids: ['rev_123_abc'],
+    })
+  })
+
+  it('rolls back when the project chat upload fails', async () => {
+    const originalChat = makeChat({
+      messages: [{ role: 'user', content: 'Keep this message' }],
+      isLocalOnly: true,
+      projectId: 'original-project',
+    })
+    const convertedChat = { ...originalChat, isLocalOnly: false }
+    getChatSpy
+      .mockResolvedValueOnce(originalChat as unknown)
+      .mockResolvedValueOnce(originalChat as unknown)
+      .mockResolvedValueOnce(convertedChat as unknown)
+    backupChatAndWaitSpy.mockRejectedValueOnce(new Error('upload failed'))
+
+    await expect(
+      chatStorage.moveChatToProject('rev_123_abc', 'target-project'),
+    ).rejects.toThrow('upload failed')
+
+    expect(backupChatAndWaitSpy).toHaveBeenCalledWith('rev_123_abc')
+    expect(deleteFromCloudSpy).toHaveBeenCalledWith('rev_123_abc', 'delete-key')
+    expect(saveChatSpy).toHaveBeenLastCalledWith(originalChat)
+    expect(chatEventsEmitSpy).toHaveBeenLastCalledWith({
+      reason: 'save',
+      ids: ['rev_123_abc'],
+    })
+  })
+
+  it('emits a save event after a successful project move', async () => {
+    getChatSpy.mockResolvedValueOnce(makeChat() as unknown)
+
+    await chatStorage.moveChatToProject('rev_123_abc', 'target-project')
+
+    expect(backupChatAndWaitSpy).toHaveBeenCalledWith('rev_123_abc')
+    expect(chatEventsEmitSpy).toHaveBeenCalledOnce()
+    expect(chatEventsEmitSpy).toHaveBeenCalledWith({
+      reason: 'save',
+      ids: ['rev_123_abc'],
+    })
   })
 })


### PR DESCRIPTION
## Summary
- enforce Premium access for project routes, mutations, context, search, and import/export
- exit active project state on downgrade and restore access on upgrade
- keep Delete all projects available for account data control
- allow free users to import ordinary chats from Tinfoil archives while reporting skipped project data

## Testing
- 1,976 unit tests
- typecheck and lint

## Related
Coordinate with the iOS Premium project-access PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Premium access across all project features so free users can no longer create, open, or mutate projects. Project routes now route through a Premium gate that redirects free users to a subscription prompt, and active project sessions are cleared on downgrade and restored on upgrade.

**Behavior changes**
- Project mutations and chat project actions are Premium-gated; project chats are hidden from search, pinned favorites, exports, and native backup transfers for free users.
- Claude project import/export is Premium-only; free Tinfoil imports keep ordinary chats, skip project chats (with a reported count), and reject project-only archives with a clear message.
- Moving a local-only chat into a project converts and moves it in one step, waits for the cloud backup to finish, and rolls back the conversion if the move fails.
- Delete all projects stays available to signed-in users for account data control.

**Rollout**
- Coordinate with the iOS Premium project-access PR.

<sup>Written for commit 56834c7ac6eeb90dbdc599f31fa3f837b09fd2b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

