### PR TITLE
fix: present sign-in errors clearly

### DIFF
--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -738,7 +738,7 @@ export default function SignInPage() {
           <p
             id="auth-error"
             role="alert"
-            className="mt-4 text-center text-sm text-red-500"
+            className="mx-auto mt-4 w-full break-words rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-center text-sm leading-relaxed text-red-500"
           >
             {errorMessage ||
               signInErrors.fields.identifier?.longMessage ||

--- a/tests/pages/signin.test.tsx
+++ b/tests/pages/signin.test.tsx
@@ -292,6 +292,44 @@ describe('SignInPage', () => {
     })
   })
 
+  it('shows TOTP verification errors in a centered alert box', async () => {
+    auth.signIn.emailCode.verifyCode.mockImplementation(async () => {
+      auth.signIn.status = 'needs_second_factor'
+      auth.signIn.supportedSecondFactors = [{ strategy: 'totp' }]
+      return { error: null }
+    })
+    auth.signIn.mfa.verifyTOTP.mockResolvedValue({
+      error: { longMessage: 'The verification code is invalid.' },
+    })
+    render(<SignInPage />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
+      target: { value: 'person@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.change(
+      await screen.findByRole('textbox', { name: 'Verification code' }),
+      { target: { value: '123456' } },
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+    await screen.findByRole('heading', { name: 'Two-step verification' })
+    fireEvent.change(
+      screen.getByRole('textbox', { name: 'Verification code' }),
+      { target: { value: '987654' } },
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('The verification code is invalid.')
+    expect(alert).toHaveClass(
+      'mx-auto',
+      'rounded-lg',
+      'border',
+      'bg-red-500/10',
+      'text-center',
+    )
+  })
+
   it('lets the user fall back to an email MFA code from the TOTP prompt', async () => {
     auth.signIn.emailCode.verifyCode.mockImplementation(async () => {
       auth.signIn.status = 'needs_second_factor'


### PR DESCRIPTION
## Summary
- place authentication errors in a centered, bordered alert box
- wrap long network error messages cleanly within the sign-in panel
- add coverage for the TOTP error presentation

## Testing
- `npx vitest run tests/pages/signin.test.tsx`
- `npx eslint src/pages/signin.tsx tests/pages/signin.test.tsx`
- `npx prettier --check src/pages/signin.tsx tests/pages/signin.test.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sign-in authentication errors so they appear in a centered, bordered alert box with a red background tint, and long messages wrap cleanly within the panel. Adds a test verifying TOTP errors render in the new alert style.

<sup>Written for commit 9a7d3ffe55551efdd2c727920adbd39a9928d6c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

