### PR TITLE
fix: clarify daily rate limit errors

### DIFF
--- a/src/components/chat/rate-limit-banner.tsx
+++ b/src/components/chat/rate-limit-banner.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { cn } from '@/components/ui/utils'
+import { DAILY_RATE_LIMIT_MESSAGE } from '@/constants/rate-limits'
 import type { RateLimitInfo } from '@/services/inference/tinfoil-client'
 
 const RATE_LIMIT_WARNING_THRESHOLD = 3
@@ -61,7 +62,7 @@ export function RateLimitBanner({
           {isHourly
             ? `You've reached your hourly usage limit${resetLabel ? ` — resets at ${resetLabel}` : ''}`
             : exhausted
-              ? "You've used all your free requests for today"
+              ? DAILY_RATE_LIMIT_MESSAGE
               : `You have ${rateLimit.remaining} free request${rateLimit.remaining === 1 ? '' : 's'} left today`}
         </span>
       </div>

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -2,6 +2,7 @@ import { GenUIToolCallRenderer } from '@/components/chat/genui/GenUIToolCallRend
 import { renderGenUIResolved } from '@/components/chat/genui/render'
 import { cn } from '@/components/ui/utils'
 import { REQUEST_UPGRADE_EVENT } from '@/constants/chat-events'
+import { DAILY_RATE_LIMIT_MESSAGE } from '@/constants/rate-limits'
 import {
   ArrowPathIcon,
   ArrowUturnLeftIcon,
@@ -488,11 +489,11 @@ const DefaultMessageComponent = ({
                       <div className="flex items-center gap-2">
                         <GoClockFill className="h-5 w-5 flex-shrink-0 text-brand-accent-dark dark:text-brand-accent-light" />
                         <span className="font-semibold text-brand-accent-dark dark:text-brand-accent-light">
-                          Daily limit reached
+                          Daily rate limit reached
                         </span>
                       </div>
                       <p className="text-sm text-brand-accent-dark/70 dark:text-brand-accent-light/70">
-                        You&apos;ve used all your free requests for today.
+                        {DAILY_RATE_LIMIT_MESSAGE}
                       </p>
                       <button
                         type="button"

--- a/src/constants/rate-limits.ts
+++ b/src/constants/rate-limits.ts
@@ -1,0 +1,1 @@
+export const DAILY_RATE_LIMIT_MESSAGE = "You've reached your daily rate limit."

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -25,6 +25,9 @@ import { INFERENCE_CLIENT_INITIALIZATION_TIMEOUT_MS } from './constants'
 export interface RateLimitInfo {
   maxRequests: number
   remaining: number
+  maxTokens?: number
+  tokensUsed?: number
+  tokensRemaining?: number
   resetsAt: string
   /**
    * Which limit this represents. Absent or `free_daily` is the anonymous/
@@ -339,6 +342,9 @@ async function fetchSessionTokenForGeneration(
     cachedRateLimit = {
       maxRequests: data.rate_limit.max_requests,
       remaining: data.rate_limit.remaining,
+      maxTokens: data.rate_limit.max_tokens,
+      tokensUsed: data.rate_limit.tokens_used,
+      tokensRemaining: data.rate_limit.tokens_remaining,
       resetsAt: data.rate_limit.resets_at,
       kind: 'free_daily',
     }

--- a/tests/services/inference/tinfoil-client-cache.test.ts
+++ b/tests/services/inference/tinfoil-client-cache.test.ts
@@ -32,6 +32,9 @@ const chatKeyResponse = (key: string, remaining: number) =>
       rate_limit: {
         max_requests: 7,
         remaining,
+        max_tokens: 2_000_000,
+        tokens_used: 750_000,
+        tokens_remaining: 1_250_000,
         resets_at: '2026-07-24T00:00:00Z',
       },
     }),
@@ -76,7 +79,12 @@ describe('tinfoil-client session cache', () => {
     await currentRefresh
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(getRateLimitInfo()?.remaining).toBe(6)
+    expect(getRateLimitInfo()).toMatchObject({
+      remaining: 6,
+      maxTokens: 2_000_000,
+      tokensUsed: 750_000,
+      tokensRemaining: 1_250_000,
+    })
   })
 
   it('keeps tracking a newer refresh when an older refresh finishes', async () => {


### PR DESCRIPTION
## Summary
- replace request-specific exhaustion copy with a generic daily rate-limit message
- use the same message in the chat error card and rate-limit banner
- retain token usage fields from the free-key response for future UI use

## Verification
- `npx eslint src/constants/rate-limits.ts src/components/chat/renderers/default/DefaultMessageRenderer.tsx src/components/chat/rate-limit-banner.tsx src/services/inference/tinfoil-client.ts tests/services/inference/tinfoil-client-cache.test.ts`
- `npx vitest run tests/services/inference/tinfoil-client-cache.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces request-specific exhaustion copy with a generic daily rate-limit message, now shared by the chat error card and the rate-limit banner. Also extends `RateLimitInfo` with token usage fields from the free-key response so the UI can use them later.

<sup>Written for commit 5a825974aaef20f8df3182e3ad53907a0df99259. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

