### PR TITLE
fix: restore passkey backup registration

### DIFF
--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -1829,7 +1829,6 @@ export function usePasskeyBackup({
         if (!wrappedKeys) return false
         await addWrappedKeyForCurrentKey({
           wrappedKeys,
-          keyBundle,
           cek: cekBytes,
           keyIdHex,
         })

--- a/src/services/cloud/ensure-current-key.ts
+++ b/src/services/cloud/ensure-current-key.ts
@@ -329,9 +329,9 @@ async function reconcileExistingAdoptedKey(
 }
 
 /**
- * Best-effort initial bundle for key adoption: wrap the complete key
- * history into the generic envelope using this device's cached passkey
- * PRF. Credential discovery is bounded so legacy auth or fetch hangs cannot
+ * Best-effort initial bundle for key adoption: wrap the current primary CEK
+ * using this device's cached passkey PRF. Credential discovery is bounded
+ * so legacy auth or fetch hangs cannot
  * starve the adoption queue. Every failure path returns null and the caller
  * registers bundleless.
  *
@@ -371,7 +371,7 @@ async function initialBundleFromCachedPrf(
       snapshot.keyBundle,
     )
     if (!wrappedKeys) return null
-    return tinfoilWrappedKeyBundleToEnclave(wrappedKeys, snapshot.keyBundle)
+    return tinfoilWrappedKeyBundleToEnclave(wrappedKeys)
   } catch (err) {
     logWarning('Could not build initial bundle for key adoption', {
       component: 'CloudSync',

--- a/src/services/passkey/passkey-key-storage.ts
+++ b/src/services/passkey/passkey-key-storage.ts
@@ -11,11 +11,9 @@
  * `key-current` / `register-key` / `add-bundle` / `remove-bundle`
  * wire.
  *
- * `KeyBundle.alternatives` is preserved end-to-end. The enclave treats
- * the bundle ciphertext as an opaque blob, so any legacy decryption
- * history the caller hands in survives unchanged. Alternatives are
- * dropped from the local model only after the client-side migration
- * loop has re-sealed every legacy row under the current primary CEK.
+ * New enclave bundles use the raw wrapped-CEK wire shape shared with
+ * iOS. `KeyBundle.alternatives` remains supported when reading legacy
+ * generic envelopes so existing recovery history is not lost.
  *
  * The legacy decoder primitives (`encryptKeyBundle`,
  * `decryptKeyBundle`) are pure client-side AES-256-GCM. Optimistic
@@ -76,10 +74,9 @@ export interface KeyBundle {
   primary: string
   /**
    * Decryption-only history retained for legacy v0/v1 rows. New
-   * bundles persist whatever the caller hands in (the enclave is a
-   * blob store at the bundle layer). Removed in Layer C of the
-   * sync-enclave refactor once the client-side migration loop has
-   * re-sealed every legacy row under `primary`.
+   * enclave bundles wrap only the current primary CEK. Removed in
+   * Layer C of the sync-enclave refactor once the client-side migration
+   * loop has re-sealed every legacy row under `primary`.
    */
   alternatives: string[]
   authorizationMode?: CloudKeyAuthorizationMode
@@ -255,41 +252,8 @@ function usesTinfoilPasskeyProfile(wrappedKey: WrappedKey): boolean {
   )
 }
 
-function encodeGenericKeyEnvelope(
-  wrappedKeys: TinfoilWrappedKeyBundle,
-  keys: KeyBundle,
-): Uint8Array {
-  validateKeyBundle(keys)
-  if (wrappedKeys.alternatives.length !== keys.alternatives.length) {
-    throw new Error('Wrapped alternative key count does not match key bundle')
-  }
-  const credentialId = wrappedKeys.primary.credentialId
-  if (
-    wrappedKeys.alternatives.some(
-      (wrappedKey) => wrappedKey.credentialId !== credentialId,
-    )
-  ) {
-    throw new Error('Wrapped keys must use one credential')
-  }
-  const envelope: TinfoilGenericKeyEnvelope = {
-    version: TINFOIL_GENERIC_KEY_ENVELOPE_VERSION,
-    authorizationMode:
-      keys.authorizationMode === 'explicit_start_fresh'
-        ? 'explicit_start_fresh'
-        : 'validated',
-    primary: encodeWrappedKeyRecord(wrappedKeys.primary),
-    alternatives: wrappedKeys.alternatives.map(encodeWrappedKeyRecord),
-  }
-  const bytes = new TextEncoder().encode(JSON.stringify(envelope))
-  if (bytes.length > TINFOIL_GENERIC_KEY_ENVELOPE_MAX_BYTES) {
-    throw new Error('Passkey key envelope is too large')
-  }
-  return bytes
-}
-
 export function tinfoilWrappedKeyBundleToEnclave(
   wrappedKeys: TinfoilWrappedKeyBundle,
-  keys: KeyBundle,
 ): {
   credentialId: string
   kekIvHex: string
@@ -298,7 +262,7 @@ export function tinfoilWrappedKeyBundleToEnclave(
   return {
     credentialId: wrappedKeys.primary.credentialId,
     kekIvHex: wrappedKeys.primary.kekIvHex,
-    encryptedKeysHex: bytesToHex(encodeGenericKeyEnvelope(wrappedKeys, keys)),
+    encryptedKeysHex: wrappedKeys.primary.wrappedKeyHex,
   }
 }
 
@@ -583,7 +547,7 @@ export async function storeEncryptedKeys(
   try {
     const credentialId = wrappedKeys.primary.credentialId
     const primaryBytes = validateKeyBundle(keys).primary
-    const enclaveBundle = tinfoilWrappedKeyBundleToEnclave(wrappedKeys, keys)
+    const enclaveBundle = tinfoilWrappedKeyBundleToEnclave(wrappedKeys)
     const localKeyId = await deriveTinfoilKeyIdHex(primaryBytes)
     const current = await enclaveKeyCurrent()
 
@@ -1029,14 +993,10 @@ export async function recoverPasskeyKeyBundle(
 
 export async function addWrappedKeyForCurrentKey(input: {
   wrappedKeys: TinfoilWrappedKeyBundle
-  keyBundle: KeyBundle
   cek: Uint8Array
   keyIdHex: string
 }): Promise<void> {
-  const envelope = tinfoilWrappedKeyBundleToEnclave(
-    input.wrappedKeys,
-    input.keyBundle,
-  )
+  const envelope = tinfoilWrappedKeyBundleToEnclave(input.wrappedKeys)
   await enclaveAddBundle({
     keyId: input.keyIdHex,
     keyB64: bytesToBase64(input.cek),
@@ -1088,7 +1048,6 @@ export async function promoteRecoveredCekToEnclave(input: {
     try {
       await addWrappedKeyForCurrentKey({
         wrappedKeys,
-        keyBundle: input.keyBundle,
         cek: input.cek,
         keyIdHex,
       })
@@ -1102,10 +1061,7 @@ export async function promoteRecoveredCekToEnclave(input: {
     }
   }
   try {
-    const envelope = tinfoilWrappedKeyBundleToEnclave(
-      wrappedKeys,
-      input.keyBundle,
-    )
+    const envelope = tinfoilWrappedKeyBundleToEnclave(wrappedKeys)
     await enclaveRegisterKey({
       keyB64: bytesToBase64(input.cek),
       ifMatch: IF_MATCH_SENTINELS.AnyKey,

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -712,7 +712,6 @@ describe('usePasskeyBackup', () => {
       )
       expect(mocks.addWrappedKeyForCurrentKey).toHaveBeenCalledWith({
         wrappedKeys,
-        keyBundle,
         cek: new Uint8Array(32),
         keyIdHex: 'kid-current',
       })

--- a/tests/services/cloud/ensure-current-key.test.ts
+++ b/tests/services/cloud/ensure-current-key.test.ts
@@ -118,19 +118,11 @@ function enableInitialBundle(): void {
       keyBundle: { alternatives: string[] },
     ) => ({ primary, alternatives: keyBundle.alternatives }),
   )
-  mockBundleToEnclave.mockImplementation(
-    (
-      _: unknown,
-      keyBundle: { alternatives: string[]; authorizationMode: string },
-    ) => ({
-      credentialId: 'AQID',
-      kekIvHex: '01'.repeat(12),
-      encryptedKeysHex: JSON.stringify({
-        alternatives: keyBundle.alternatives,
-        authorizationMode: keyBundle.authorizationMode,
-      }),
-    }),
-  )
+  mockBundleToEnclave.mockReturnValue({
+    credentialId: 'AQID',
+    kekIvHex: '01'.repeat(12),
+    encryptedKeysHex: '02'.repeat(48),
+  })
 }
 
 vi.mock('@/utils/error-handling', () => ({
@@ -468,7 +460,7 @@ describe('ensure-current-key adoptLocalKeyForMigration', () => {
           JSON.stringify({ mode: 'explicit_start_fresh' }),
         ),
     ],
-  ])('reconciles changed %s after a delayed create', async (_, mutate) => {
+  ])('accepts changed %s after a delayed create', async (_, mutate) => {
     enableInitialBundle()
     let releaseFirstRegistration: () => void = () => {}
     const registrationGate = new Promise<void>((resolve) => {
@@ -488,7 +480,7 @@ describe('ensure-current-key adoptLocalKeyForMigration', () => {
     await expect(staleAdoption).resolves.toBe(false)
     await expect(currentAdoption).resolves.toBe(true)
     expect(mockRegisterKey).toHaveBeenCalledOnce()
-    expect(mockAddBundle).toHaveBeenCalledOnce()
+    expect(mockAddBundle).not.toHaveBeenCalled()
     expect(remoteKeyState.bundles.AQID.encrypted_keys).toBe(
       mockBundleToEnclave.mock.results.at(-1)?.value.encryptedKeysHex,
     )

--- a/tests/services/passkey/passkey-enclave-wire.integration.test.ts
+++ b/tests/services/passkey/passkey-enclave-wire.integration.test.ts
@@ -1,0 +1,66 @@
+import { passkeyKeyManager } from '@/services/passkey/kit'
+import { tinfoilWrappedKeyBundleToEnclave } from '@/services/passkey/passkey-key-storage'
+import { registerKey } from '@/services/sync-enclave/sync-api'
+import { expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  post: vi.fn(),
+}))
+
+vi.mock(
+  '@/services/sync-enclave/sync-enclave-client',
+  async (importOriginal) => {
+    const original =
+      await importOriginal<
+        typeof import('@/services/sync-enclave/sync-enclave-client')
+      >()
+    return {
+      ...original,
+      getSyncEnclaveClient: vi.fn(async () => ({ post: mocks.post })),
+    }
+  },
+)
+
+it('sends passkey-kit output through the enclave register wire unchanged', async () => {
+  const credentialId = 'AQID'
+  const prfResult = {
+    output: Uint8Array.from({ length: 32 }, (_, index) => index),
+  }
+  const primary = await passkeyKeyManager.wrapKeyWithPRFResult({
+    keyMaterial: new Uint8Array(32).fill(0x11),
+    credentialId,
+    prfResult,
+  })
+  const alternative = await passkeyKeyManager.wrapKeyWithPRFResult({
+    keyMaterial: new Uint8Array(32).fill(0x22),
+    credentialId,
+    prfResult,
+  })
+  const bundle = tinfoilWrappedKeyBundleToEnclave({
+    primary,
+    alternatives: [alternative],
+  })
+  mocks.post.mockResolvedValueOnce({ ok: true, key_id: 'aa'.repeat(16) })
+
+  await registerKey({
+    keyB64: 'ERERERERERERERERERERERERERERERERERERERERERE=',
+    ifMatch: '*',
+    createdVia: 'passkey',
+    idempotencyKey: 'integration-test',
+    initialBundle: bundle,
+  })
+
+  expect(bundle.encryptedKeysHex).toBe(primary.wrappedKeyHex)
+  expect(bundle.encryptedKeysHex).toMatch(/^[0-9a-f]{96}$/)
+  expect(mocks.post).toHaveBeenCalledWith('/v1/key/register', {
+    key: 'ERERERERERERERERERERERERERERERERERERERERERE=',
+    if_match: '*',
+    created_via: 'passkey',
+    idempotency_key: 'integration-test',
+    initial_bundle: {
+      credential_id: credentialId,
+      kek_iv: primary.kekIvHex,
+      encrypted_keys: primary.wrappedKeyHex,
+    },
+  })
+})

--- a/tests/services/passkey/passkey-key-recovery.test.ts
+++ b/tests/services/passkey/passkey-key-recovery.test.ts
@@ -8,7 +8,6 @@ import {
   encryptKeyBundle,
   promoteRecoveredCekToEnclave,
   recoverPasskeyKeyBundle,
-  tinfoilWrappedKeyBundleToEnclave,
   wrapTinfoilKeyBundle,
   type KeyBundle,
   type PasskeyCredentialEntry,
@@ -63,11 +62,20 @@ async function genericEnvelopeEntry(
     output: PRF_OUTPUT,
   })
   if (!wrappedKeys) throw new Error('failed to create generic envelope fixture')
-  const transport = tinfoilWrappedKeyBundleToEnclave(wrappedKeys, keyBundle)
+  const envelope = JSON.stringify({
+    version: 1,
+    authorizationMode: keyBundle.authorizationMode ?? 'validated',
+    primary: encodeWrappedKeyRecord(wrappedKeys.primary),
+    alternatives: wrappedKeys.alternatives.map(encodeWrappedKeyRecord),
+  })
+  const encryptedKeysHex = Array.from(
+    new TextEncoder().encode(envelope),
+    (byte) => byte.toString(16).padStart(2, '0'),
+  ).join('')
   return entry({
     id: credentialId,
-    iv: hexToB64(transport.kekIvHex),
-    encrypted_keys: hexToB64(transport.encryptedKeysHex),
+    iv: hexToB64(wrappedKeys.primary.kekIvHex),
+    encrypted_keys: hexToB64(encryptedKeysHex),
     source: 'enclave',
   })
 }
@@ -446,7 +454,7 @@ describe('recoverPasskeyKeyBundle', () => {
     expect(get.mock.calls[0][0].publicKey.allowCredentials).toHaveLength(3)
   })
 
-  it('persists all alternatives when promoting a recovered legacy bundle', async () => {
+  it('persists the primary CEK when promoting a recovered legacy bundle', async () => {
     const cek = new Uint8Array(32).fill(0x81)
     const keyBundle = {
       primary: encryptionService.encodeKeyFromBytes(cek),
@@ -470,6 +478,7 @@ describe('recoverPasskeyKeyBundle', () => {
     ).resolves.toBe(true)
     expect(mockRegisterKey).toHaveBeenCalledOnce()
     const initialBundle = mockRegisterKey.mock.calls[0][0].initialBundle
+    expect(initialBundle.encryptedKeysHex).toMatch(/^[0-9a-f]{96}$/)
     const recovered = await recoverPasskeyKeyBundle(
       [
         entry({
@@ -481,8 +490,8 @@ describe('recoverPasskeyKeyBundle', () => {
       { cachedOnly: true },
     )
     expect(recovered?.keyBundle).toEqual({
-      ...keyBundle,
-      authorizationMode: 'validated',
+      primary: keyBundle.primary,
+      alternatives: [],
     })
   })
 

--- a/tests/services/passkey/passkey-key-storage-store.test.ts
+++ b/tests/services/passkey/passkey-key-storage-store.test.ts
@@ -18,7 +18,6 @@ import {
 } from '@/services/passkey/passkey-key-storage'
 import { SyncEnclaveError } from '@/services/sync-enclave/sync-enclave-client'
 import { deriveTinfoilKeyIdHex } from '@/services/sync-enclave/tinfoil-key-id'
-import { encodeWrappedKeyRecord } from '@tinfoilsh/passkey-kit'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/utils/error-handling', () => ({
@@ -58,22 +57,11 @@ const KEY_BUNDLE: KeyBundle = {
   authorizationMode: 'validated',
 }
 
-function expectedEnvelope(
-  wrappedKeys: TinfoilWrappedKeyBundle,
-  authorizationMode: 'validated' | 'explicit_start_fresh' = 'validated',
-) {
-  const json = JSON.stringify({
-    version: 1,
-    authorizationMode,
-    primary: encodeWrappedKeyRecord(wrappedKeys.primary),
-    alternatives: wrappedKeys.alternatives.map(encodeWrappedKeyRecord),
-  })
+function expectedBundle(wrappedKeys: TinfoilWrappedKeyBundle) {
   return {
     credentialId: wrappedKeys.primary.credentialId,
     kekIvHex: wrappedKeys.primary.kekIvHex,
-    encryptedKeysHex: Array.from(new TextEncoder().encode(json), (byte) =>
-      byte.toString(16).padStart(2, '0'),
-    ).join(''),
+    encryptedKeysHex: wrappedKeys.primary.wrappedKeyHex,
   }
 }
 
@@ -132,7 +120,8 @@ describe('passkey-key-storage storeEncryptedKeys (enclave wire)', () => {
     const arg = mockRegisterKey.mock.calls[0][0]
     expect(arg.createdVia).toBe('passkey')
     expect(arg.initialBundle.credentialId).toBe('AQID')
-    expect(arg.initialBundle).toEqual(expectedEnvelope(bundle))
+    expect(arg.initialBundle).toEqual(expectedBundle(bundle))
+    expect(arg.initialBundle.encryptedKeysHex).toMatch(/^[0-9a-f]{96}$/)
   })
 
   it('uses created_via=start_fresh when the bundle is marked explicit_start_fresh', async () => {
@@ -150,7 +139,7 @@ describe('passkey-key-storage storeEncryptedKeys (enclave wire)', () => {
     })
     expect(mockRegisterKey.mock.calls[0][0].createdVia).toBe('start_fresh')
     expect(mockRegisterKey.mock.calls[0][0].initialBundle).toEqual(
-      expectedEnvelope(bundle, 'explicit_start_fresh'),
+      expectedBundle(bundle),
     )
   })
 
@@ -199,9 +188,10 @@ describe('passkey-key-storage storeEncryptedKeys (enclave wire)', () => {
     const arg = mockAddBundle.mock.calls[0][0]
     expect(arg.keyId).toBe(expectedKeyId)
     expect(arg.credentialId).toBe('BAUG')
-    const expectedBundle = expectedEnvelope(bundle)
-    expect(arg.kekIvHex).toBe(expectedBundle.kekIvHex)
-    expect(arg.encryptedKeysHex).toBe(expectedBundle.encryptedKeysHex)
+    const expected = expectedBundle(bundle)
+    expect(arg.kekIvHex).toBe(expected.kekIvHex)
+    expect(arg.encryptedKeysHex).toBe(expected.encryptedKeysHex)
+    expect(arg.encryptedKeysHex).toMatch(/^[0-9a-f]{96}$/)
     expect(typeof arg.idempotencyKey).toBe('string')
   })
 


### PR DESCRIPTION
## Summary
- send the raw 96-character wrapped CEK expected by the sync enclave
- retain legacy generic-envelope decoding for existing passkey backups
- enforce the enclave wire format in passkey registration and recovery tests

## Testing
- `npm run test:unit -- --run` (1,978 tests)
- ESLint on all changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores passkey backup registration by sending the raw 96-character wrapped CEK to the sync enclave instead of the generic JSON envelope. Legacy generic envelopes are still decoded for existing passkey backups, so recovery history is preserved. Tests now enforce the enclave wire format end-to-end, and the adoption flow no longer adds a redundant bundle when the initial bundle is present.

<sup>Written for commit 9b7815c6d294c0af0355ecbc4d5052b83486cc1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

