### PR TITLE
fix: make account signup reliable

### DIFF
--- a/scripts/check-clerk-environment.mjs
+++ b/scripts/check-clerk-environment.mjs
@@ -22,6 +22,41 @@ export function getClerkPrivacyDrift(environment) {
   return drift
 }
 
+export function getClerkAuthDrift(environment) {
+  const drift = []
+  const attributes = environment?.user_settings?.attributes
+
+  if (environment?.user_settings?.sign_up?.mode !== 'public') {
+    drift.push('user_settings.sign_up.mode must be public')
+  }
+
+  if (attributes?.password?.enabled !== true) {
+    drift.push('user_settings.attributes.password.enabled must be true')
+  }
+
+  if (attributes?.password?.required !== true) {
+    drift.push('user_settings.attributes.password.required must be true')
+  }
+
+  if (attributes?.email_address?.enabled !== true) {
+    drift.push('user_settings.attributes.email_address.enabled must be true')
+  }
+
+  if (attributes?.email_address?.verify_at_sign_up !== true) {
+    drift.push(
+      'user_settings.attributes.email_address.verify_at_sign_up must be true',
+    )
+  }
+
+  if (!attributes?.email_address?.verifications?.includes('email_code')) {
+    drift.push(
+      'user_settings.attributes.email_address.verifications must include email_code',
+    )
+  }
+
+  return drift
+}
+
 export async function checkClerkEnvironment({
   fetchImplementation = fetch,
   url = CLERK_ENVIRONMENT_URL,
@@ -58,19 +93,20 @@ export async function checkClerkEnvironment({
     )
   }
 
-  const drift = getClerkPrivacyDrift(environment)
+  const drift = [
+    ...getClerkPrivacyDrift(environment),
+    ...getClerkAuthDrift(environment),
+  ]
 
   if (drift.length > 0) {
-    throw new Error(
-      `Clerk privacy configuration drifted:\n- ${drift.join('\n- ')}`,
-    )
+    throw new Error(`Clerk configuration drifted:\n- ${drift.join('\n- ')}`)
   }
 }
 
 async function main() {
   try {
     await checkClerkEnvironment()
-    process.stdout.write('Clerk privacy configuration is valid.\n')
+    process.stdout.write('Clerk configuration is valid.\n')
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     process.stderr.write(`${message}\n`)

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3959,6 +3959,7 @@ export function ChatInterface({
                 deleteChat={deleteChat}
                 isClient={isClient}
                 isPremium={isPremium}
+                isSubscriptionLoading={isSubscriptionLoading}
                 onEncryptionKeyClick={
                   isSignedIn ? handleOpenEncryptionKeyModal : undefined
                 }

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -39,6 +39,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { AnimatePresence, motion } from 'framer-motion'
+import { useRouter } from 'next/router'
 import { CiFloppyDisk } from 'react-icons/ci'
 import { FaLock } from 'react-icons/fa6'
 import { GoSidebarCollapse, GoSidebarExpand } from 'react-icons/go'
@@ -57,6 +58,7 @@ import { CONSTANTS } from './constants'
 import { useDrag } from './drag-context'
 import { consumeFavoriteDrop } from './favorite-drag'
 import { SidebarSyncButton } from './sidebar-sync-button'
+import { getSidebarUpsellVariant } from './sidebar-upsell-state'
 import { useFavoriteDropTarget } from './use-favorite-drop-target'
 
 import { useProject } from '@/components/project/project-context'
@@ -112,6 +114,7 @@ type ChatSidebarProps = {
   deleteChat: (chatId: string) => void
   isClient: boolean
   isPremium?: boolean
+  isSubscriptionLoading?: boolean
   onEncryptionKeyClick?: () => void
   onCloudSyncSetupClick?: () => void
   onSetupPasskey?: () => Promise<boolean>
@@ -195,6 +198,7 @@ export function ChatSidebar({
   deleteChat,
   isClient,
   isPremium = true,
+  isSubscriptionLoading = false,
   onEncryptionKeyClick,
   onCloudSyncSetupClick,
   onSetupPasskey,
@@ -226,6 +230,8 @@ export function ChatSidebar({
   windowWidth,
   chatDecryptionProgress,
 }: ChatSidebarProps) {
+  const router = useRouter()
+  const authRedirectUrl = encodeURIComponent(router.asPath)
   const syncNeedsAttention = useSyncHealthAttention()
   const syncHealth = useSyncHealth()
   const [isInitialLoad, setIsInitialLoad] = useState(true)
@@ -308,6 +314,12 @@ export function ChatSidebar({
     isLocalOnlyModeEnabled(),
   )
   const { isLoaded: isAuthLoaded, isSignedIn } = useAuth()
+  const upsellVariant = getSidebarUpsellVariant({
+    isAuthLoaded,
+    isSignedIn,
+    isSubscriptionLoading,
+    isPremium,
+  })
   const favoritesAvailable = Boolean(isSignedIn && cloudSyncEnabled)
   const { user } = useUser()
 
@@ -1168,7 +1180,7 @@ export function ChatSidebar({
           )}
         >
           {/* Message for non-premium users (signed in or not) */}
-          {!isPremium && (
+          {upsellVariant && (
             <div
               className={cn(
                 'relative z-10 m-2 flex-none rounded-lg border border-border-subtle bg-surface-chat p-4 transition-all duration-300',
@@ -1178,24 +1190,43 @@ export function ChatSidebar({
                 <h4 className="mb-3 text-sm font-semibold text-content-primary">
                   Get more out of Tinfoil Chat
                 </h4>
-                <div className="space-y-2.5">
-                  <div className="flex items-center gap-3 text-xs text-content-secondary">
-                    <PiMicrophone className="h-4 w-4 flex-shrink-0 text-content-muted" />
-                    <span>Speech-to-text voice input</span>
-                  </div>
+                {upsellVariant === 'premium' ? (
+                  <div className="space-y-2.5">
+                    <div className="flex items-center gap-3 text-xs text-content-secondary">
+                      <PiMicrophone className="h-4 w-4 flex-shrink-0 text-content-muted" />
+                      <span>Speech-to-text voice input</span>
+                    </div>
 
-                  <div className="flex items-center gap-3 text-xs text-content-secondary">
-                    <PiSparkle className="h-4 w-4 flex-shrink-0 text-content-muted" />
-                    <span>No daily request limits</span>
-                  </div>
+                    <div className="flex items-center gap-3 text-xs text-content-secondary">
+                      <PiSparkle className="h-4 w-4 flex-shrink-0 text-content-muted" />
+                      <span>No daily request limits</span>
+                    </div>
 
-                  <div className="flex items-center gap-3 text-xs text-content-secondary">
-                    <PiFolder className="h-4 w-4 flex-shrink-0 text-content-muted" />
-                    <span>Create projects to chat with files</span>
+                    <div className="flex items-center gap-3 text-xs text-content-secondary">
+                      <PiFolder className="h-4 w-4 flex-shrink-0 text-content-muted" />
+                      <span>Create projects to chat with files</span>
+                    </div>
                   </div>
-                </div>
+                ) : (
+                  <div className="space-y-2.5">
+                    <div className="flex items-center gap-3 text-xs text-content-secondary">
+                      <IoChatbubblesOutline className="h-4 w-4 flex-shrink-0 text-content-muted" />
+                      <span>Keep your chat history</span>
+                    </div>
+
+                    <div className="flex items-center gap-3 text-xs text-content-secondary">
+                      <CloudIcon className="h-4 w-4 flex-shrink-0 text-content-muted" />
+                      <span>Encrypted sync across devices</span>
+                    </div>
+
+                    <div className="flex items-center gap-3 text-xs text-content-secondary">
+                      <PiPushPin className="h-4 w-4 flex-shrink-0 text-content-muted" />
+                      <span>Save your favorite chats</span>
+                    </div>
+                  </div>
+                )}
                 <div className="mt-4">
-                  {isSignedIn ? (
+                  {upsellVariant === 'premium' ? (
                     <>
                       <button
                         type="button"
@@ -1237,15 +1268,15 @@ export function ChatSidebar({
                   ) : (
                     <div className="space-y-2">
                       <Link
-                        href="/signin"
+                        href={`/signup?redirect_url=${authRedirectUrl}`}
                         className="relative block w-full cursor-pointer rounded-md bg-brand-accent-dark px-4 py-2 text-center text-sm font-medium text-white transition-all hover:bg-brand-accent-dark/90"
                       >
-                        Subscribe to Premium
+                        Create account
                       </Link>
                       <p className="text-center text-xs text-content-secondary">
-                        Already subscribed?{' '}
+                        Already signed up?{' '}
                         <Link
-                          href="/signin"
+                          href={`/signin?redirect_url=${authRedirectUrl}`}
                           className="cursor-pointer underline hover:text-content-primary"
                         >
                           Log in
@@ -1259,7 +1290,7 @@ export function ChatSidebar({
           )}
 
           {/* Divider after boxes */}
-          {!isPremium && (
+          {upsellVariant && (
             <div className="relative z-10 border-b border-border-subtle" />
           )}
 

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1234,30 +1234,11 @@ export function ChatSidebar({
                           void handleUpgradeToPro()
                         }}
                         disabled={upgradeLoading}
-                        className={`inline-flex items-center gap-1 text-sm font-medium transition-colors ${
-                          isDarkMode
-                            ? 'text-brand-accent-light hover:text-brand-accent-light/80'
-                            : 'text-brand-accent-dark hover:text-brand-accent-dark/80'
-                        } ${upgradeLoading ? 'cursor-not-allowed opacity-70' : ''}`}
+                        className={`block w-full rounded-md bg-brand-accent-dark px-4 py-2 text-center text-sm font-medium text-white transition-all hover:bg-brand-accent-dark/90 ${upgradeLoading ? 'cursor-not-allowed opacity-70' : ''}`}
                       >
                         {upgradeLoading
                           ? 'Redirecting…'
                           : 'Subscribe to Premium'}
-                        {!upgradeLoading && (
-                          <svg
-                            className="h-3 w-3"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M9 5l7 7-7 7"
-                            />
-                          </svg>
-                        )}
                       </button>
                       {upgradeError && (
                         <p className="mt-2 text-xs text-destructive">

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -87,6 +87,8 @@ import { Logo } from '../logo'
 import type { Chat } from './types'
 
 const FAVORITES_PANEL_ID = 'sidebar-favorites-panel'
+const SIDEBAR_CTA_CLASS_NAME =
+  'block w-full rounded-md bg-brand-accent-dark px-4 py-2 text-center text-sm font-medium text-white transition-all hover:bg-brand-accent-dark/90'
 
 // Utility function to detect iOS devices
 function isIOSDevice() {
@@ -1234,7 +1236,10 @@ export function ChatSidebar({
                           void handleUpgradeToPro()
                         }}
                         disabled={upgradeLoading}
-                        className={`block w-full rounded-md bg-brand-accent-dark px-4 py-2 text-center text-sm font-medium text-white transition-all hover:bg-brand-accent-dark/90 ${upgradeLoading ? 'cursor-not-allowed opacity-70' : ''}`}
+                        className={cn(
+                          SIDEBAR_CTA_CLASS_NAME,
+                          upgradeLoading && 'cursor-not-allowed opacity-70',
+                        )}
                       >
                         {upgradeLoading
                           ? 'Redirecting…'
@@ -1250,7 +1255,10 @@ export function ChatSidebar({
                     <div className="space-y-2">
                       <Link
                         href={`/signup?redirect_url=${authRedirectUrl}`}
-                        className="relative block w-full cursor-pointer rounded-md bg-brand-accent-dark px-4 py-2 text-center text-sm font-medium text-white transition-all hover:bg-brand-accent-dark/90"
+                        className={cn(
+                          SIDEBAR_CTA_CLASS_NAME,
+                          'relative cursor-pointer',
+                        )}
                       >
                         Create account
                       </Link>

--- a/src/components/chat/sidebar-upsell-state.ts
+++ b/src/components/chat/sidebar-upsell-state.ts
@@ -1,0 +1,18 @@
+export type SidebarUpsellVariant = 'account' | 'premium' | null
+
+type SidebarUpsellState = {
+  isAuthLoaded: boolean
+  isSignedIn: boolean | undefined
+  isSubscriptionLoading: boolean
+  isPremium: boolean
+}
+
+export function getSidebarUpsellVariant({
+  isAuthLoaded,
+  isSignedIn,
+  isSubscriptionLoading,
+  isPremium,
+}: SidebarUpsellState): SidebarUpsellVariant {
+  if (!isAuthLoaded || isSubscriptionLoading || isPremium) return null
+  return isSignedIn ? 'premium' : 'account'
+}

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -322,6 +322,39 @@ export default function SignInPage({
     )
   }
 
+  const verifyCode = () => {
+    switch (verificationKind) {
+      case 'signup':
+        return signUp.verifications.verifyEmailCode({ code })
+      case 'reset':
+        return signIn.resetPasswordEmailCode.verifyCode({ code })
+      case 'primary':
+        return signIn.emailCode.verifyCode({ code })
+      case 'mfa':
+        return signIn.mfa.verifyEmailCode({ code })
+      case 'backup':
+        return signIn.mfa.verifyBackupCode({ code })
+      case 'totp':
+        return signIn.mfa.verifyTOTP({ code })
+    }
+  }
+
+  const resendCode = () => {
+    switch (verificationKind) {
+      case 'signup':
+        return signUp.verifications.sendEmailCode()
+      case 'reset':
+        return signIn.resetPasswordEmailCode.sendCode()
+      case 'primary':
+        return signIn.emailCode.sendCode()
+      case 'mfa':
+        return signIn.mfa.sendEmailCode()
+      case 'backup':
+      case 'totp':
+        throw new Error('This verification strategy does not send codes')
+    }
+  }
+
   const handleCodeSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
     await runAuthAction(
@@ -329,18 +362,7 @@ export default function SignInPage({
       'Could not verify sign-in code',
       'handleCodeSubmit',
       async () => {
-        const { error } =
-          verificationKind === 'signup'
-            ? await signUp.verifications.verifyEmailCode({ code })
-            : verificationKind === 'reset'
-              ? await signIn.resetPasswordEmailCode.verifyCode({ code })
-              : verificationKind === 'primary'
-                ? await signIn.emailCode.verifyCode({ code })
-                : verificationKind === 'mfa'
-                  ? await signIn.mfa.verifyEmailCode({ code })
-                  : verificationKind === 'backup'
-                    ? await signIn.mfa.verifyBackupCode({ code })
-                    : await signIn.mfa.verifyTOTP({ code })
+        const { error } = await verifyCode()
 
         if (error) {
           setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
@@ -379,14 +401,7 @@ export default function SignInPage({
       'Could not resend sign-in code',
       'handleResendCode',
       async () => {
-        const { error } =
-          verificationKind === 'signup'
-            ? await signUp.verifications.sendEmailCode()
-            : verificationKind === 'reset'
-              ? await signIn.resetPasswordEmailCode.sendCode()
-              : verificationKind === 'primary'
-                ? await signIn.emailCode.sendCode()
-                : await signIn.mfa.sendEmailCode()
+        const { error } = await resendCode()
         if (error) {
           setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
         }
@@ -643,9 +658,7 @@ export default function SignInPage({
                         ? 'Two-step verification'
                         : verificationKind === 'signup'
                           ? 'Verify your email'
-                          : verificationKind === 'reset'
-                            ? 'Check your email'
-                            : 'Check your email'}
+                          : 'Check your email'}
           </h1>
           <p className="mt-1 text-lg leading-tight text-content-muted">
             {step === 'email'

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -15,7 +15,6 @@ import { PiSpinner } from 'react-icons/pi'
 
 const POST_AUTH_REDIRECT_URL = '/'
 const SSO_CALLBACK_URL = '/sso-callback'
-const SIGN_UP_TRANSFER_ERROR = 'sign_up_if_missing_transfer'
 const SUPPORTED_MISSING_FIELDS = new Set([
   'first_name',
   'last_name',
@@ -25,10 +24,19 @@ const AUTH_ERROR_MESSAGE = 'Something went wrong. Please try again.'
 const UNSUPPORTED_REQUIREMENTS_MESSAGE =
   'Your account needs additional setup. Please contact support.'
 
-type AuthStep = 'email' | 'code' | 'details'
-type VerificationKind = 'primary' | 'mfa' | 'totp'
+type AuthMode = 'signin' | 'signup'
+type AuthStep = 'email' | 'code' | 'details' | 'reset-email' | 'reset-password'
+type VerificationKind =
+  'primary' | 'signup' | 'mfa' | 'totp' | 'backup' | 'reset'
 type PendingAction =
-  'google' | 'apple' | 'email' | 'verify' | 'resend' | 'details' | null
+  | 'google'
+  | 'apple'
+  | 'email'
+  | 'verify'
+  | 'resend'
+  | 'details'
+  | 'reset'
+  | null
 type ActiveAuthAction = Exclude<PendingAction, null>
 
 type SignInFinalizeParams = NonNullable<
@@ -38,29 +46,19 @@ type FinalizeNavigateParams = Parameters<
   NonNullable<SignInFinalizeParams['navigate']>
 >[0]
 
-function clerkErrorCode(error: unknown): string | undefined {
-  if (typeof error !== 'object' || error === null) return undefined
-  if ('code' in error && typeof error.code === 'string') return error.code
-  if ('errors' in error && Array.isArray(error.errors)) {
-    const firstError = error.errors[0]
-    if (
-      typeof firstError === 'object' &&
-      firstError !== null &&
-      'code' in firstError &&
-      typeof firstError.code === 'string'
-    ) {
-      return firstError.code
-    }
-  }
-  return undefined
+type SignInPageProps = {
+  initialMode?: AuthMode
 }
 
-export default function SignInPage() {
+export default function SignInPage({
+  initialMode = 'signin',
+}: SignInPageProps) {
   const router = useRouter()
   const clerk = useClerk()
   const { isLoaded: isAuthLoaded, isSignedIn } = useAuth()
   const { signIn, errors: signInErrors } = useSignIn()
-  const { signUp } = useSignUp()
+  const { signUp, errors: signUpErrors } = useSignUp()
+  const mode = initialMode
   const [isDarkMode, setIsDarkMode] = useState(false)
   const [step, setStep] = useState<AuthStep>('email')
   const [verificationKind, setVerificationKind] =
@@ -69,9 +67,12 @@ export default function SignInPage() {
   const [code, setCode] = useState('')
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')
+  const [password, setPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
   const [pendingAction, setPendingAction] = useState<PendingAction>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [emailMfaAvailable, setEmailMfaAvailable] = useState(false)
+  const [backupCodeAvailable, setBackupCodeAvailable] = useState(false)
 
   useEffect(() => {
     const root = document.documentElement
@@ -113,11 +114,17 @@ export default function SignInPage() {
   }
 
   const finalizeSignIn = async () => {
-    await signIn.finalize({ navigate: navigateAfterAuth })
+    const { error } = await signIn.finalize({ navigate: navigateAfterAuth })
+    if (error) {
+      setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+    }
   }
 
   const finalizeSignUp = async () => {
-    await signUp.finalize({ navigate: navigateAfterAuth })
+    const { error } = await signUp.finalize({ navigate: navigateAfterAuth })
+    if (error) {
+      setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+    }
   }
 
   const showAdditionalRequirements = async () => {
@@ -145,26 +152,6 @@ export default function SignInPage() {
     setStep('details')
   }
 
-  const transferToSignUp = async () => {
-    const { error } = await signUp.create({ transfer: true })
-    if (error) {
-      setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
-      return
-    }
-
-    if (signUp.status === 'complete') {
-      await finalizeSignUp()
-      return
-    }
-
-    if (signUp.status === 'missing_requirements') {
-      await showAdditionalRequirements()
-      return
-    }
-
-    setErrorMessage(AUTH_ERROR_MESSAGE)
-  }
-
   const continueSignIn = async () => {
     if (signIn.status === 'complete') {
       await finalizeSignIn()
@@ -181,18 +168,30 @@ export default function SignInPage() {
       const hasEmailCode = signIn.supportedSecondFactors.some(
         (factor) => factor.strategy === 'email_code',
       )
+      const hasBackupCode = signIn.supportedSecondFactors.some(
+        (factor) => factor.strategy === 'backup_code',
+      )
 
       // Prefer the authenticator app when enrolled; it needs no send step.
       if (hasTotp) {
         setCode('')
         setEmailMfaAvailable(hasEmailCode)
+        setBackupCodeAvailable(hasBackupCode)
         setVerificationKind('totp')
         setStep('code')
         return
       }
 
-      if (!hasEmailCode) {
+      if (!hasEmailCode && !hasBackupCode) {
         setErrorMessage(UNSUPPORTED_REQUIREMENTS_MESSAGE)
+        return
+      }
+
+      if (!hasEmailCode) {
+        setCode('')
+        setBackupCodeAvailable(false)
+        setVerificationKind('backup')
+        setStep('code')
         return
       }
 
@@ -203,6 +202,7 @@ export default function SignInPage() {
       }
 
       setCode('')
+      setBackupCodeAvailable(hasBackupCode)
       setVerificationKind('mfa')
       setStep('code')
       return
@@ -248,7 +248,7 @@ export default function SignInPage() {
           postAuthRedirectUrl === POST_AUTH_REDIRECT_URL
             ? SSO_CALLBACK_URL
             : `${SSO_CALLBACK_URL}?redirect_url=${encodeURIComponent(postAuthRedirectUrl)}`
-        const { error } = await signIn.sso({
+        const { error } = await (mode === 'signup' ? signUp : signIn).sso({
           strategy,
           redirectCallbackUrl,
           redirectUrl: postAuthRedirectUrl,
@@ -264,26 +264,60 @@ export default function SignInPage() {
     event.preventDefault()
     await runAuthAction(
       'email',
-      'Could not send sign-in code',
+      mode === 'signup' ? 'Could not create account' : 'Could not sign in',
       'handleEmailSubmit',
       async () => {
-        const { error: createError } = await signIn.create({
+        if (mode === 'signup') {
+          const { error } = await signUp.password({
+            emailAddress,
+            password,
+            firstName: firstName || undefined,
+            lastName: lastName || undefined,
+          })
+          if (error) {
+            setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+            return
+          }
+
+          if (signUp.status === 'complete') {
+            await finalizeSignUp()
+            return
+          }
+
+          if (signUp.unverifiedFields.includes('email_address')) {
+            const { error: sendError } =
+              await signUp.verifications.sendEmailCode()
+            if (sendError) {
+              setErrorMessage(
+                getClerkErrorMessage(sendError, AUTH_ERROR_MESSAGE),
+              )
+              return
+            }
+            setVerificationKind('signup')
+            setCode('')
+            setStep('code')
+            return
+          }
+
+          if (signUp.status === 'missing_requirements') {
+            await showAdditionalRequirements()
+            return
+          }
+
+          setErrorMessage(AUTH_ERROR_MESSAGE)
+          return
+        }
+
+        const { error } = await signIn.password({
           identifier: emailAddress,
-          signUpIfMissing: true,
+          password,
         })
-        if (createError) {
-          setErrorMessage(getClerkErrorMessage(createError, AUTH_ERROR_MESSAGE))
+        if (error) {
+          setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
           return
         }
 
-        const { error: sendError } = await signIn.emailCode.sendCode()
-        if (sendError) {
-          setErrorMessage(getClerkErrorMessage(sendError, AUTH_ERROR_MESSAGE))
-          return
-        }
-
-        setVerificationKind('primary')
-        setStep('code')
+        await continueSignIn()
       },
     )
   }
@@ -296,23 +330,41 @@ export default function SignInPage() {
       'handleCodeSubmit',
       async () => {
         const { error } =
-          verificationKind === 'primary'
-            ? await signIn.emailCode.verifyCode({ code })
-            : verificationKind === 'mfa'
-              ? await signIn.mfa.verifyEmailCode({ code })
-              : await signIn.mfa.verifyTOTP({ code })
+          verificationKind === 'signup'
+            ? await signUp.verifications.verifyEmailCode({ code })
+            : verificationKind === 'reset'
+              ? await signIn.resetPasswordEmailCode.verifyCode({ code })
+              : verificationKind === 'primary'
+                ? await signIn.emailCode.verifyCode({ code })
+                : verificationKind === 'mfa'
+                  ? await signIn.mfa.verifyEmailCode({ code })
+                  : verificationKind === 'backup'
+                    ? await signIn.mfa.verifyBackupCode({ code })
+                    : await signIn.mfa.verifyTOTP({ code })
 
         if (error) {
-          const errorCode = clerkErrorCode(error)
-          if (
-            verificationKind === 'primary' &&
-            errorCode === SIGN_UP_TRANSFER_ERROR
-          ) {
-            await transferToSignUp()
-            return
-          }
-
           setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+          return
+        }
+
+        if (verificationKind === 'signup') {
+          if (signUp.status === 'complete') {
+            await finalizeSignUp()
+          } else if (signUp.status === 'missing_requirements') {
+            await showAdditionalRequirements()
+          } else {
+            setErrorMessage(UNSUPPORTED_REQUIREMENTS_MESSAGE)
+          }
+          return
+        }
+
+        if (verificationKind === 'reset') {
+          if (signIn.status === 'needs_new_password') {
+            setCode('')
+            setStep('reset-password')
+          } else {
+            setErrorMessage(AUTH_ERROR_MESSAGE)
+          }
           return
         }
 
@@ -328,9 +380,13 @@ export default function SignInPage() {
       'handleResendCode',
       async () => {
         const { error } =
-          verificationKind === 'primary'
-            ? await signIn.emailCode.sendCode()
-            : await signIn.mfa.sendEmailCode()
+          verificationKind === 'signup'
+            ? await signUp.verifications.sendEmailCode()
+            : verificationKind === 'reset'
+              ? await signIn.resetPasswordEmailCode.sendCode()
+              : verificationKind === 'primary'
+                ? await signIn.emailCode.sendCode()
+                : await signIn.mfa.sendEmailCode()
         if (error) {
           setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
         }
@@ -353,6 +409,12 @@ export default function SignInPage() {
         setVerificationKind('mfa')
       },
     )
+  }
+
+  const handleUseBackupCode = () => {
+    setErrorMessage(null)
+    setCode('')
+    setVerificationKind('backup')
   }
 
   const handleDetailsSubmit = async (event: React.FormEvent) => {
@@ -388,6 +450,56 @@ export default function SignInPage() {
     )
   }
 
+  const handleResetEmailSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    await runAuthAction(
+      'reset',
+      'Could not send password reset code',
+      'handleResetEmailSubmit',
+      async () => {
+        const { error: createError } = await signIn.create({
+          identifier: emailAddress,
+        })
+        if (createError) {
+          setErrorMessage(getClerkErrorMessage(createError, AUTH_ERROR_MESSAGE))
+          return
+        }
+
+        const { error: sendError } =
+          await signIn.resetPasswordEmailCode.sendCode()
+        if (sendError) {
+          setErrorMessage(getClerkErrorMessage(sendError, AUTH_ERROR_MESSAGE))
+          return
+        }
+
+        setCode('')
+        setVerificationKind('reset')
+        setStep('code')
+      },
+    )
+  }
+
+  const handleNewPasswordSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    await runAuthAction(
+      'reset',
+      'Could not reset password',
+      'handleNewPasswordSubmit',
+      async () => {
+        const { error } = await signIn.resetPasswordEmailCode.submitPassword({
+          password: newPassword,
+          signOutOfOtherSessions: true,
+        })
+        if (error) {
+          setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+          return
+        }
+
+        await continueSignIn()
+      },
+    )
+  }
+
   const landingAttemptCheckedRef = useRef(false)
   useEffect(() => {
     if (!router.isReady || !clerk.loaded || landingAttemptCheckedRef.current) {
@@ -395,10 +507,23 @@ export default function SignInPage() {
     }
 
     landingAttemptCheckedRef.current = true
-    if (router.query.resume === '1' || !signIn.id) return
+    if (router.query.resume === '1') return
 
-    void signIn.reset()
-  }, [clerk.loaded, router.isReady, router.query.resume, signIn, signIn.id])
+    if (mode === 'signup' && signUp.id) {
+      void signUp.reset()
+    } else if (mode === 'signin' && signIn.id) {
+      void signIn.reset()
+    }
+  }, [
+    clerk.loaded,
+    mode,
+    router.isReady,
+    router.query.resume,
+    signIn,
+    signIn.id,
+    signUp,
+    signUp.id,
+  ])
 
   // Social sign-ins that still need MFA, client trust, or sign-up details
   // come back from the SSO callback with ?resume=1 — pick the flow back up
@@ -468,10 +593,14 @@ export default function SignInPage() {
 
   const startOver = () => {
     signIn.reset()
+    signUp.reset()
     setCode('')
+    setPassword('')
+    setNewPassword('')
     setErrorMessage(null)
     setVerificationKind('primary')
     setEmailMfaAvailable(false)
+    setBackupCodeAvailable(false)
     setStep('email')
   }
 
@@ -496,24 +625,46 @@ export default function SignInPage() {
           <Logo dark={isDarkMode} className="h-9 w-auto" />
         </Link>
 
-        {step !== 'email' && (
-          <div className="mb-8">
-            <h1 className="text-2xl font-medium leading-tight text-content-primary">
-              {step !== 'code'
+        <div className="mb-8">
+          <h1 className="text-2xl font-medium leading-tight text-content-primary">
+            {step === 'email'
+              ? mode === 'signup'
+                ? 'Create your account'
+                : 'Welcome back'
+              : step === 'details'
                 ? 'Complete your account'
-                : verificationKind === 'totp'
-                  ? 'Two-step verification'
-                  : 'Check your email'}
-            </h1>
-            <p className="mt-1 text-lg leading-tight text-content-muted">
-              {step !== 'code'
+                : step === 'reset-email'
+                  ? 'Reset your password'
+                  : step === 'reset-password'
+                    ? 'Choose a new password'
+                    : verificationKind === 'backup'
+                      ? 'Use a recovery code'
+                      : verificationKind === 'totp'
+                        ? 'Two-step verification'
+                        : verificationKind === 'signup'
+                          ? 'Verify your email'
+                          : verificationKind === 'reset'
+                            ? 'Check your email'
+                            : 'Check your email'}
+          </h1>
+          <p className="mt-1 text-lg leading-tight text-content-muted">
+            {step === 'email'
+              ? mode === 'signup'
+                ? 'Sign up with Google, Apple, or email'
+                : 'Sign in with Google, Apple, or email'
+              : step === 'details'
                 ? 'Your email is verified'
-                : verificationKind === 'totp'
-                  ? 'Enter the code from your authenticator app'
-                  : `We sent a verification code to ${emailAddress}`}
-            </p>
-          </div>
-        )}
+                : step === 'reset-email'
+                  ? 'Enter the email address for your account'
+                  : step === 'reset-password'
+                    ? 'Use a strong password you do not use elsewhere'
+                    : verificationKind === 'backup'
+                      ? 'Enter one of your saved recovery codes'
+                      : verificationKind === 'totp'
+                        ? 'Enter the code from your authenticator app'
+                        : `We sent a verification code to ${emailAddress}`}
+          </p>
+        </div>
 
         {step === 'email' && (
           <>
@@ -557,6 +708,46 @@ export default function SignInPage() {
             </div>
 
             <form onSubmit={handleEmailSubmit} className="space-y-5">
+              {mode === 'signup' && (
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label
+                      htmlFor="first-name"
+                      className="mb-2 block text-sm text-content-secondary"
+                    >
+                      First name
+                    </label>
+                    <input
+                      id="first-name"
+                      name="firstName"
+                      type="text"
+                      autoComplete="given-name"
+                      required
+                      value={firstName}
+                      onChange={(event) => setFirstName(event.target.value)}
+                      className="h-11 w-full rounded-lg border border-border-subtle bg-surface-chat px-3 text-sm text-content-primary outline-none transition-colors focus:border-border-strong"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="last-name"
+                      className="mb-2 block text-sm text-content-secondary"
+                    >
+                      Last name
+                    </label>
+                    <input
+                      id="last-name"
+                      name="lastName"
+                      type="text"
+                      autoComplete="family-name"
+                      required
+                      value={lastName}
+                      onChange={(event) => setLastName(event.target.value)}
+                      className="h-11 w-full rounded-lg border border-border-subtle bg-surface-chat px-3 text-sm text-content-primary outline-none transition-colors focus:border-border-strong"
+                    />
+                  </div>
+                </div>
+              )}
               <div>
                 <label
                   htmlFor="email"
@@ -581,6 +772,26 @@ export default function SignInPage() {
                   className="h-11 w-full rounded-lg border border-border-subtle bg-surface-chat px-3 text-sm text-content-primary outline-none transition-colors placeholder:text-content-muted focus:border-border-strong"
                 />
               </div>
+              <div>
+                <label
+                  htmlFor="password"
+                  className="mb-2 block text-sm text-content-secondary"
+                >
+                  Password
+                </label>
+                <input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autoComplete={
+                    mode === 'signup' ? 'new-password' : 'current-password'
+                  }
+                  required
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  className="h-11 w-full rounded-lg border border-border-subtle bg-surface-chat px-3 text-sm text-content-primary outline-none transition-colors focus:border-border-strong"
+                />
+              </div>
               <Button
                 type="submit"
                 variant="solid"
@@ -592,9 +803,35 @@ export default function SignInPage() {
                 {pendingAction === 'email' && (
                   <PiSpinner className="h-4 w-4 animate-spin" />
                 )}
-                Continue
+                {mode === 'signup' ? 'Create account' : 'Sign in'}
               </Button>
+              {mode === 'signin' && (
+                <button
+                  type="button"
+                  disabled={isPending}
+                  onClick={() => {
+                    setErrorMessage(null)
+                    setStep('reset-email')
+                  }}
+                  className="mx-auto block text-sm text-content-secondary underline transition-colors hover:text-content-primary disabled:opacity-60"
+                >
+                  Forgot password?
+                </button>
+              )}
             </form>
+            <p className="mt-6 text-center text-sm text-content-secondary">
+              {mode === 'signup' ? 'Already signed up? ' : 'New to Tinfoil? '}
+              <Link
+                href={
+                  mode === 'signup'
+                    ? `/signin?redirect_url=${encodeURIComponent(postAuthRedirectUrl)}`
+                    : `/signup?redirect_url=${encodeURIComponent(postAuthRedirectUrl)}`
+                }
+                className="underline hover:text-content-primary"
+              >
+                {mode === 'signup' ? 'Log in' : 'Create account'}
+              </Link>
+            </p>
           </>
         )}
 
@@ -605,13 +842,17 @@ export default function SignInPage() {
                 htmlFor="code"
                 className="mb-2 block text-sm text-content-secondary"
               >
-                Verification code
+                {verificationKind === 'backup'
+                  ? 'Recovery code'
+                  : 'Verification code'}
               </label>
               <input
                 id="code"
                 name="code"
                 type="text"
-                inputMode="numeric"
+                inputMode={
+                  verificationKind === 'backup' ? undefined : 'numeric'
+                }
                 autoComplete="one-time-code"
                 required
                 autoFocus
@@ -638,8 +879,8 @@ export default function SignInPage() {
               )}
               Verify
             </Button>
-            <div className="flex justify-center gap-4 text-sm">
-              {verificationKind !== 'totp' ? (
+            <div className="flex flex-wrap justify-center gap-4 text-sm">
+              {verificationKind !== 'totp' && verificationKind !== 'backup' ? (
                 <button
                   type="button"
                   disabled={isPending}
@@ -662,6 +903,16 @@ export default function SignInPage() {
                   </button>
                 )
               )}
+              {backupCodeAvailable && verificationKind !== 'backup' && (
+                <button
+                  type="button"
+                  disabled={isPending}
+                  onClick={handleUseBackupCode}
+                  className="text-content-secondary transition-colors hover:text-content-primary disabled:opacity-60"
+                >
+                  Use a recovery code
+                </button>
+              )}
               <button
                 type="button"
                 disabled={isPending}
@@ -671,6 +922,88 @@ export default function SignInPage() {
                 Use another email
               </button>
             </div>
+          </form>
+        )}
+
+        {step === 'reset-email' && (
+          <form onSubmit={handleResetEmailSubmit} className="space-y-5">
+            <div>
+              <label
+                htmlFor="reset-email"
+                className="mb-2 block text-sm text-content-secondary"
+              >
+                Email
+              </label>
+              <input
+                id="reset-email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                autoFocus
+                value={emailAddress}
+                onChange={(event) => setEmailAddress(event.target.value)}
+                className="h-11 w-full rounded-lg border border-border-subtle bg-surface-chat px-3 text-sm text-content-primary outline-none transition-colors placeholder:text-content-muted focus:border-border-strong"
+              />
+            </div>
+            <Button
+              type="submit"
+              variant="solid"
+              size="landing"
+              chevron
+              disabled={isPending}
+              className="w-full"
+            >
+              {pendingAction === 'reset' && (
+                <PiSpinner className="h-4 w-4 animate-spin" />
+              )}
+              Send reset code
+            </Button>
+            <button
+              type="button"
+              disabled={isPending}
+              onClick={startOver}
+              className="mx-auto block text-sm text-content-secondary transition-colors hover:text-content-primary disabled:opacity-60"
+            >
+              Back to log in
+            </button>
+          </form>
+        )}
+
+        {step === 'reset-password' && (
+          <form onSubmit={handleNewPasswordSubmit} className="space-y-5">
+            <div>
+              <label
+                htmlFor="new-password"
+                className="mb-2 block text-sm text-content-secondary"
+              >
+                New password
+              </label>
+              <input
+                id="new-password"
+                name="newPassword"
+                type="password"
+                autoComplete="new-password"
+                required
+                autoFocus
+                value={newPassword}
+                onChange={(event) => setNewPassword(event.target.value)}
+                className="h-11 w-full rounded-lg border border-border-subtle bg-surface-chat px-3 text-sm text-content-primary outline-none transition-colors focus:border-border-strong"
+              />
+            </div>
+            <Button
+              type="submit"
+              variant="solid"
+              size="landing"
+              chevron
+              disabled={isPending}
+              className="w-full"
+            >
+              {pendingAction === 'reset' && (
+                <PiSpinner className="h-4 w-4 animate-spin" />
+              )}
+              Reset password
+            </Button>
           </form>
         )}
 
@@ -734,7 +1067,9 @@ export default function SignInPage() {
 
         {(errorMessage ||
           signInErrors.fields.identifier ||
-          signInErrors.fields.code) && (
+          signInErrors.fields.code ||
+          signUpErrors.fields.emailAddress ||
+          signUpErrors.fields.password) && (
           <p
             id="auth-error"
             role="alert"
@@ -742,7 +1077,9 @@ export default function SignInPage() {
           >
             {errorMessage ||
               signInErrors.fields.identifier?.longMessage ||
-              signInErrors.fields.code?.longMessage}
+              signInErrors.fields.code?.longMessage ||
+              signUpErrors.fields.emailAddress?.longMessage ||
+              signUpErrors.fields.password?.longMessage}
           </p>
         )}
 

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,0 +1,5 @@
+import SignInPage from './signin'
+
+export default function SignUpPage() {
+  return <SignInPage initialMode="signup" />
+}

--- a/tests/components/chat/sidebar-upsell-state.test.ts
+++ b/tests/components/chat/sidebar-upsell-state.test.ts
@@ -1,0 +1,42 @@
+import { getSidebarUpsellVariant } from '@/components/chat/sidebar-upsell-state'
+import { describe, expect, it } from 'vitest'
+
+describe('getSidebarUpsellVariant', () => {
+  it('shows account benefits to signed-out users', () => {
+    expect(
+      getSidebarUpsellVariant({
+        isAuthLoaded: true,
+        isSignedIn: false,
+        isSubscriptionLoading: false,
+        isPremium: false,
+      }),
+    ).toBe('account')
+  })
+
+  it('shows premium benefits to signed-in free users', () => {
+    expect(
+      getSidebarUpsellVariant({
+        isAuthLoaded: true,
+        isSignedIn: true,
+        isSubscriptionLoading: false,
+        isPremium: false,
+      }),
+    ).toBe('premium')
+  })
+
+  it.each([
+    { isAuthLoaded: false, isSubscriptionLoading: false, isPremium: false },
+    { isAuthLoaded: true, isSubscriptionLoading: true, isPremium: false },
+    { isAuthLoaded: true, isSubscriptionLoading: false, isPremium: true },
+  ])(
+    'hides the upsell until status is settled or for premium users',
+    (state) => {
+      expect(
+        getSidebarUpsellVariant({
+          ...state,
+          isSignedIn: true,
+        }),
+      ).toBeNull()
+    },
+  )
+})

--- a/tests/pages/signin.test.tsx
+++ b/tests/pages/signin.test.tsx
@@ -34,7 +34,6 @@ const auth = vi.hoisted(() => {
     status: 'missing_requirements',
     missingFields: [] as string[],
     unverifiedFields: [] as string[],
-    create: vi.fn(),
     update: vi.fn(),
     password: vi.fn(),
     sso: vi.fn(),
@@ -91,6 +90,17 @@ vi.mock('next/router', () => ({
   }),
 }))
 
+function renderAndSubmitPasswordSignIn(password = 'account password') {
+  render(<SignInPage />)
+  fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
+    target: { value: 'person@example.com' },
+  })
+  fireEvent.change(screen.getByLabelText('Password'), {
+    target: { value: password },
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+}
+
 describe('SignInPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -129,7 +139,6 @@ describe('SignInPage', () => {
     })
     auth.signIn.finalize.mockResolvedValue({ error: null })
     auth.signIn.reset.mockResolvedValue({ error: null })
-    auth.signUp.create.mockResolvedValue({ error: null })
     auth.signUp.update.mockResolvedValue({ error: null })
     auth.signUp.password.mockResolvedValue({ error: null })
     auth.signUp.sso.mockResolvedValue({ error: null })
@@ -224,15 +233,7 @@ describe('SignInPage', () => {
       auth.signIn.status = 'complete'
       return { error: null }
     })
-    render(<SignInPage />)
-
-    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
-      target: { value: 'person@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'correct horse battery staple' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+    renderAndSubmitPasswordSignIn('correct horse battery staple')
 
     await waitFor(() => {
       expect(auth.signIn.password).toHaveBeenCalledWith({
@@ -311,15 +312,7 @@ describe('SignInPage', () => {
       auth.signIn.status = 'complete'
       return { error: null }
     })
-    render(<SignInPage />)
-
-    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
-      target: { value: 'person@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'account password' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+    renderAndSubmitPasswordSignIn()
 
     expect(
       await screen.findByRole('heading', { name: 'Two-step verification' }),
@@ -395,15 +388,7 @@ describe('SignInPage', () => {
     auth.signIn.password.mockResolvedValue({
       error: { longMessage: 'The password is incorrect.' },
     })
-    render(<SignInPage />)
-
-    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
-      target: { value: 'person@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'incorrect password' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+    renderAndSubmitPasswordSignIn('incorrect password')
 
     const alert = await screen.findByRole('alert')
     expect(alert).toHaveTextContent('The password is incorrect.')
@@ -424,15 +409,7 @@ describe('SignInPage', () => {
     auth.signIn.finalize.mockResolvedValue({
       error: { longMessage: 'The session could not be activated.' },
     })
-    render(<SignInPage />)
-
-    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
-      target: { value: 'person@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'account password' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+    renderAndSubmitPasswordSignIn()
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       'The session could not be activated.',
@@ -448,15 +425,7 @@ describe('SignInPage', () => {
       ]
       return { error: null }
     })
-    render(<SignInPage />)
-
-    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
-      target: { value: 'person@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'account password' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+    renderAndSubmitPasswordSignIn()
 
     fireEvent.click(
       await screen.findByRole('button', { name: 'Email me a code instead' }),
@@ -500,15 +469,7 @@ describe('SignInPage', () => {
       auth.signIn.status = 'complete'
       return { error: null }
     })
-    render(<SignInPage />)
-
-    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
-      target: { value: 'person@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'account password' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+    renderAndSubmitPasswordSignIn()
     fireEvent.click(
       await screen.findByRole('button', { name: 'Use a recovery code' }),
     )

--- a/tests/pages/signin.test.tsx
+++ b/tests/pages/signin.test.tsx
@@ -7,7 +7,9 @@ const auth = vi.hoisted(() => {
     id: undefined as string | undefined,
     status: 'needs_identifier',
     supportedSecondFactors: [] as Array<{ strategy: string }>,
+    supportedFirstFactors: [] as Array<{ strategy: string }>,
     create: vi.fn(),
+    password: vi.fn(),
     emailCode: {
       sendCode: vi.fn(),
       verifyCode: vi.fn(),
@@ -16,17 +18,32 @@ const auth = vi.hoisted(() => {
       sendEmailCode: vi.fn(),
       verifyEmailCode: vi.fn(),
       verifyTOTP: vi.fn(),
+      verifyBackupCode: vi.fn(),
     },
     sso: vi.fn(),
+    resetPasswordEmailCode: {
+      sendCode: vi.fn(),
+      verifyCode: vi.fn(),
+      submitPassword: vi.fn(),
+    },
     finalize: vi.fn(),
     reset: vi.fn(),
   }
   const signUp = {
+    id: undefined as string | undefined,
     status: 'missing_requirements',
     missingFields: [] as string[],
+    unverifiedFields: [] as string[],
     create: vi.fn(),
     update: vi.fn(),
+    password: vi.fn(),
+    sso: vi.fn(),
+    verifications: {
+      sendEmailCode: vi.fn(),
+      verifyEmailCode: vi.fn(),
+    },
     finalize: vi.fn(),
+    reset: vi.fn(),
   }
 
   const router = {
@@ -43,6 +60,8 @@ const auth = vi.hoisted(() => {
     router,
     routerPush: vi.fn(),
     routerReplace: vi.fn(),
+    signInErrors: {} as Record<string, unknown>,
+    signUpErrors: {} as Record<string, unknown>,
   }
 })
 
@@ -54,12 +73,12 @@ vi.mock('@clerk/nextjs', () => ({
   useClerk: () => ({ loaded: auth.clerkLoaded }),
   useSignIn: () => ({
     signIn: auth.signIn,
-    errors: { fields: {} },
+    errors: { fields: auth.signInErrors },
     fetchStatus: 'idle',
   }),
   useSignUp: () => ({
     signUp: auth.signUp,
-    errors: { fields: {} },
+    errors: { fields: auth.signUpErrors },
     fetchStatus: 'idle',
   }),
 }))
@@ -83,18 +102,41 @@ describe('SignInPage', () => {
     auth.signIn.id = undefined
     auth.signIn.status = 'needs_identifier'
     auth.signIn.supportedSecondFactors = []
+    auth.signIn.supportedFirstFactors = []
     auth.signUp.status = 'missing_requirements'
+    auth.signUp.id = undefined
     auth.signUp.missingFields = []
+    auth.signUp.unverifiedFields = []
+    auth.signInErrors = {}
+    auth.signUpErrors = {}
     auth.signIn.create.mockResolvedValue({ error: null })
+    auth.signIn.password.mockResolvedValue({ error: null })
     auth.signIn.emailCode.sendCode.mockResolvedValue({ error: null })
     auth.signIn.emailCode.verifyCode.mockResolvedValue({ error: null })
     auth.signIn.mfa.sendEmailCode.mockResolvedValue({ error: null })
     auth.signIn.mfa.verifyEmailCode.mockResolvedValue({ error: null })
     auth.signIn.mfa.verifyTOTP.mockResolvedValue({ error: null })
+    auth.signIn.mfa.verifyBackupCode.mockResolvedValue({ error: null })
     auth.signIn.sso.mockResolvedValue({ error: null })
+    auth.signIn.resetPasswordEmailCode.sendCode.mockResolvedValue({
+      error: null,
+    })
+    auth.signIn.resetPasswordEmailCode.verifyCode.mockResolvedValue({
+      error: null,
+    })
+    auth.signIn.resetPasswordEmailCode.submitPassword.mockResolvedValue({
+      error: null,
+    })
+    auth.signIn.finalize.mockResolvedValue({ error: null })
     auth.signIn.reset.mockResolvedValue({ error: null })
     auth.signUp.create.mockResolvedValue({ error: null })
     auth.signUp.update.mockResolvedValue({ error: null })
+    auth.signUp.password.mockResolvedValue({ error: null })
+    auth.signUp.sso.mockResolvedValue({ error: null })
+    auth.signUp.verifications.sendEmailCode.mockResolvedValue({ error: null })
+    auth.signUp.verifications.verifyEmailCode.mockResolvedValue({ error: null })
+    auth.signUp.finalize.mockResolvedValue({ error: null })
+    auth.signUp.reset.mockResolvedValue({ error: null })
   })
 
   afterEach(() => {
@@ -167,33 +209,18 @@ describe('SignInPage', () => {
     expect(auth.signIn.reset).not.toHaveBeenCalled()
   })
 
-  it('sends a privacy-preserving email code for sign-in or sign-up', async () => {
-    render(<SignInPage />)
+  it('clears an abandoned sign-up attempt on a fresh signup landing', async () => {
+    auth.signUp.id = 'stale_sign_up'
 
-    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
-      target: { value: 'person@example.com' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    render(<SignInPage initialMode="signup" />)
 
     await waitFor(() => {
-      expect(auth.signIn.create).toHaveBeenCalledWith({
-        identifier: 'person@example.com',
-        signUpIfMissing: true,
-      })
-      expect(auth.signIn.emailCode.sendCode).toHaveBeenCalledTimes(1)
+      expect(auth.signUp.reset).toHaveBeenCalledTimes(1)
     })
-
-    expect(
-      screen.getByRole('heading', { name: 'Check your email' }),
-    ).toBeInTheDocument()
-    expect(screen.getByText(/person@example\.com/)).toBeInTheDocument()
-    expect(
-      screen.getByRole('textbox', { name: 'Verification code' }),
-    ).toHaveAttribute('autocomplete', 'one-time-code')
   })
 
-  it('finalizes an existing account after code verification', async () => {
-    auth.signIn.emailCode.verifyCode.mockImplementation(async () => {
+  it('signs in an existing account with its password', async () => {
+    auth.signIn.password.mockImplementation(async () => {
       auth.signIn.status = 'complete'
       return { error: null }
     })
@@ -202,16 +229,15 @@ describe('SignInPage', () => {
     fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
       target: { value: 'person@example.com' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-    const codeInput = await screen.findByRole('textbox', {
-      name: 'Verification code',
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'correct horse battery staple' },
     })
-    fireEvent.change(codeInput, { target: { value: '123456' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
 
     await waitFor(() => {
-      expect(auth.signIn.emailCode.verifyCode).toHaveBeenCalledWith({
-        code: '123456',
+      expect(auth.signIn.password).toHaveBeenCalledWith({
+        identifier: 'person@example.com',
+        password: 'correct horse battery staple',
       })
       expect(auth.signIn.finalize).toHaveBeenCalledWith({
         navigate: expect.any(Function),
@@ -219,30 +245,56 @@ describe('SignInPage', () => {
     })
   })
 
-  it('transfers a verified email to sign-up when the account is new', async () => {
-    auth.signIn.emailCode.verifyCode.mockResolvedValue({
-      error: { code: 'sign_up_if_missing_transfer' },
-    })
-    auth.signUp.create.mockImplementation(async () => {
-      auth.signUp.status = 'complete'
+  it('creates a password account and verifies its email code', async () => {
+    auth.signUp.password.mockImplementation(async () => {
+      auth.signUp.status = 'missing_requirements'
+      auth.signUp.unverifiedFields = ['email_address']
       return { error: null }
     })
-    render(<SignInPage />)
+    render(<SignInPage initialMode="signup" />)
 
+    fireEvent.change(screen.getByRole('textbox', { name: 'First name' }), {
+      target: { value: 'New' },
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Last name' }), {
+      target: { value: 'Person' },
+    })
     fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
       target: { value: 'new@example.com' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'new account password' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }))
+
+    await waitFor(() => {
+      expect(auth.signUp.password).toHaveBeenCalledWith({
+        emailAddress: 'new@example.com',
+        password: 'new account password',
+        firstName: 'New',
+        lastName: 'Person',
+      })
+      expect(auth.signUp.verifications.sendEmailCode).toHaveBeenCalledTimes(1)
+    })
+
+    expect(
+      screen.getByRole('heading', { name: 'Verify your email' }),
+    ).toBeInTheDocument()
     fireEvent.change(
       await screen.findByRole('textbox', { name: 'Verification code' }),
-      {
-        target: { value: '654321' },
-      },
+      { target: { value: '654321' } },
     )
+    auth.signUp.verifications.verifyEmailCode.mockImplementation(async () => {
+      auth.signUp.status = 'complete'
+      auth.signUp.unverifiedFields = []
+      return { error: null }
+    })
     fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
 
     await waitFor(() => {
-      expect(auth.signUp.create).toHaveBeenCalledWith({ transfer: true })
+      expect(auth.signUp.verifications.verifyEmailCode).toHaveBeenCalledWith({
+        code: '654321',
+      })
       expect(auth.signUp.finalize).toHaveBeenCalledWith({
         navigate: expect.any(Function),
       })
@@ -250,7 +302,7 @@ describe('SignInPage', () => {
   })
 
   it('verifies an authenticator app code when TOTP is the second factor', async () => {
-    auth.signIn.emailCode.verifyCode.mockImplementation(async () => {
+    auth.signIn.password.mockImplementation(async () => {
       auth.signIn.status = 'needs_second_factor'
       auth.signIn.supportedSecondFactors = [{ strategy: 'totp' }]
       return { error: null }
@@ -264,12 +316,10 @@ describe('SignInPage', () => {
     fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
       target: { value: 'person@example.com' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-    fireEvent.change(
-      await screen.findByRole('textbox', { name: 'Verification code' }),
-      { target: { value: '123456' } },
-    )
-    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'account password' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
 
     expect(
       await screen.findByRole('heading', { name: 'Two-step verification' }),
@@ -292,35 +342,71 @@ describe('SignInPage', () => {
     })
   })
 
-  it('shows TOTP verification errors in a centered alert box', async () => {
-    auth.signIn.emailCode.verifyCode.mockImplementation(async () => {
-      auth.signIn.status = 'needs_second_factor'
-      auth.signIn.supportedSecondFactors = [{ strategy: 'totp' }]
-      return { error: null }
+  it('resets a forgotten password with an email code', async () => {
+    auth.signIn.resetPasswordEmailCode.verifyCode.mockImplementation(
+      async () => {
+        auth.signIn.status = 'needs_new_password'
+        return { error: null }
+      },
+    )
+    auth.signIn.resetPasswordEmailCode.submitPassword.mockImplementation(
+      async () => {
+        auth.signIn.status = 'complete'
+        return { error: null }
+      },
+    )
+    render(<SignInPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Forgot password?' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
+      target: { value: 'person@example.com' },
     })
-    auth.signIn.mfa.verifyTOTP.mockResolvedValue({
-      error: { longMessage: 'The verification code is invalid.' },
+    fireEvent.click(screen.getByRole('button', { name: 'Send reset code' }))
+
+    await waitFor(() => {
+      expect(auth.signIn.create).toHaveBeenCalledWith({
+        identifier: 'person@example.com',
+      })
+      expect(auth.signIn.resetPasswordEmailCode.sendCode).toHaveBeenCalled()
+    })
+
+    fireEvent.change(
+      await screen.findByRole('textbox', { name: 'Verification code' }),
+      { target: { value: '123456' } },
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+    fireEvent.change(await screen.findByLabelText('New password'), {
+      target: { value: 'replacement password' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Reset password' }))
+
+    await waitFor(() => {
+      expect(
+        auth.signIn.resetPasswordEmailCode.submitPassword,
+      ).toHaveBeenCalledWith({
+        password: 'replacement password',
+        signOutOfOtherSessions: true,
+      })
+      expect(auth.signIn.finalize).toHaveBeenCalled()
+    })
+  })
+
+  it('shows password sign-in errors in a centered alert box', async () => {
+    auth.signIn.password.mockResolvedValue({
+      error: { longMessage: 'The password is incorrect.' },
     })
     render(<SignInPage />)
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
       target: { value: 'person@example.com' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-    fireEvent.change(
-      await screen.findByRole('textbox', { name: 'Verification code' }),
-      { target: { value: '123456' } },
-    )
-    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
-    await screen.findByRole('heading', { name: 'Two-step verification' })
-    fireEvent.change(
-      screen.getByRole('textbox', { name: 'Verification code' }),
-      { target: { value: '987654' } },
-    )
-    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'incorrect password' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
 
     const alert = await screen.findByRole('alert')
-    expect(alert).toHaveTextContent('The verification code is invalid.')
+    expect(alert).toHaveTextContent('The password is incorrect.')
     expect(alert).toHaveClass(
       'mx-auto',
       'rounded-lg',
@@ -330,8 +416,31 @@ describe('SignInPage', () => {
     )
   })
 
+  it('shows an error returned while activating the session', async () => {
+    auth.signIn.password.mockImplementation(async () => {
+      auth.signIn.status = 'complete'
+      return { error: null }
+    })
+    auth.signIn.finalize.mockResolvedValue({
+      error: { longMessage: 'The session could not be activated.' },
+    })
+    render(<SignInPage />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
+      target: { value: 'person@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'account password' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The session could not be activated.',
+    )
+  })
+
   it('lets the user fall back to an email MFA code from the TOTP prompt', async () => {
-    auth.signIn.emailCode.verifyCode.mockImplementation(async () => {
+    auth.signIn.password.mockImplementation(async () => {
       auth.signIn.status = 'needs_second_factor'
       auth.signIn.supportedSecondFactors = [
         { strategy: 'totp' },
@@ -344,12 +453,10 @@ describe('SignInPage', () => {
     fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
       target: { value: 'person@example.com' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-    fireEvent.change(
-      await screen.findByRole('textbox', { name: 'Verification code' }),
-      { target: { value: '123456' } },
-    )
-    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'account password' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
 
     fireEvent.click(
       await screen.findByRole('button', { name: 'Email me a code instead' }),
@@ -380,6 +487,44 @@ describe('SignInPage', () => {
     })
   })
 
+  it('lets the user authenticate with a recovery code', async () => {
+    auth.signIn.password.mockImplementation(async () => {
+      auth.signIn.status = 'needs_second_factor'
+      auth.signIn.supportedSecondFactors = [
+        { strategy: 'totp' },
+        { strategy: 'backup_code' },
+      ]
+      return { error: null }
+    })
+    auth.signIn.mfa.verifyBackupCode.mockImplementation(async () => {
+      auth.signIn.status = 'complete'
+      return { error: null }
+    })
+    render(<SignInPage />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
+      target: { value: 'person@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'account password' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Use a recovery code' }),
+    )
+    fireEvent.change(screen.getByRole('textbox', { name: 'Recovery code' }), {
+      target: { value: 'recovery-code' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+
+    await waitFor(() => {
+      expect(auth.signIn.mfa.verifyBackupCode).toHaveBeenCalledWith({
+        code: 'recovery-code',
+      })
+      expect(auth.signIn.finalize).toHaveBeenCalled()
+    })
+  })
+
   it.each([
     ['Google', 'oauth_google'],
     ['Apple', 'oauth_apple'],
@@ -403,6 +548,23 @@ describe('SignInPage', () => {
       })
     },
   )
+
+  it('starts social sign-up from the create-account page', async () => {
+    render(<SignInPage initialMode="signup" />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue with Google' }),
+    )
+
+    await waitFor(() => {
+      expect(auth.signUp.sso).toHaveBeenCalledWith({
+        strategy: 'oauth_google',
+        redirectCallbackUrl: '/sso-callback',
+        redirectUrl: '/',
+      })
+      expect(auth.signIn.sso).not.toHaveBeenCalled()
+    })
+  })
 
   it('shows the Clerk error when social sign-in cannot start', async () => {
     auth.signIn.sso.mockResolvedValue({

--- a/tests/scripts/check-clerk-environment.test.mjs
+++ b/tests/scripts/check-clerk-environment.test.mjs
@@ -2,13 +2,33 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   checkClerkEnvironment,
+  getClerkAuthDrift,
   getClerkPrivacyDrift,
 } from '../../scripts/check-clerk-environment.mjs'
 
-function environment({ captchaEnabled = false, captchaProvider = null } = {}) {
+function environment({
+  captchaEnabled = false,
+  captchaProvider = null,
+  passwordEnabled = true,
+  passwordRequired = true,
+  signUpMode = 'public',
+  emailEnabled = true,
+  verifyEmailAtSignUp = true,
+  emailVerifications = ['email_code'],
+} = {}) {
   return {
     display_config: { captcha_provider: captchaProvider },
-    user_settings: { sign_up: { captcha_enabled: captchaEnabled } },
+    user_settings: {
+      sign_up: { captcha_enabled: captchaEnabled, mode: signUpMode },
+      attributes: {
+        password: { enabled: passwordEnabled, required: passwordRequired },
+        email_address: {
+          enabled: emailEnabled,
+          verify_at_sign_up: verifyEmailAtSignUp,
+          verifications: emailVerifications,
+        },
+      },
+    },
   }
 }
 
@@ -30,6 +50,26 @@ describe('Clerk environment privacy check', () => {
 
   it('fails closed when expected configuration fields are absent', () => {
     expect(getClerkPrivacyDrift({})).toHaveLength(2)
+  })
+
+  it('accepts password signup with email-code verification', () => {
+    expect(getClerkAuthDrift(environment())).toEqual([])
+  })
+
+  it('reports authentication settings incompatible with the custom flow', () => {
+    expect(
+      getClerkAuthDrift(
+        environment({
+          passwordRequired: false,
+          signUpMode: 'restricted',
+          emailVerifications: [],
+        }),
+      ),
+    ).toEqual([
+      'user_settings.sign_up.mode must be public',
+      'user_settings.attributes.password.required must be true',
+      'user_settings.attributes.email_address.verifications must include email_code',
+    ])
   })
 
   it('checks the fetched production response', async () => {
@@ -102,6 +142,6 @@ describe('Clerk environment privacy check', () => {
 
     await expect(
       checkClerkEnvironment({ fetchImplementation }),
-    ).rejects.toThrow('Clerk privacy configuration drifted')
+    ).rejects.toThrow('Clerk configuration drifted')
   })
 })

--- a/tests/scripts/check-clerk-environment.test.mjs
+++ b/tests/scripts/check-clerk-environment.test.mjs
@@ -60,16 +60,26 @@ describe('Clerk environment privacy check', () => {
     expect(
       getClerkAuthDrift(
         environment({
+          passwordEnabled: false,
           passwordRequired: false,
           signUpMode: 'restricted',
+          emailEnabled: false,
+          verifyEmailAtSignUp: false,
           emailVerifications: [],
         }),
       ),
     ).toEqual([
       'user_settings.sign_up.mode must be public',
+      'user_settings.attributes.password.enabled must be true',
       'user_settings.attributes.password.required must be true',
+      'user_settings.attributes.email_address.enabled must be true',
+      'user_settings.attributes.email_address.verify_at_sign_up must be true',
       'user_settings.attributes.email_address.verifications must include email_code',
     ])
+  })
+
+  it('fails closed when authentication configuration is absent', () => {
+    expect(getClerkAuthDrift({})).toHaveLength(6)
   })
 
   it('checks the fetched production response', async () => {


### PR DESCRIPTION
## Summary
- add a dedicated password-based signup flow with email verification, redirects, and social signup
- support password sign-in, password recovery, MFA, and recovery codes
- tailor the sidebar CTA to account or Premium benefits and guard Clerk configuration drift

## Testing
- `npm run lint`
- `npm run test:unit -- --run` (1,990 tests)
- `npm run build`
- `node scripts/check-clerk-environment.mjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the email-code sign-in with a password-based flow so account signup is reliable. Adds dedicated signup, sign-in, password recovery, and MFA backup codes.

- Signup now collects name, email, and password, then verifies email via a code.
- Sign-in uses email and password; MFA still requires a second factor.
- Password recovery sends a reset code and lets users set a new password.
- The sidebar upsell now distinguishes account benefits from premium benefits, hides while auth or subscription state settles, and gives both CTAs the same solid style.
- Clerk environment check now also validates sign-up mode, password requirements, and email verification settings.

<sup>Written for commit 83f7bb0386abea72e3d217781332cc4d77b0dd54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

