### PR TITLE
fix: restore access to older chats

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -454,7 +454,6 @@ export function ChatInterface({
   const [chatPagination, setChatPagination] = useState<{
     isReady: boolean
     userId?: string
-    nextToken?: string
   }>({ isReady: false })
   const [cloudSyncSettingEnabled, setCloudSyncSettingEnabled] =
     useState(isCloudSyncEnabled)
@@ -2036,16 +2035,12 @@ export function ChatInterface({
     }
 
     runInitialSync()
-      .then(async (result) => {
+      .then(async () => {
         await reloadChats()
         if (!cancelled && !isProjectMode) {
           setChatPagination({
             isReady: true,
             userId: authUserId ?? undefined,
-            nextToken:
-              result && typeof result !== 'boolean'
-                ? result.nextToken
-                : undefined,
           })
         }
       })
@@ -3977,11 +3972,6 @@ export function ChatInterface({
                 backupWarningNeedsRecovery={manualRecoveryNeeded}
                 onDismissBackupWarning={dismissBackupWarning}
                 onChatsUpdated={reloadChats}
-                initialChatPageToken={
-                  chatPagination.userId === authUserId
-                    ? chatPagination.nextToken
-                    : undefined
-                }
                 isInitialChatPageReady={
                   chatPagination.userId === authUserId && chatPagination.isReady
                 }

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -82,6 +82,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '../link'
 import { Logo } from '../logo'
+import { getChatLoadMoreAction } from './sidebar-pagination'
 import type { Chat } from './types'
 
 const FAVORITES_PANEL_ID = 'sidebar-favorites-panel'
@@ -127,9 +128,8 @@ type ChatSidebarProps = {
   backupWarningNeedsRecovery?: boolean
   onDismissBackupWarning?: () => void
   onChatsUpdated?: () => void | Promise<void>
-  initialChatPageToken?: string
   isInitialChatPageReady?: boolean
-  /** Triggers a deep (all-pages) cloud sync from the sidebar "Sync" button. */
+  /** Triggers an account revision sync from the sidebar "Sync" button. */
   onManualSync?: () => Promise<boolean>
   /** True while a cloud sync is in progress; drives the Sync button spinner. */
   isSyncing?: boolean
@@ -205,7 +205,6 @@ export function ChatSidebar({
   backupWarningNeedsRecovery = false,
   onDismissBackupWarning,
   onChatsUpdated,
-  initialChatPageToken,
   isInitialChatPageReady = false,
   onManualSync,
   isSyncing = false,
@@ -379,11 +378,11 @@ export function ChatSidebar({
     isLoading: isLoadingMore,
     hasAttempted: hasAttemptedLoadMore,
     isInitialized: isPaginationInitialized,
+    canRetryInitialization,
     loadMore: loadMorePage,
   } = useCloudPagination({
     isSignedIn: !!isSignedIn,
     userId: user?.id,
-    initialToken: initialChatPageToken,
     isInitialPageReady: isInitialChatPageReady,
   })
   const [visibleCloudChatCount, setVisibleCloudChatCount] = useState<number>(
@@ -714,7 +713,8 @@ export function ChatSidebar({
   )
   const hasMoreLoadedChats = filteredChats.length > visibleCloudChatCount
   const canLoadRemoteChats =
-    isInitialChatPageReady && isPaginationInitialized && hasMoreRemote
+    isInitialChatPageReady &&
+    ((isPaginationInitialized && hasMoreRemote) || canRetryInitialization)
   const shouldShowLoadMore =
     paginatesCloudChats && (hasMoreLoadedChats || canLoadRemoteChats)
 
@@ -725,7 +725,14 @@ export function ChatSidebar({
   const loadMoreChats = useCallback(async (): Promise<void> => {
     if (isLoadingMore || !isSignedIn) return
 
-    if (!hasMoreRemote) {
+    const action = getChatLoadMoreAction({
+      loadedChatCount: filteredChats.length,
+      visibleChatCount: visibleCloudChatCount,
+      hasRemoteCursor: hasMoreRemote,
+      canRetryRemoteInitialization: canRetryInitialization,
+    })
+    if (action === 'none') return
+    if (action === 'reveal-local') {
       setVisibleCloudChatCount((count) => count + PAGINATION.CHATS_PER_PAGE)
       return
     }
@@ -753,7 +760,16 @@ export function ChatSidebar({
         action: 'loadMoreChats',
       })
     }
-  }, [hasMoreRemote, isLoadingMore, isSignedIn, loadMorePage, onChatsUpdated])
+  }, [
+    canRetryInitialization,
+    filteredChats.length,
+    hasMoreRemote,
+    isLoadingMore,
+    isSignedIn,
+    loadMorePage,
+    onChatsUpdated,
+    visibleCloudChatCount,
+  ])
 
   // Prefer backing up the existing key with a passkey (PRF-capable devices
   // must stay in the passkey-only flow); fall back to the manual cloud-sync

--- a/src/components/chat/sidebar-pagination.ts
+++ b/src/components/chat/sidebar-pagination.ts
@@ -1,0 +1,14 @@
+export type ChatLoadMoreAction = 'reveal-local' | 'fetch-remote' | 'none'
+
+export function getChatLoadMoreAction(options: {
+  loadedChatCount: number
+  visibleChatCount: number
+  hasRemoteCursor: boolean
+  canRetryRemoteInitialization: boolean
+}): ChatLoadMoreAction {
+  if (options.loadedChatCount > options.visibleChatCount) return 'reveal-local'
+  if (options.hasRemoteCursor || options.canRetryRemoteInitialization) {
+    return 'fetch-remote'
+  }
+  return 'none'
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,12 @@ export const SYNC_ENCLAVE_TIMEOUTS = {
 // Pagination settings
 export const PAGINATION = {
   CHATS_PER_PAGE: 20,
+  // Metadata-only page size used when scanning cloud history to find the
+  // first chat that is not cached locally. Larger than CHATS_PER_PAGE so
+  // long, fully-cached histories cost few round trips to scan. A returned
+  // cursor still points at a page start, so a later content fetch of
+  // CHATS_PER_PAGE items from that cursor stays correct.
+  CURSOR_SCAN_PAGE_SIZE: 100,
 } as const
 
 // Cloud sync settings

--- a/src/hooks/use-cloud-pagination.ts
+++ b/src/hooks/use-cloud-pagination.ts
@@ -11,7 +11,6 @@ interface UseCloudPaginationOptions {
   isSignedIn: boolean
   userId?: string
   pageSize?: number
-  initialToken?: string
   isInitialPageReady?: boolean
 }
 
@@ -20,6 +19,7 @@ interface UseCloudPaginationReturn {
   isLoading: boolean
   hasAttempted: boolean
   isInitialized: boolean
+  canRetryInitialization: boolean
   loadMore: () => Promise<
     | {
         hasMore: boolean
@@ -37,7 +37,6 @@ export function useCloudPagination(
     isSignedIn,
     userId,
     pageSize = PAGINATION.CHATS_PER_PAGE,
-    initialToken,
     isInitialPageReady = false,
   } = options
 
@@ -46,6 +45,7 @@ export function useCloudPagination(
   const [isLoading, setIsLoading] = useState(false)
   const [hasAttempted, setHasAttempted] = useState(false)
   const [isInitialized, setIsInitialized] = useState(false)
+  const [canRetryInitialization, setCanRetryInitialization] = useState(false)
   const loadingGenerationRef = useRef<number | null>(null)
   const requestGenerationRef = useRef(0)
   const [cloudSyncEnabled, setCloudSyncEnabled] = useState(isCloudSyncEnabled())
@@ -72,15 +72,35 @@ export function useCloudPagination(
     }
   }, [])
 
-  const initialize = useCallback(async () => {
-    requestGenerationRef.current += 1
+  const initializeCursor = useCallback(async (requestGeneration: number) => {
+    try {
+      const result = await cloudSync.initializeChatPaginationCursor()
+      if (requestGeneration !== requestGenerationRef.current) return
+      setNextToken(result.nextToken)
+      setHasMore(result.hasMore && Boolean(result.nextToken))
+      setIsInitialized(true)
+      setCanRetryInitialization(false)
+      return result
+    } catch (error) {
+      if (requestGeneration !== requestGenerationRef.current) return
+      setCanRetryInitialization(true)
+      logError('Failed to initialize chat pagination', error, {
+        component: 'useCloudPagination',
+        action: 'initialize',
+      })
+    }
+  }, [])
+
+  useEffect(() => {
+    const requestGeneration = ++requestGenerationRef.current
     loadingGenerationRef.current = null
     setIsLoading(false)
+    setNextToken(undefined)
+    setHasMore(false)
+    setHasAttempted(false)
+    setIsInitialized(false)
+    setCanRetryInitialization(false)
     if (!isSignedIn || !userId || !cloudSyncEnabled || !isInitialPageReady) {
-      setNextToken(undefined)
-      setHasMore(false)
-      setHasAttempted(false)
-      setIsInitialized(false)
       return
     }
 
@@ -88,17 +108,19 @@ export function useCloudPagination(
     // IndexedDB can hold gigabytes of data, so keeping all synced chats
     // locally provides better offline access. Users can fetch older chats
     // from the cloud on demand via loadMore().
-
-    setNextToken(initialToken)
-    setHasMore(Boolean(initialToken))
-    setHasAttempted(false)
-    setIsInitialized(true)
-    return {
-      hasMore: Boolean(initialToken),
-      nextToken: initialToken,
-      deletedIds: [], // Never delete local chats
-    }
-  }, [isSignedIn, userId, cloudSyncEnabled, isInitialPageReady, initialToken])
+    loadingGenerationRef.current = requestGeneration
+    void initializeCursor(requestGeneration).finally(() => {
+      if (loadingGenerationRef.current === requestGeneration) {
+        loadingGenerationRef.current = null
+      }
+    })
+  }, [
+    isSignedIn,
+    userId,
+    cloudSyncEnabled,
+    isInitialPageReady,
+    initializeCursor,
+  ])
 
   const loadMore = useCallback(async () => {
     if (
@@ -106,7 +128,7 @@ export function useCloudPagination(
       !userId ||
       isLoading ||
       !cloudSyncEnabled ||
-      !isInitialized ||
+      (!isInitialized && !canRetryInitialization) ||
       loadingGenerationRef.current !== null
     )
       return
@@ -114,14 +136,29 @@ export function useCloudPagination(
     const requestGeneration = requestGenerationRef.current
     loadingGenerationRef.current = requestGeneration
     // Save current state in case we need to rollback
-    const previousToken = nextToken
-    const previousHasMore = hasMore
+    let token = nextToken
+    let previousToken = token
+    let previousHasMore = hasMore
 
     setIsLoading(true)
     setHasAttempted(true)
 
     try {
-      if (!nextToken) {
+      if (!isInitialized) {
+        setCanRetryInitialization(false)
+        const initialized = await initializeCursor(requestGeneration)
+        if (
+          requestGeneration !== requestGenerationRef.current ||
+          !initialized
+        ) {
+          return
+        }
+        token = initialized.nextToken
+        previousToken = token
+        previousHasMore = initialized.hasMore && Boolean(token)
+      }
+
+      if (!token) {
         if (requestGeneration === requestGenerationRef.current) {
           setHasMore(false)
         }
@@ -130,7 +167,7 @@ export function useCloudPagination(
 
       const result = await cloudSync.fetchAndStorePage({
         limit: pageSize,
-        continuationToken: nextToken,
+        continuationToken: token,
       })
       if (requestGeneration !== requestGenerationRef.current) return
 
@@ -169,25 +206,16 @@ export function useCloudPagination(
     hasMore,
     cloudSyncEnabled,
     isInitialized,
+    canRetryInitialization,
+    initializeCursor,
   ])
-
-  // Initialize when user changes (only if cloud sync is enabled)
-  useEffect(() => {
-    if (isSignedIn && userId && cloudSyncEnabled) {
-      void initialize()
-    } else {
-      setNextToken(undefined)
-      setHasMore(false)
-      setHasAttempted(false)
-      setIsInitialized(false)
-    }
-  }, [isSignedIn, userId, cloudSyncEnabled, initialize])
 
   return {
     hasMore,
     isLoading,
     hasAttempted,
     isInitialized,
+    canRetryInitialization,
     loadMore,
   }
 }

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -1,3 +1,4 @@
+import { PAGINATION } from '@/config'
 import {
   AUTH_ACTIVE_USER_ID,
   SETTINGS_CLOUD_SYNC_ENABLED,
@@ -27,7 +28,11 @@ import { logError } from '@/utils/error-handling'
 import type { AccountOperationGuard } from './account-operation'
 import { hasPrimaryKey, primaryKeyIdHexOrNull } from './cek-encoding'
 import { processRemoteChat } from './chat-codec'
-import { drainChatRevisionSync } from './chat-revision-sync'
+import { ingestRemoteChats } from './chat-ingestion'
+import {
+  BOOTSTRAP_RECENT_CONTENT_LIMIT,
+  drainChatRevisionSync,
+} from './chat-revision-sync'
 import { canWriteToCloud } from './cloud-key-authorization'
 import { cloudStorage, type UploadChatOptions } from './cloud-storage'
 import { adoptLocalKeyForMigration } from './ensure-current-key'
@@ -54,7 +59,6 @@ export interface SyncResult {
   uploaded: number
   downloaded: number
   errors: string[]
-  nextToken?: string
 }
 
 export class SyncInProgressError extends Error {
@@ -93,11 +97,16 @@ export interface PaginatedChatsResult {
   nextToken?: string
 }
 
-class RemoteChatPageIncompleteError extends Error {
-  constructor(chatId: string, cause: unknown) {
-    super(
-      `Remote chat page is incomplete because ${chatId} could not be decoded`,
-    )
+export class RemoteChatPageIncompleteError extends Error {
+  readonly code = 'REMOTE_CHAT_PAGE_INCOMPLETE'
+
+  constructor(
+    public readonly chatId: string,
+    public readonly stage:
+      'boundary' | 'missing-content' | 'decode' | 'storage',
+    cause?: unknown,
+  ) {
+    super(`Remote chat page is incomplete at ${chatId}`)
     this.name = 'RemoteChatPageIncompleteError'
     this.cause = cause
   }
@@ -914,7 +923,7 @@ export class CloudSyncService {
             action: 'loadChatsWithPagination',
             metadata: { chatId: entry.id },
           })
-          throw new RemoteChatPageIncompleteError(entry.id, error)
+          throw new RemoteChatPageIncompleteError(entry.id, 'decode', error)
         }
       }
       return {
@@ -931,6 +940,107 @@ export class CloudSyncService {
       if (loadLocal) return this.paginateLocalChats(limit, continuationToken)
       throw error
     }
+  }
+
+  async initializeChatPaginationCursor(): Promise<{
+    hasMore: boolean
+    nextToken?: string
+  }> {
+    const generation = this.accountGeneration
+    const userId = this.readActiveUserId()
+    if (!(await cloudStorage.isAuthenticated())) {
+      this.ensureCurrentAccount(generation, userId)
+      return { hasMore: false }
+    }
+    this.ensureCurrentAccount(generation, userId)
+    if (!userId) throw new Error('Authenticated user ID is unavailable')
+    const remote = await cloudStorage.listChats({
+      limit: BOOTSTRAP_RECENT_CONTENT_LIMIT,
+      includeContent: false,
+    })
+    this.ensureCurrentAccount(generation, userId)
+    const prefix = remote.conversations.filter(
+      (entry) => !deletedChatsTracker.isDeleted(entry.id),
+    )
+    const missingOrStale = []
+    for (const entry of prefix) {
+      const local = await indexedDBStorage.getChat(entry.id)
+      this.ensureCurrentAccount(generation, userId)
+      if (
+        !local ||
+        local.syncUserId !== userId ||
+        local.decryptionFailed ||
+        local.syncVersion !== entry.syncVersion
+      ) {
+        missingOrStale.push(entry)
+      }
+    }
+    if (missingOrStale.length > 0) {
+      const pulled = await cloudStorage.downloadChats(
+        missingOrStale.map((entry) => entry.id),
+      )
+      this.ensureCurrentAccount(generation, userId)
+      const metadata = new Map(missingOrStale.map((entry) => [entry.id, entry]))
+      await ingestRemoteChats(
+        pulled.map((entry) => ({
+          ...entry,
+          updatedAt: metadata.get(entry.id)!.updatedAt,
+          projectId: metadata.get(entry.id)!.projectId,
+        })),
+        {
+          setLoadedAt: true,
+          eventReason: 'pagination',
+          isCurrent: () =>
+            this.isCurrentGeneration(generation) &&
+            this.readActiveUserId() === userId,
+          userId,
+        },
+      )
+      this.ensureCurrentAccount(generation, userId)
+    }
+    for (const entry of prefix) {
+      const local = await indexedDBStorage.getChat(entry.id)
+      this.ensureCurrentAccount(generation, userId)
+      if (
+        !local ||
+        local.syncUserId !== userId ||
+        local.decryptionFailed ||
+        local.syncVersion !== entry.syncVersion
+      ) {
+        throw new RemoteChatPageIncompleteError(entry.id, 'boundary')
+      }
+    }
+
+    let nextToken = remote.nextContinuationToken
+    const visitedTokens = new Set<string>()
+    while (nextToken) {
+      if (visitedTokens.has(nextToken)) {
+        throw new Error('Cloud pagination cursor did not advance')
+      }
+      visitedTokens.add(nextToken)
+      const pageStartToken = nextToken
+      const page = await cloudStorage.listChats({
+        limit: PAGINATION.CHATS_PER_PAGE,
+        continuationToken: pageStartToken,
+        includeContent: false,
+      })
+      this.ensureCurrentAccount(generation, userId)
+      for (const entry of page.conversations) {
+        if (deletedChatsTracker.isDeleted(entry.id)) continue
+        const local = await indexedDBStorage.getChat(entry.id)
+        this.ensureCurrentAccount(generation, userId)
+        if (
+          !local ||
+          local.syncUserId !== userId ||
+          local.decryptionFailed ||
+          local.syncVersion !== entry.syncVersion
+        ) {
+          return { hasMore: true, nextToken: pageStartToken }
+        }
+      }
+      nextToken = page.nextContinuationToken
+    }
+    return { hasMore: false }
   }
 
   async fetchAndStorePage(options: {
@@ -953,15 +1063,24 @@ export class CloudSyncService {
     this.ensureCurrentAccount(generation, userId)
     let saved = 0
     for (const entry of remote.conversations) {
-      if (!entry.content || deletedChatsTracker.isDeleted(entry.id)) continue
+      if (deletedChatsTracker.isDeleted(entry.id)) continue
+      if (!entry.content) {
+        throw new RemoteChatPageIncompleteError(entry.id, 'missing-content')
+      }
+      let decoded: Awaited<ReturnType<typeof processRemoteChat>>
       try {
-        const decoded = await processRemoteChat({
+        decoded = await processRemoteChat({
           id: entry.id,
           plaintext: entry.content,
           syncVersion: entry.syncVersion,
           formatVersion: 2,
         })
+      } catch (error) {
         this.ensureCurrentAccount(generation, userId)
+        throw new RemoteChatPageIncompleteError(entry.id, 'decode', error)
+      }
+      this.ensureCurrentAccount(generation, userId)
+      try {
         const local = await indexedDBStorage.getChat(entry.id)
         this.ensureCurrentAccount(generation, userId)
         const applied = await indexedDBStorage.applyRemoteChatIfFresh({
@@ -983,6 +1102,7 @@ export class CloudSyncService {
           action: 'fetchAndStorePage',
           metadata: { chatId: entry.id },
         })
+        throw new RemoteChatPageIncompleteError(entry.id, 'storage', error)
       }
     }
     if (saved > 0) chatEvents.emit({ reason: 'pagination', ids: [] })

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -34,7 +34,11 @@ import {
   drainChatRevisionSync,
 } from './chat-revision-sync'
 import { canWriteToCloud } from './cloud-key-authorization'
-import { cloudStorage, type UploadChatOptions } from './cloud-storage'
+import {
+  cloudStorage,
+  type ChatListResponse,
+  type UploadChatOptions,
+} from './cloud-storage'
 import { adoptLocalKeyForMigration } from './ensure-current-key'
 import {
   finalizeAlternativesIfMigrated,
@@ -889,6 +893,19 @@ export class CloudSyncService {
     }
   }
 
+  private isLocalChatCurrent(
+    local: StoredChat | null | undefined,
+    remote: ChatListResponse['conversations'][number],
+    userId: string,
+  ): boolean {
+    return (
+      !!local &&
+      local.syncUserId === userId &&
+      !local.decryptionFailed &&
+      local.syncVersion === remote.syncVersion
+    )
+  }
+
   async loadChatsWithPagination(options: {
     limit: number
     continuationToken?: string
@@ -966,12 +983,7 @@ export class CloudSyncService {
     for (const entry of prefix) {
       const local = await indexedDBStorage.getChat(entry.id)
       this.ensureCurrentAccount(generation, userId)
-      if (
-        !local ||
-        local.syncUserId !== userId ||
-        local.decryptionFailed ||
-        local.syncVersion !== entry.syncVersion
-      ) {
+      if (!this.isLocalChatCurrent(local, entry, userId)) {
         missingOrStale.push(entry)
       }
     }
@@ -1001,12 +1013,7 @@ export class CloudSyncService {
     for (const entry of prefix) {
       const local = await indexedDBStorage.getChat(entry.id)
       this.ensureCurrentAccount(generation, userId)
-      if (
-        !local ||
-        local.syncUserId !== userId ||
-        local.decryptionFailed ||
-        local.syncVersion !== entry.syncVersion
-      ) {
+      if (!this.isLocalChatCurrent(local, entry, userId)) {
         throw new RemoteChatPageIncompleteError(entry.id, 'boundary')
       }
     }
@@ -1029,12 +1036,7 @@ export class CloudSyncService {
         if (deletedChatsTracker.isDeleted(entry.id)) continue
         const local = await indexedDBStorage.getChat(entry.id)
         this.ensureCurrentAccount(generation, userId)
-        if (
-          !local ||
-          local.syncUserId !== userId ||
-          local.decryptionFailed ||
-          local.syncVersion !== entry.syncVersion
-        ) {
+        if (!this.isLocalChatCurrent(local, entry, userId)) {
           return { hasMore: true, nextToken: pageStartToken }
         }
       }
@@ -1064,9 +1066,7 @@ export class CloudSyncService {
     let saved = 0
     for (const entry of remote.conversations) {
       if (deletedChatsTracker.isDeleted(entry.id)) continue
-      if (!entry.content) {
-        throw new RemoteChatPageIncompleteError(entry.id, 'missing-content')
-      }
+      if (!entry.content) continue
       let decoded: Awaited<ReturnType<typeof processRemoteChat>>
       try {
         decoded = await processRemoteChat({
@@ -1077,7 +1077,12 @@ export class CloudSyncService {
         })
       } catch (error) {
         this.ensureCurrentAccount(generation, userId)
-        throw new RemoteChatPageIncompleteError(entry.id, 'decode', error)
+        logError('Failed to decode paginated remote chat', error, {
+          component: 'CloudSync',
+          action: 'fetchAndStorePage',
+          metadata: { chatId: entry.id },
+        })
+        continue
       }
       this.ensureCurrentAccount(generation, userId)
       try {

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -1027,7 +1027,7 @@ export class CloudSyncService {
       visitedTokens.add(nextToken)
       const pageStartToken = nextToken
       const page = await cloudStorage.listChats({
-        limit: PAGINATION.CHATS_PER_PAGE,
+        limit: PAGINATION.CURSOR_SCAN_PAGE_SIZE,
         continuationToken: pageStartToken,
         includeContent: false,
       })

--- a/tests/components/chat/sidebar-pagination.test.ts
+++ b/tests/components/chat/sidebar-pagination.test.ts
@@ -1,0 +1,34 @@
+import { getChatLoadMoreAction } from '@/components/chat/sidebar-pagination'
+import { describe, expect, it } from 'vitest'
+
+describe('getChatLoadMoreAction', () => {
+  it('reveals local hydration in page increments before fetching remotely', () => {
+    expect(
+      getChatLoadMoreAction({
+        loadedChatCount: 50,
+        visibleChatCount: 20,
+        hasRemoteCursor: true,
+        canRetryRemoteInitialization: false,
+      }),
+    ).toBe('reveal-local')
+    expect(
+      getChatLoadMoreAction({
+        loadedChatCount: 50,
+        visibleChatCount: 60,
+        hasRemoteCursor: true,
+        canRetryRemoteInitialization: false,
+      }),
+    ).toBe('fetch-remote')
+  })
+
+  it('fetches remotely to retry cursor initialization', () => {
+    expect(
+      getChatLoadMoreAction({
+        loadedChatCount: 20,
+        visibleChatCount: 20,
+        hasRemoteCursor: false,
+        canRetryRemoteInitialization: true,
+      }),
+    ).toBe('fetch-remote')
+  })
+})

--- a/tests/components/chat/sidebar-pagination.test.ts
+++ b/tests/components/chat/sidebar-pagination.test.ts
@@ -31,4 +31,15 @@ describe('getChatLoadMoreAction', () => {
       }),
     ).toBe('fetch-remote')
   })
+
+  it('does nothing when local and remote history are exhausted', () => {
+    expect(
+      getChatLoadMoreAction({
+        loadedChatCount: 20,
+        visibleChatCount: 20,
+        hasRemoteCursor: false,
+        canRetryRemoteInitialization: false,
+      }),
+    ).toBe('none')
+  })
 })

--- a/tests/hooks/use-cloud-pagination.test.tsx
+++ b/tests/hooks/use-cloud-pagination.test.tsx
@@ -2,21 +2,29 @@ import { useCloudPagination } from '@/hooks/use-cloud-pagination'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { fetchAndStorePage } = vi.hoisted(() => ({
-  fetchAndStorePage: vi.fn(),
-}))
+const { cloudSyncState, fetchAndStorePage, initializeChatPaginationCursor } =
+  vi.hoisted(() => ({
+    cloudSyncState: { enabled: true },
+    fetchAndStorePage: vi.fn(),
+    initializeChatPaginationCursor: vi.fn(),
+  }))
 
 vi.mock('@/services/cloud/cloud-sync', () => ({
-  cloudSync: { fetchAndStorePage },
+  cloudSync: { fetchAndStorePage, initializeChatPaginationCursor },
 }))
 
 vi.mock('@/utils/cloud-sync-settings', () => ({
   CLOUD_SYNC_SETTING_CHANGED_EVENT: 'cloudSyncSettingChanged',
-  isCloudSyncEnabled: () => true,
+  isCloudSyncEnabled: () => cloudSyncState.enabled,
 }))
 
 describe('useCloudPagination', () => {
   beforeEach(() => {
+    cloudSyncState.enabled = true
+    initializeChatPaginationCursor.mockReset().mockResolvedValue({
+      hasMore: true,
+      nextToken: 'page-2',
+    })
     fetchAndStorePage.mockReset().mockResolvedValue({
       hasMore: true,
       nextToken: 'page-3',
@@ -24,27 +32,27 @@ describe('useCloudPagination', () => {
     })
   })
 
-  it('loads the page after the initial sync token', async () => {
+  it('initializes and uses the cursor after revision sync readiness', async () => {
     const { result } = renderHook(() =>
       useCloudPagination({
         isSignedIn: true,
         userId: 'user-1',
-        initialToken: 'page-2',
         isInitialPageReady: true,
       }),
     )
 
     await waitFor(() => expect(result.current.isInitialized).toBe(true))
-
     await act(() => result.current.loadMore())
 
+    expect(initializeChatPaginationCursor).toHaveBeenCalledOnce()
     expect(fetchAndStorePage).toHaveBeenCalledWith({
       limit: 20,
       continuationToken: 'page-2',
     })
   })
 
-  it('does not repeat the first page when it has no continuation token', async () => {
+  it('does not request a page when initialization returns no cursor', async () => {
+    initializeChatPaginationCursor.mockResolvedValue({ hasMore: false })
     const { result } = renderHook(() =>
       useCloudPagination({
         isSignedIn: true,
@@ -54,10 +62,121 @@ describe('useCloudPagination', () => {
     )
 
     await waitFor(() => expect(result.current.isInitialized).toBe(true))
-
     await act(() => result.current.loadMore())
 
+    expect(result.current.hasMore).toBe(false)
     expect(fetchAndStorePage).not.toHaveBeenCalled()
+  })
+
+  it('retries failed cursor initialization from load more', async () => {
+    initializeChatPaginationCursor
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce({ hasMore: true, nextToken: 'page-2' })
+    const { result } = renderHook(() =>
+      useCloudPagination({
+        isSignedIn: true,
+        userId: 'user-1',
+        isInitialPageReady: true,
+      }),
+    )
+
+    await waitFor(() =>
+      expect(result.current.canRetryInitialization).toBe(true),
+    )
+    await act(() => result.current.loadMore())
+
+    expect(initializeChatPaginationCursor).toHaveBeenCalledTimes(2)
+    expect(fetchAndStorePage).toHaveBeenCalledWith({
+      limit: 20,
+      continuationToken: 'page-2',
+    })
+    expect(result.current.isInitialized).toBe(true)
+  })
+
+  it('waits for initial revision sync readiness before initializing', async () => {
+    const { result, rerender } = renderHook(
+      ({ isReady }: { isReady: boolean }) =>
+        useCloudPagination({
+          isSignedIn: true,
+          userId: 'user-1',
+          isInitialPageReady: isReady,
+        }),
+      { initialProps: { isReady: false } },
+    )
+
+    expect(result.current.isInitialized).toBe(false)
+    expect(initializeChatPaginationCursor).not.toHaveBeenCalled()
+
+    rerender({ isReady: true })
+    await waitFor(() => expect(result.current.isInitialized).toBe(true))
+    expect(initializeChatPaginationCursor).toHaveBeenCalledOnce()
+  })
+
+  it('ignores a cursor response from a stale account', async () => {
+    let resolveOldCursor!: (value: {
+      hasMore: boolean
+      nextToken?: string
+    }) => void
+    initializeChatPaginationCursor
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveOldCursor = resolve
+        }),
+      )
+      .mockResolvedValueOnce({ hasMore: true, nextToken: 'user-2-page-2' })
+    const { result, rerender } = renderHook(
+      ({ userId }: { userId: string }) =>
+        useCloudPagination({
+          isSignedIn: true,
+          userId,
+          isInitialPageReady: true,
+        }),
+      { initialProps: { userId: 'user-1' } },
+    )
+
+    await waitFor(() =>
+      expect(initializeChatPaginationCursor).toHaveBeenCalled(),
+    )
+    rerender({ userId: 'user-2' })
+    await waitFor(() => expect(result.current.isInitialized).toBe(true))
+    resolveOldCursor({ hasMore: true, nextToken: 'user-1-page-2' })
+    await act(async () => Promise.resolve())
+    await act(() => result.current.loadMore())
+
+    expect(fetchAndStorePage).toHaveBeenCalledWith({
+      limit: 20,
+      continuationToken: 'user-2-page-2',
+    })
+  })
+
+  it('discards cursor initialization when cloud sync is disabled', async () => {
+    let resolveCursor!: (value: {
+      hasMore: boolean
+      nextToken?: string
+    }) => void
+    initializeChatPaginationCursor.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveCursor = resolve
+      }),
+    )
+    const { result } = renderHook(() =>
+      useCloudPagination({
+        isSignedIn: true,
+        userId: 'user-1',
+        isInitialPageReady: true,
+      }),
+    )
+    await waitFor(() =>
+      expect(initializeChatPaginationCursor).toHaveBeenCalled(),
+    )
+
+    cloudSyncState.enabled = false
+    act(() => window.dispatchEvent(new Event('cloudSyncSettingChanged')))
+    resolveCursor({ hasMore: true, nextToken: 'page-2' })
+    await act(async () => Promise.resolve())
+
+    expect(result.current.isInitialized).toBe(false)
+    expect(result.current.hasMore).toBe(false)
   })
 
   it('deduplicates concurrent requests for the same page', async () => {
@@ -75,7 +194,6 @@ describe('useCloudPagination', () => {
       useCloudPagination({
         isSignedIn: true,
         userId: 'user-1',
-        initialToken: 'page-2',
         isInitialPageReady: true,
       }),
     )
@@ -90,7 +208,37 @@ describe('useCloudPagination', () => {
     })
   })
 
-  it('does not let an obsolete request unlock a newer request', async () => {
+  it('retries an incomplete page with the previous cursor', async () => {
+    fetchAndStorePage
+      .mockRejectedValueOnce(new Error('incomplete page'))
+      .mockResolvedValueOnce({ hasMore: true, nextToken: 'page-3', saved: 20 })
+    const { result } = renderHook(() =>
+      useCloudPagination({
+        isSignedIn: true,
+        userId: 'user-1',
+        isInitialPageReady: true,
+      }),
+    )
+    await waitFor(() => expect(result.current.isInitialized).toBe(true))
+
+    await act(() => result.current.loadMore())
+    expect(result.current.hasMore).toBe(true)
+    await act(() => result.current.loadMore())
+
+    expect(fetchAndStorePage).toHaveBeenNthCalledWith(1, {
+      limit: 20,
+      continuationToken: 'page-2',
+    })
+    expect(fetchAndStorePage).toHaveBeenNthCalledWith(2, {
+      limit: 20,
+      continuationToken: 'page-2',
+    })
+  })
+
+  it('does not let an obsolete page request unlock a newer request', async () => {
+    initializeChatPaginationCursor
+      .mockResolvedValueOnce({ hasMore: true, nextToken: 'user-1-page-2' })
+      .mockResolvedValueOnce({ hasMore: true, nextToken: 'user-2-page-2' })
     let resolveOldPage!: (value: {
       hasMore: boolean
       nextToken?: string
@@ -102,14 +250,13 @@ describe('useCloudPagination', () => {
       }),
     )
     const { result, rerender } = renderHook(
-      ({ userId, token }: { userId: string; token: string }) =>
+      ({ userId }: { userId: string }) =>
         useCloudPagination({
           isSignedIn: true,
           userId,
-          initialToken: token,
           isInitialPageReady: true,
         }),
-      { initialProps: { userId: 'user-1', token: 'user-1-page-2' } },
+      { initialProps: { userId: 'user-1' } },
     )
     await waitFor(() => expect(result.current.isInitialized).toBe(true))
 
@@ -117,7 +264,7 @@ describe('useCloudPagination', () => {
     act(() => {
       oldRequest = result.current.loadMore()
     })
-    rerender({ userId: 'user-2', token: 'user-2-page-2' })
+    rerender({ userId: 'user-2' })
     await waitFor(() => expect(result.current.isInitialized).toBe(true))
 
     await act(() => result.current.loadMore())

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -6,6 +6,7 @@ import {
   CloudSyncService,
   CROSS_TAB_SYNC_LOCK,
   CROSS_TAB_SYNC_LOCK_OPTIONS,
+  RemoteChatPageIncompleteError,
 } from '@/services/cloud/cloud-sync'
 import { SyncEnclaveError } from '@/services/sync-enclave/sync-enclave-client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -18,6 +19,7 @@ const {
   canWriteToCloud,
   uploadChat,
   downloadChat,
+  downloadChats,
   finalizeUpload,
   getPendingUploadChats,
   applyRemoteChatIfFresh,
@@ -34,6 +36,7 @@ const {
   canWriteToCloud: vi.fn(),
   uploadChat: vi.fn(),
   downloadChat: vi.fn(),
+  downloadChats: vi.fn(),
   finalizeUpload: vi.fn(),
   getPendingUploadChats: vi.fn(),
   applyRemoteChatIfFresh: vi.fn(),
@@ -45,6 +48,7 @@ const {
 }))
 
 vi.mock('@/services/cloud/chat-revision-sync', () => ({
+  BOOTSTRAP_RECENT_CONTENT_LIMIT: 50,
   drainChatRevisionSync,
 }))
 vi.mock('@/services/cloud/cloud-storage', () => ({
@@ -52,6 +56,7 @@ vi.mock('@/services/cloud/cloud-storage', () => ({
     isAuthenticated,
     uploadChat,
     downloadChat,
+    downloadChats,
     listChats,
   },
 }))
@@ -70,6 +75,9 @@ vi.mock('@/services/storage/indexed-db', () => ({
 }))
 vi.mock('@/services/cloud/cloud-key-authorization', () => ({
   canWriteToCloud,
+}))
+vi.mock('@/services/cloud/ensure-current-key', () => ({
+  adoptLocalKeyForMigration: vi.fn(),
 }))
 vi.mock('@/services/cloud/chat-codec', () => ({ processRemoteChat }))
 vi.mock('@/services/storage/deleted-chats-tracker', () => ({
@@ -394,6 +402,345 @@ describe('CloudSyncService revision coordinator routing', () => {
       new CloudSyncService().fetchAndStorePage({ limit: 10 }),
     ).rejects.toThrow('Cloud account changed during synchronization')
     expect(applyRemoteChatIfFresh).not.toHaveBeenCalled()
+  })
+
+  it('initializes pagination metadata at the hydration boundary', async () => {
+    const conversations = Array.from({ length: 50 }, (_, index) => ({
+      id: `chat-${index}`,
+      syncVersion: index + 1,
+      updatedAt: `2026-01-${String(index + 1).padStart(2, '0')}T00:00:00Z`,
+    }))
+    listChats
+      .mockResolvedValueOnce({
+        conversations,
+        hasMore: true,
+        nextContinuationToken: 'page-2',
+      })
+      .mockResolvedValueOnce({
+        conversations: [
+          {
+            id: 'uncached-chat',
+            syncVersion: 51,
+            updatedAt: '2025-12-31T00:00:00Z',
+          },
+        ],
+        hasMore: false,
+      })
+    getChat.mockImplementation(async (id: string) => {
+      const entry = conversations.find((chat) => chat.id === id)!
+      return {
+        ...entry,
+        syncUserId: 'user-1',
+        messages: [],
+      }
+    })
+
+    await expect(
+      new CloudSyncService().initializeChatPaginationCursor(),
+    ).resolves.toEqual({ hasMore: true, nextToken: 'page-2' })
+    expect(listChats).toHaveBeenCalledWith({
+      limit: 50,
+      includeContent: false,
+    })
+    expect(downloadChats).not.toHaveBeenCalled()
+    expect(processRemoteChat).not.toHaveBeenCalled()
+  })
+
+  it('hydrates missing and stale chats before returning the boundary cursor', async () => {
+    const metadata = [
+      {
+        id: 'current-chat',
+        syncVersion: 1,
+        updatedAt: '2026-01-03T00:00:00Z',
+      },
+      {
+        id: 'missing-chat',
+        syncVersion: 2,
+        updatedAt: '2026-01-02T00:00:00Z',
+      },
+      {
+        id: 'stale-chat',
+        syncVersion: 3,
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ]
+    const localChats = new Map<string, Record<string, unknown>>([
+      ['current-chat', { ...metadata[0], syncUserId: 'user-1', messages: [] }],
+      [
+        'stale-chat',
+        { ...metadata[2], syncVersion: 2, syncUserId: 'user-1', messages: [] },
+      ],
+    ])
+    listChats
+      .mockResolvedValueOnce({
+        conversations: metadata,
+        hasMore: true,
+        nextContinuationToken: 'page-2',
+      })
+      .mockResolvedValueOnce({
+        conversations: [
+          {
+            id: 'uncached-chat',
+            syncVersion: 4,
+            updatedAt: '2025-12-31T00:00:00Z',
+          },
+        ],
+        hasMore: false,
+      })
+    downloadChats.mockResolvedValue([
+      { ...metadata[1], content: '{"id":"missing-chat"}' },
+      { ...metadata[2], content: '{"id":"stale-chat"}' },
+    ])
+    getChat.mockImplementation(async (id: string) => localChats.get(id))
+    processRemoteChat.mockImplementation(async ({ id, syncVersion }) => ({
+      chat: { id, syncVersion, syncUserId: 'user-1', messages: [] },
+    }))
+    applyRemoteChatIfFresh.mockImplementation(async ({ chat }) => {
+      localChats.set(chat.id, chat)
+      return { applied: true }
+    })
+
+    await expect(
+      new CloudSyncService().initializeChatPaginationCursor(),
+    ).resolves.toEqual({ hasMore: true, nextToken: 'page-2' })
+    expect(downloadChats).toHaveBeenCalledWith(['missing-chat', 'stale-chat'])
+    expect(processRemoteChat).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips fully cached metadata pages before fetching unseen history', async () => {
+    const cachedChats = new Map<string, Record<string, unknown>>()
+    const boundary = Array.from({ length: 50 }, (_, index) => ({
+      id: `boundary-${index}`,
+      syncVersion: index + 1,
+      updatedAt: `2026-01-${String(index + 1).padStart(2, '0')}T00:00:00Z`,
+    }))
+    const cachedPage = Array.from({ length: 20 }, (_, index) => ({
+      id: `cached-history-${index}`,
+      syncVersion: index + 51,
+      updatedAt: `2025-12-${String(index + 1).padStart(2, '0')}T00:00:00Z`,
+    }))
+    for (const entry of [...boundary, ...cachedPage]) {
+      cachedChats.set(entry.id, {
+        ...entry,
+        syncUserId: 'user-1',
+        messages: [],
+      })
+    }
+    const unseen = {
+      id: 'first-unseen-chat',
+      syncVersion: 71,
+      updatedAt: '2025-11-30T00:00:00Z',
+    }
+    listChats
+      .mockResolvedValueOnce({
+        conversations: boundary,
+        hasMore: true,
+        nextContinuationToken: 'cached-page',
+      })
+      .mockResolvedValueOnce({
+        conversations: cachedPage,
+        hasMore: true,
+        nextContinuationToken: 'unseen-page',
+      })
+      .mockResolvedValueOnce({
+        conversations: [unseen],
+        hasMore: false,
+      })
+      .mockResolvedValueOnce({
+        conversations: [{ ...unseen, content: '{}' }],
+        hasMore: false,
+      })
+    getChat.mockImplementation(async (id: string) => cachedChats.get(id))
+    processRemoteChat.mockResolvedValue({
+      chat: { ...unseen, syncUserId: 'user-1', messages: [] },
+    })
+
+    const service = new CloudSyncService()
+    await expect(service.initializeChatPaginationCursor()).resolves.toEqual({
+      hasMore: true,
+      nextToken: 'unseen-page',
+    })
+    await service.fetchAndStorePage({
+      limit: 20,
+      continuationToken: 'unseen-page',
+    })
+
+    expect(downloadChats).not.toHaveBeenCalled()
+    expect(listChats).toHaveBeenNthCalledWith(2, {
+      limit: 20,
+      continuationToken: 'cached-page',
+      includeContent: false,
+    })
+    expect(listChats).toHaveBeenNthCalledWith(3, {
+      limit: 20,
+      continuationToken: 'unseen-page',
+      includeContent: false,
+    })
+    expect(listChats).toHaveBeenNthCalledWith(4, {
+      limit: 20,
+      continuationToken: 'unseen-page',
+      includeContent: true,
+    })
+  })
+
+  it('rejects a non-advancing metadata cursor', async () => {
+    const boundary = [
+      {
+        id: 'boundary-chat',
+        syncVersion: 1,
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ]
+    const cachedPage = [
+      {
+        id: 'cached-chat',
+        syncVersion: 2,
+        updatedAt: '2025-12-31T00:00:00Z',
+      },
+    ]
+    listChats
+      .mockResolvedValueOnce({
+        conversations: boundary,
+        hasMore: true,
+        nextContinuationToken: 'repeated-page',
+      })
+      .mockResolvedValueOnce({
+        conversations: cachedPage,
+        hasMore: true,
+        nextContinuationToken: 'repeated-page',
+      })
+    getChat.mockImplementation(async (id: string) => ({
+      ...(id === 'boundary-chat' ? boundary[0] : cachedPage[0]),
+      syncUserId: 'user-1',
+      messages: [],
+    }))
+
+    await expect(
+      new CloudSyncService().initializeChatPaginationCursor(),
+    ).rejects.toThrow('Cloud pagination cursor did not advance')
+    expect(listChats).toHaveBeenCalledTimes(2)
+  })
+
+  it('withholds a cursor when a boundary mutation is not fully stored', async () => {
+    listChats.mockResolvedValue({
+      conversations: [
+        {
+          id: 'new-boundary-chat',
+          syncVersion: 2,
+          updatedAt: '2026-01-02T00:00:00Z',
+        },
+      ],
+      hasMore: true,
+      nextContinuationToken: 'page-2',
+    })
+    getChat.mockResolvedValue(undefined)
+    downloadChats.mockResolvedValue([
+      {
+        id: 'new-boundary-chat',
+        syncVersion: 2,
+        updatedAt: '',
+        content: '{}',
+      },
+    ])
+    processRemoteChat.mockResolvedValue({
+      chat: { id: 'new-boundary-chat', syncVersion: 2, messages: [] },
+    })
+    applyRemoteChatIfFresh.mockResolvedValue({ applied: false })
+
+    await expect(
+      new CloudSyncService().initializeChatPaginationCursor(),
+    ).rejects.toMatchObject({
+      code: 'REMOTE_CHAT_PAGE_INCOMPLETE',
+      chatId: 'new-boundary-chat',
+      stage: 'boundary',
+    })
+  })
+
+  it('rejects a pagination cursor from a previous account', async () => {
+    listChats.mockImplementationOnce(async () => {
+      localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user-2')
+      return {
+        conversations: [],
+        hasMore: true,
+        nextContinuationToken: 'stale-page-2',
+      }
+    })
+
+    await expect(
+      new CloudSyncService().initializeChatPaginationCursor(),
+    ).rejects.toThrow('Cloud account changed during synchronization')
+  })
+
+  it('retries an incomplete page without advancing its cursor', async () => {
+    listChats
+      .mockResolvedValueOnce({
+        conversations: [
+          { id: 'chat-1', syncVersion: 2, updatedAt: '2026-01-01T00:00:00Z' },
+        ],
+        hasMore: true,
+        nextContinuationToken: 'page-3',
+      })
+      .mockResolvedValueOnce({
+        conversations: [
+          {
+            id: 'chat-1',
+            syncVersion: 2,
+            updatedAt: '2026-01-01T00:00:00Z',
+            content: '{}',
+          },
+        ],
+        hasMore: true,
+        nextContinuationToken: 'page-3',
+      })
+    processRemoteChat.mockResolvedValue({
+      chat: { id: 'chat-1', syncVersion: 2, messages: [] },
+    })
+    getChat.mockResolvedValue(undefined)
+
+    const service = new CloudSyncService()
+    await expect(
+      service.fetchAndStorePage({ limit: 20, continuationToken: 'page-2' }),
+    ).rejects.toBeInstanceOf(RemoteChatPageIncompleteError)
+    await expect(
+      service.fetchAndStorePage({ limit: 20, continuationToken: 'page-2' }),
+    ).resolves.toEqual({ hasMore: true, nextToken: 'page-3', saved: 1 })
+    expect(listChats).toHaveBeenNthCalledWith(1, {
+      limit: 20,
+      continuationToken: 'page-2',
+      includeContent: true,
+    })
+    expect(listChats).toHaveBeenNthCalledWith(2, {
+      limit: 20,
+      continuationToken: 'page-2',
+      includeContent: true,
+    })
+  })
+
+  it('rejects a page when storage fails', async () => {
+    listChats.mockResolvedValue({
+      conversations: [
+        {
+          id: 'chat-1',
+          syncVersion: 2,
+          updatedAt: '2026-01-01T00:00:00Z',
+          content: '{}',
+        },
+      ],
+      hasMore: false,
+    })
+    processRemoteChat.mockResolvedValue({
+      chat: { id: 'chat-1', syncVersion: 2, messages: [] },
+    })
+    getChat.mockResolvedValue(undefined)
+    applyRemoteChatIfFresh.mockRejectedValueOnce(new Error('storage failed'))
+
+    await expect(
+      new CloudSyncService().fetchAndStorePage({ limit: 20 }),
+    ).rejects.toMatchObject({
+      code: 'REMOTE_CHAT_PAGE_INCOMPLETE',
+      chatId: 'chat-1',
+      stage: 'storage',
+    })
   })
 
   it('rejects an incomplete export page instead of falling back locally', async () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -1,3 +1,4 @@
+import { PAGINATION } from '@/config'
 import {
   AUTH_ACTIVE_USER_ID,
   SETTINGS_CLOUD_SYNC_ENABLED,
@@ -566,12 +567,12 @@ describe('CloudSyncService revision coordinator routing', () => {
 
     expect(downloadChats).not.toHaveBeenCalled()
     expect(listChats).toHaveBeenNthCalledWith(2, {
-      limit: 20,
+      limit: PAGINATION.CURSOR_SCAN_PAGE_SIZE,
       continuationToken: 'cached-page',
       includeContent: false,
     })
     expect(listChats).toHaveBeenNthCalledWith(3, {
-      limit: 20,
+      limit: PAGINATION.CURSOR_SCAN_PAGE_SIZE,
       continuationToken: 'unseen-page',
       includeContent: false,
     })

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -6,7 +6,6 @@ import {
   CloudSyncService,
   CROSS_TAB_SYNC_LOCK,
   CROSS_TAB_SYNC_LOCK_OPTIONS,
-  RemoteChatPageIncompleteError,
 } from '@/services/cloud/cloud-sync'
 import { SyncEnclaveError } from '@/services/sync-enclave/sync-enclave-client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -671,11 +670,21 @@ describe('CloudSyncService revision coordinator routing', () => {
     ).rejects.toThrow('Cloud account changed during synchronization')
   })
 
-  it('retries an incomplete page without advancing its cursor', async () => {
+  it('skips unavailable rows and continues into later history', async () => {
     listChats
       .mockResolvedValueOnce({
         conversations: [
-          { id: 'chat-1', syncVersion: 2, updatedAt: '2026-01-01T00:00:00Z' },
+          {
+            id: 'missing-chat',
+            syncVersion: 1,
+            updatedAt: '2026-01-03T00:00:00Z',
+          },
+          {
+            id: 'invalid-chat',
+            syncVersion: 2,
+            updatedAt: '2026-01-02T00:00:00Z',
+            content: 'invalid',
+          },
         ],
         hasMore: true,
         nextContinuationToken: 'page-3',
@@ -683,27 +692,28 @@ describe('CloudSyncService revision coordinator routing', () => {
       .mockResolvedValueOnce({
         conversations: [
           {
-            id: 'chat-1',
-            syncVersion: 2,
+            id: 'older-chat',
+            syncVersion: 3,
             updatedAt: '2026-01-01T00:00:00Z',
             content: '{}',
           },
         ],
-        hasMore: true,
-        nextContinuationToken: 'page-3',
+        hasMore: false,
       })
-    processRemoteChat.mockResolvedValue({
-      chat: { id: 'chat-1', syncVersion: 2, messages: [] },
-    })
+    processRemoteChat
+      .mockRejectedValueOnce(new Error('invalid ciphertext'))
+      .mockResolvedValueOnce({
+        chat: { id: 'older-chat', syncVersion: 3, messages: [] },
+      })
     getChat.mockResolvedValue(undefined)
 
     const service = new CloudSyncService()
     await expect(
       service.fetchAndStorePage({ limit: 20, continuationToken: 'page-2' }),
-    ).rejects.toBeInstanceOf(RemoteChatPageIncompleteError)
+    ).resolves.toEqual({ hasMore: true, nextToken: 'page-3', saved: 0 })
     await expect(
-      service.fetchAndStorePage({ limit: 20, continuationToken: 'page-2' }),
-    ).resolves.toEqual({ hasMore: true, nextToken: 'page-3', saved: 1 })
+      service.fetchAndStorePage({ limit: 20, continuationToken: 'page-3' }),
+    ).resolves.toEqual({ hasMore: false, nextToken: undefined, saved: 1 })
     expect(listChats).toHaveBeenNthCalledWith(1, {
       limit: 20,
       continuationToken: 'page-2',
@@ -711,12 +721,13 @@ describe('CloudSyncService revision coordinator routing', () => {
     })
     expect(listChats).toHaveBeenNthCalledWith(2, {
       limit: 20,
-      continuationToken: 'page-2',
+      continuationToken: 'page-3',
       includeContent: true,
     })
+    expect(applyRemoteChatIfFresh).toHaveBeenCalledOnce()
   })
 
-  it('rejects a page when storage fails', async () => {
+  it('retains the page cursor for retry when storage fails', async () => {
     listChats.mockResolvedValue({
       conversations: [
         {
@@ -732,14 +743,36 @@ describe('CloudSyncService revision coordinator routing', () => {
       chat: { id: 'chat-1', syncVersion: 2, messages: [] },
     })
     getChat.mockResolvedValue(undefined)
-    applyRemoteChatIfFresh.mockRejectedValueOnce(new Error('storage failed'))
+    applyRemoteChatIfFresh
+      .mockRejectedValueOnce(new Error('storage failed'))
+      .mockResolvedValueOnce({ applied: true })
 
+    const service = new CloudSyncService()
     await expect(
-      new CloudSyncService().fetchAndStorePage({ limit: 20 }),
+      service.fetchAndStorePage({
+        limit: 20,
+        continuationToken: 'page-2',
+      }),
     ).rejects.toMatchObject({
       code: 'REMOTE_CHAT_PAGE_INCOMPLETE',
       chatId: 'chat-1',
       stage: 'storage',
+    })
+    await expect(
+      service.fetchAndStorePage({
+        limit: 20,
+        continuationToken: 'page-2',
+      }),
+    ).resolves.toEqual({ hasMore: false, nextToken: undefined, saved: 1 })
+    expect(listChats).toHaveBeenNthCalledWith(1, {
+      limit: 20,
+      continuationToken: 'page-2',
+      includeContent: true,
+    })
+    expect(listChats).toHaveBeenNthCalledWith(2, {
+      limit: 20,
+      continuationToken: 'page-2',
+      includeContent: true,
     })
   })
 


### PR DESCRIPTION
## Summary
- initialize chat pagination independently from revision sync at the hydrated-history boundary
- reveal cached chats before fetching metadata-verified remote pages
- retain cursors across incomplete pages and allow failed initialization to retry safely

## Testing
- `npx vitest run tests/hooks/use-cloud-pagination.test.tsx tests/services/cloud/cloud-sync.test.ts tests/components/chat/sidebar-pagination.test.ts`
- `npx vitest run`
- `npx tsc --noEmit --incremental false`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loading of older chats by decoupling pagination from the account revision sync. Previously the sync result supplied the pagination cursor; now the cursor is derived at the hydrated-history boundary, locally cached chats are revealed before remote pages, and incomplete pages keep their cursor for safe retry.

- `CloudSyncService` hydrates missing or stale boundary chats before returning a cursor at the first uncached chat, scanning fully-cached history in larger metadata-only pages to cut round trips.
- `useCloudPagination` initializes the cursor once the initial page is ready, discards responses from stale accounts, and retries failed initialization from Load more.
- Incomplete pages throw `RemoteChatPageIncompleteError` with a stage instead of advancing the cursor.
- Load more reveals already-hydrated chats in page increments before fetching a remote page.

<sup>Written for commit b50144a97f4be3b7b764239ba0225b037b956808. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

