### PR TITLE
fix: export backups with unavailable items

### DIFF
--- a/src/components/chat/native-backup-export.tsx
+++ b/src/components/chat/native-backup-export.tsx
@@ -43,11 +43,30 @@ export function NativeBackupExport({ available }: { available: boolean }) {
     controller.current = current
     const isCurrent = () => controller.current === current
     try {
-      await runNativeBackupExport(current.signal, (value) => {
+      const result = await runNativeBackupExport(current.signal, (value) => {
         if (isCurrent()) setProgress(value)
       })
       if (!isCurrent() || !availableRef.current) return
-      setMessage('Backup saved successfully.')
+      const warningDetails = result
+        ? [
+            result.omitted
+              ? `${result.omitted} source item${result.omitted === 1 ? '' : 's'} could not be included.`
+              : '',
+            result.adjustedRelationships
+              ? `${result.adjustedRelationships} relationship${result.adjustedRelationships === 1 ? ' was' : 's were'} adjusted to keep the archive valid.`
+              : '',
+            result.localInventoryUnstable
+              ? 'Local chats changed repeatedly; included local chats are a partial snapshot.'
+              : '',
+          ]
+            .filter(Boolean)
+            .join(' ')
+        : ''
+      setMessage(
+        result && !result.complete
+          ? `Backup saved with warnings. ${warningDetails}`
+          : 'Backup saved successfully.',
+      )
     } catch (error) {
       if (!isCurrent()) return
       setFailed(true)

--- a/src/services/cloud/backup-read-error.ts
+++ b/src/services/cloud/backup-read-error.ts
@@ -1,0 +1,14 @@
+export type CloudBackupReadCategory =
+  'item_unavailable' | 'item_invalid' | 'key_unavailable'
+
+export class CloudBackupReadError extends Error {
+  constructor(
+    public readonly category: CloudBackupReadCategory,
+    public readonly reason: string,
+    public readonly omittable: boolean,
+    options?: ErrorOptions,
+  ) {
+    super('Cloud backup source could not be read', options)
+    this.name = 'CloudBackupReadError'
+  }
+}

--- a/src/services/cloud/backup-read-error.ts
+++ b/src/services/cloud/backup-read-error.ts
@@ -33,6 +33,43 @@ export class CloudBackupProtocolError extends Error {
   }
 }
 
+/**
+ * Settled result of one record inside a batched backup pull. Batch
+ * responses stay positionally aligned with their requests so callers
+ * can keep processing records in captured-inventory order.
+ */
+export type BackupPullResult<T> =
+  { ok: true; value: T } | { ok: false; error: unknown }
+
+export function unwrapBackupPullResult<T>(
+  result: BackupPullResult<T> | undefined,
+): T {
+  if (!result) throw new CloudBackupProtocolError('missing_item')
+  if (!result.ok) throw result.error
+  return result.value
+}
+
+/**
+ * Group a batched pull response by record ID. Every returned item must
+ * have been requested; per-ID duplicate detection is delegated to
+ * `validateBackupPullItem`, which rejects multi-item buckets.
+ */
+export function groupBackupPullItems(
+  items: PullItem[],
+  requestedIds: readonly string[],
+): Map<string, PullItem[]> {
+  const requested = new Set(requestedIds)
+  const grouped = new Map<string, PullItem[]>()
+  for (const item of items) {
+    if (!requested.has(item.id))
+      throw new CloudBackupProtocolError('unexpected_item')
+    const bucket = grouped.get(item.id)
+    if (bucket) bucket.push(item)
+    else grouped.set(item.id, [item])
+  }
+  return grouped
+}
+
 export function validateBackupPullItem(
   items: PullItem[],
   expectedId: string,

--- a/src/services/cloud/backup-read-error.ts
+++ b/src/services/cloud/backup-read-error.ts
@@ -50,15 +50,19 @@ export function unwrapBackupPullResult<T>(
 }
 
 /**
- * Group a batched pull response by record ID. Every returned item must
- * have been requested; per-ID duplicate detection is delegated to
- * `validateBackupPullItem`, which rejects multi-item buckets.
+ * Group a batched pull response by record ID. Request IDs must be
+ * unique so one returned record can never satisfy two positional
+ * results; every returned item must have been requested. Per-ID
+ * duplicate detection is delegated to `validateBackupPullItem`,
+ * which rejects multi-item buckets.
  */
 export function groupBackupPullItems(
   items: PullItem[],
   requestedIds: readonly string[],
 ): Map<string, PullItem[]> {
   const requested = new Set(requestedIds)
+  if (requested.size !== requestedIds.length)
+    throw new CloudBackupProtocolError('unexpected_item')
   const grouped = new Map<string, PullItem[]>()
   for (const item of items) {
     if (!requested.has(item.id))

--- a/src/services/cloud/backup-read-error.ts
+++ b/src/services/cloud/backup-read-error.ts
@@ -1,5 +1,11 @@
+import type { PullItem } from '@/services/sync-enclave/sync-api'
+
 export type CloudBackupReadCategory =
-  'item_unavailable' | 'item_invalid' | 'key_unavailable'
+  | 'item_unavailable'
+  | 'item_invalid'
+  | 'key_unavailable'
+  | 'snapshot_deleted'
+  | 'snapshot_changed'
 
 export class CloudBackupReadError extends Error {
   constructor(
@@ -11,4 +17,75 @@ export class CloudBackupReadError extends Error {
     super('Cloud backup source could not be read', options)
     this.name = 'CloudBackupReadError'
   }
+}
+
+export type CloudBackupProtocolErrorCode =
+  | 'missing_item'
+  | 'unexpected_item'
+  | 'missing_etag'
+  | 'invalid_etag'
+  | 'invalid_previous_etag'
+
+export class CloudBackupProtocolError extends Error {
+  constructor(public readonly code: CloudBackupProtocolErrorCode) {
+    super('Sync enclave returned an invalid backup pull response')
+    this.name = 'CloudBackupProtocolError'
+  }
+}
+
+export function validateBackupPullItem(
+  items: PullItem[],
+  expectedId: string,
+  expectedEtag: string,
+): PullItem {
+  if (items.length === 0) throw new CloudBackupProtocolError('missing_item')
+  if (items.length !== 1 || items[0].id !== expectedId)
+    throw new CloudBackupProtocolError('unexpected_item')
+  const item = items[0]
+  const hasEtag = Object.hasOwn(item, 'etag')
+  const hasPreviousEtag = Object.hasOwn(item, 'previous_etag')
+  if (
+    hasEtag &&
+    (typeof item.etag !== 'string' || item.etag.trim().length === 0)
+  )
+    throw new CloudBackupProtocolError('invalid_etag')
+  if (
+    hasPreviousEtag &&
+    (typeof item.previous_etag !== 'string' ||
+      item.previous_etag.trim().length === 0)
+  )
+    throw new CloudBackupProtocolError('invalid_previous_etag')
+
+  if (item.ok) {
+    if (!hasEtag) throw new CloudBackupProtocolError('missing_etag')
+    if (item.etag === expectedEtag || item.previous_etag === expectedEtag)
+      return item
+    throw new CloudBackupReadError(
+      'snapshot_changed',
+      'record_changed_after_snapshot',
+      true,
+    )
+  }
+
+  const returnedEtags = [item.etag, item.previous_etag].filter(
+    (etag): etag is string => etag !== undefined,
+  )
+  if (
+    returnedEtags.length > 0 &&
+    !returnedEtags.some((etag) => etag === expectedEtag)
+  )
+    throw new CloudBackupReadError(
+      'snapshot_changed',
+      'record_changed_after_snapshot',
+      true,
+    )
+  if (returnedEtags.length === 0 && item.code !== 'NOT_FOUND')
+    throw new CloudBackupProtocolError('missing_etag')
+  if (item.code === 'NOT_FOUND')
+    throw new CloudBackupReadError(
+      'snapshot_deleted',
+      'record_deleted_after_snapshot',
+      true,
+    )
+  return item
 }

--- a/src/services/cloud/chat-codec.ts
+++ b/src/services/cloud/chat-codec.ts
@@ -38,6 +38,16 @@ export interface ProcessRemoteChatOptions {
   projectId?: string | null
 }
 
+export class RemoteChatDecodeError extends Error {
+  constructor(
+    public readonly reason: 'invalid_json' | 'invalid_shape',
+    options?: ErrorOptions,
+  ) {
+    super(`v2_plaintext_invalid: ${reason}`, options)
+    this.name = 'RemoteChatDecodeError'
+  }
+}
+
 /**
  * Decode a plaintext v2 row coming back from the enclave into a
  * `StoredChat`. Failure modes:
@@ -86,16 +96,16 @@ export async function processRemoteChat(
   try {
     parsed = JSON.parse(remote.plaintext)
   } catch (parseErr) {
-    throw new Error(
-      `v2_plaintext_invalid: ${
-        parseErr instanceof Error ? parseErr.message : String(parseErr)
-      }`,
-    )
+    if (parseErr instanceof SyntaxError)
+      throw new RemoteChatDecodeError('invalid_json', { cause: parseErr })
+    throw parseErr
   }
 
   const validation = RemoteChatPlaintextSchema.safeParse(parsed)
   if (!validation.success) {
-    throw new Error(`v2_plaintext_invalid: ${validation.error.message}`)
+    throw new RemoteChatDecodeError('invalid_shape', {
+      cause: validation.error,
+    })
   }
   const decrypted = validation.data
 

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -46,6 +46,11 @@ const PROJECT_CHAT_LIST_LIMIT = 500
 const ATTACHMENT_NOT_FOUND_STATUS = 404
 const LEGACY_ATTACHMENT_GONE_STATUS = 410
 const ATTACHMENT_IDEMPOTENCY_KEY_BYTES = 16
+const LEGACY_ATTACHMENT_DATA_ERROR_NAMES = new Set([
+  'DataError',
+  'InvalidCharacterError',
+  'OperationError',
+])
 
 /**
  * Lean chat list entry. Anything the caller needs beyond (id,
@@ -725,7 +730,21 @@ export class CloudStorageService {
         response.status,
       )
     const encrypted = new Uint8Array(await response.arrayBuffer())
-    return decryptAttachment(encrypted, base64ToUint8Array(keyB64))
+    try {
+      return await decryptAttachment(encrypted, base64ToUint8Array(keyB64))
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        LEGACY_ATTACHMENT_DATA_ERROR_NAMES.has(error.name)
+      )
+        throw new CloudBackupReadError(
+          'item_invalid',
+          'attachment_payload_invalid',
+          true,
+          { cause: error },
+        )
+      throw error
+    }
   }
 
   async listChats(options?: {

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -26,7 +26,10 @@ import {
 } from '../sync-enclave/sync-enclave-client'
 import { RESTORE_DELETED_HEADERS } from '../sync-enclave/wire-contract'
 import type { AccountOperationGuard } from './account-operation'
-import { CloudBackupReadError } from './backup-read-error'
+import {
+  CloudBackupReadError,
+  validateBackupPullItem,
+} from './backup-read-error'
 import { pullKey, requirePrimaryKeyB64 } from './cek-encoding'
 import {
   processRemoteChat,
@@ -40,6 +43,7 @@ const AUTH_INIT_WAIT_MS = 3000
 const RESTORE_DELETED_CHAT_HEADER = RESTORE_DELETED_HEADERS.Chat
 const ENCLAVE_CHAT_LIST_LIMIT = 100
 const PROJECT_CHAT_LIST_LIMIT = 500
+const ATTACHMENT_NOT_FOUND_STATUS = 404
 const LEGACY_ATTACHMENT_GONE_STATUS = 410
 const ATTACHMENT_IDEMPOTENCY_KEY_BYTES = 16
 
@@ -431,7 +435,7 @@ export class CloudStorageService {
    */
   async fetchRawChatContent(
     chatId: string,
-    options: { strictBackupRead?: boolean } = {},
+    options: { strictBackupRead?: boolean; expectedEtag?: string } = {},
   ): Promise<RawChatContent | null> {
     const keys = pullKey()
     if (keys.length === 0) {
@@ -449,7 +453,10 @@ export class CloudStorageService {
       ids: [chatId],
       keys,
     })
-    const item = resp.items[0]
+    const item =
+      options.expectedEtag !== undefined
+        ? validateBackupPullItem(resp.items, chatId, options.expectedEtag)
+        : resp.items[0]
     if (!item || !item.ok) {
       if (item && item.code === 'NOT_FOUND') return null
       if (options.strictBackupRead)
@@ -509,9 +516,13 @@ export class CloudStorageService {
     }
   }
 
-  async downloadChatForBackup(chatId: string): Promise<StoredChat | null> {
+  async downloadChatForBackup(
+    chatId: string,
+    expectedEtag: string,
+  ): Promise<StoredChat | null> {
     const raw = await this.fetchRawChatContent(chatId, {
       strictBackupRead: true,
+      expectedEtag,
     })
     if (raw === null) return null
     try {
@@ -650,10 +661,26 @@ export class CloudStorageService {
       )
     }
     if (keyB64) {
-      const plaintext = await enclaveAttachmentGet({
-        id: value.id,
-        attKeyB64: keyB64,
-      })
+      let plaintext: Uint8Array
+      try {
+        plaintext = await enclaveAttachmentGet({
+          id: value.id,
+          attKeyB64: keyB64,
+        })
+      } catch (error) {
+        if (
+          error instanceof SyncEnclaveError &&
+          (error.status === ATTACHMENT_NOT_FOUND_STATUS ||
+            error.code === 'NOT_FOUND')
+        )
+          throw new CloudBackupReadError(
+            'item_unavailable',
+            'attachment_not_found',
+            true,
+            { cause: error },
+          )
+        throw error
+      }
       if (!plaintext) {
         throw new CloudBackupReadError(
           'item_unavailable',
@@ -684,7 +711,7 @@ export class CloudStorageService {
       throw error
     }
     if (
-      response.status === 404 ||
+      response.status === ATTACHMENT_NOT_FOUND_STATUS ||
       response.status === LEGACY_ATTACHMENT_GONE_STATUS
     )
       throw new CloudBackupReadError(

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -20,6 +20,7 @@ import {
   newIdempotencyKey,
   pullItemPlaintext,
   revisionSnapshot,
+  type PullItem,
 } from '../sync-enclave/sync-api'
 import {
   SyncEnclaveError,
@@ -29,7 +30,9 @@ import { RESTORE_DELETED_HEADERS } from '../sync-enclave/wire-contract'
 import type { AccountOperationGuard } from './account-operation'
 import {
   CloudBackupReadError,
+  groupBackupPullItems,
   validateBackupPullItem,
+  type BackupPullResult,
 } from './backup-read-error'
 import { pullKey, requirePrimaryKeyB64 } from './cek-encoding'
 import {
@@ -434,50 +437,22 @@ export class CloudStorageService {
    * Fetch raw encrypted content for a single chat by ID.
    * Returns v0 JSON string or v1 binary ArrayBuffer based on X-Format-Version header.
    */
-  async fetchRawChatContent(
-    chatId: string,
-    options: { strictBackupRead?: boolean; expectedEtag?: string } = {},
-  ): Promise<RawChatContent | null> {
+  async fetchRawChatContent(chatId: string): Promise<RawChatContent | null> {
     const keys = pullKey()
-    if (keys.length === 0) {
-      if (options.strictBackupRead)
-        throw new CloudBackupReadError(
-          'key_unavailable',
-          'cloud_key_unavailable',
-          false,
-        )
-      return null
-    }
+    if (keys.length === 0) return null
 
     const resp = await enclavePull({
       scope: 'chat',
       ids: [chatId],
       keys,
     })
-    const item =
-      options.expectedEtag !== undefined
-        ? validateBackupPullItem(resp.items, chatId, options.expectedEtag)
-        : resp.items[0]
+    const item = resp.items[0]
     if (!item || !item.ok) {
       if (item && item.code === 'NOT_FOUND') return null
-      if (options.strictBackupRead)
-        throw new SyncEnclaveError(
-          'Chat pull returned an invalid item',
-          undefined,
-          item?.code,
-        )
       throw new Error(item?.code || 'Failed to pull chat from sync enclave')
     }
     const plaintext = pullItemPlaintext(item)
-    if (!plaintext) {
-      if (options.strictBackupRead)
-        throw new CloudBackupReadError(
-          'item_invalid',
-          'chat_payload_unavailable',
-          true,
-        )
-      return null
-    }
+    if (!plaintext) return null
     return {
       plaintext: new TextDecoder().decode(plaintext),
       formatVersion: 2,
@@ -517,24 +492,74 @@ export class CloudStorageService {
     }
   }
 
-  async downloadChatForBackup(
-    chatId: string,
-    expectedEtag: string,
-  ): Promise<StoredChat | null> {
-    const raw = await this.fetchRawChatContent(chatId, {
-      strictBackupRead: true,
-      expectedEtag,
+  /**
+   * Batched strict backup read: one enclave round trip pulls every
+   * requested chat and validates each item against its captured
+   * inventory ETag. Results align positionally with `requests`;
+   * per-record failures are settled into the result slot so one
+   * unreadable record cannot mask its batch peers.
+   */
+  async downloadChatsForBackup(
+    requests: ReadonlyArray<{ id: string; expectedEtag: string }>,
+  ): Promise<BackupPullResult<StoredChat | null>[]> {
+    if (requests.length === 0) return []
+    const keys = pullKey()
+    if (keys.length === 0)
+      throw new CloudBackupReadError(
+        'key_unavailable',
+        'cloud_key_unavailable',
+        false,
+      )
+    const resp = await enclavePull({
+      scope: 'chat',
+      ids: requests.map(({ id }) => id),
+      keys,
     })
-    if (raw === null) return null
+    const grouped = groupBackupPullItems(
+      resp.items,
+      requests.map(({ id }) => id),
+    )
+    return Promise.all(
+      requests.map(async ({ id, expectedEtag }) => {
+        try {
+          const item = validateBackupPullItem(
+            grouped.get(id) ?? [],
+            id,
+            expectedEtag,
+          )
+          return { ok: true as const, value: await this.decodeBackupItem(item) }
+        } catch (error) {
+          return { ok: false as const, error }
+        }
+      }),
+    )
+  }
+
+  private async decodeBackupItem(item: PullItem): Promise<StoredChat | null> {
+    if (!item.ok) {
+      if (item.code === 'NOT_FOUND') return null
+      throw new SyncEnclaveError(
+        'Chat pull returned an invalid item',
+        undefined,
+        item.code,
+      )
+    }
+    const plaintext = pullItemPlaintext(item)
+    if (!plaintext)
+      throw new CloudBackupReadError(
+        'item_invalid',
+        'chat_payload_unavailable',
+        true,
+      )
     try {
       const result = await processRemoteChat(
         {
-          id: chatId,
-          plaintext: raw.plaintext,
+          id: item.id,
+          plaintext: new TextDecoder().decode(plaintext),
           formatVersion: 2,
-          syncVersion: raw.syncVersion,
+          syncVersion: etagToSyncVersion(item.etag),
         },
-        raw.projectIdSet ? { projectId: raw.projectId } : {},
+        item.project_id_set === true ? { projectId: item.project_id } : {},
       )
       return result.chat
     } catch (error) {

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -536,14 +536,14 @@ export class CloudStorageService {
   }
 
   private async decodeBackupItem(item: PullItem): Promise<StoredChat | null> {
-    if (!item.ok) {
-      if (item.code === 'NOT_FOUND') return null
+    // validateBackupPullItem throws for NOT_FOUND, so any failed item
+    // that survives it carries an unexpected error code.
+    if (!item.ok)
       throw new SyncEnclaveError(
         'Chat pull returned an invalid item',
         undefined,
         item.code,
       )
-    }
     const plaintext = pullItemPlaintext(item)
     if (!plaintext)
       throw new CloudBackupReadError(

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -20,10 +20,19 @@ import {
   pullItemPlaintext,
   revisionSnapshot,
 } from '../sync-enclave/sync-api'
+import {
+  SyncEnclaveError,
+  SyncNetworkError,
+} from '../sync-enclave/sync-enclave-client'
 import { RESTORE_DELETED_HEADERS } from '../sync-enclave/wire-contract'
 import type { AccountOperationGuard } from './account-operation'
+import { CloudBackupReadError } from './backup-read-error'
 import { pullKey, requirePrimaryKeyB64 } from './cek-encoding'
-import { processRemoteChat, type RemoteChatData } from './chat-codec'
+import {
+  processRemoteChat,
+  RemoteChatDecodeError,
+  type RemoteChatData,
+} from './chat-codec'
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.tinfoil.sh'
@@ -67,6 +76,8 @@ export interface BulkConversationResult {
   success: boolean
   error?: string
 }
+
+export { CloudBackupReadError } from './backup-read-error'
 
 export interface BulkUploadResponse {
   results: BulkConversationResult[]
@@ -418,9 +429,20 @@ export class CloudStorageService {
    * Fetch raw encrypted content for a single chat by ID.
    * Returns v0 JSON string or v1 binary ArrayBuffer based on X-Format-Version header.
    */
-  async fetchRawChatContent(chatId: string): Promise<RawChatContent | null> {
+  async fetchRawChatContent(
+    chatId: string,
+    options: { strictBackupRead?: boolean } = {},
+  ): Promise<RawChatContent | null> {
     const keys = pullKey()
-    if (keys.length === 0) return null
+    if (keys.length === 0) {
+      if (options.strictBackupRead)
+        throw new CloudBackupReadError(
+          'key_unavailable',
+          'cloud_key_unavailable',
+          false,
+        )
+      return null
+    }
 
     const resp = await enclavePull({
       scope: 'chat',
@@ -430,10 +452,24 @@ export class CloudStorageService {
     const item = resp.items[0]
     if (!item || !item.ok) {
       if (item && item.code === 'NOT_FOUND') return null
+      if (options.strictBackupRead)
+        throw new SyncEnclaveError(
+          'Chat pull returned an invalid item',
+          undefined,
+          item?.code,
+        )
       throw new Error(item?.code || 'Failed to pull chat from sync enclave')
     }
     const plaintext = pullItemPlaintext(item)
-    if (!plaintext) return null
+    if (!plaintext) {
+      if (options.strictBackupRead)
+        throw new CloudBackupReadError(
+          'item_invalid',
+          'chat_payload_unavailable',
+          true,
+        )
+      return null
+    }
     return {
       plaintext: new TextDecoder().decode(plaintext),
       formatVersion: 2,
@@ -470,6 +506,33 @@ export class CloudStorageService {
         metadata: { chatId },
       })
       throw error
+    }
+  }
+
+  async downloadChatForBackup(chatId: string): Promise<StoredChat | null> {
+    const raw = await this.fetchRawChatContent(chatId, {
+      strictBackupRead: true,
+    })
+    if (raw === null) return null
+    try {
+      const result = await processRemoteChat(
+        {
+          id: chatId,
+          plaintext: raw.plaintext,
+          formatVersion: 2,
+          syncVersion: raw.syncVersion,
+        },
+        raw.projectIdSet ? { projectId: raw.projectId } : {},
+      )
+      return result.chat
+    } catch (error) {
+      if (!(error instanceof RemoteChatDecodeError)) throw error
+      throw new CloudBackupReadError(
+        'item_invalid',
+        'chat_payload_invalid',
+        true,
+        { cause: error },
+      )
     }
   }
 
@@ -569,6 +632,40 @@ export class CloudStorageService {
     return results
   }
 
+  async loadChatImageForBackup(value: Attachment): Promise<Uint8Array | null> {
+    if (value.type !== 'image') {
+      throw new CloudBackupReadError(
+        'item_invalid',
+        'attachment_type_invalid',
+        false,
+      )
+    }
+    const keyB64 = value.encryptionKey
+    const legacyKeyB64 = (value as { key?: string }).key
+    if (!keyB64 && !legacyKeyB64) {
+      throw new CloudBackupReadError(
+        'item_invalid',
+        'attachment_key_unavailable',
+        true,
+      )
+    }
+    if (keyB64) {
+      const plaintext = await enclaveAttachmentGet({
+        id: value.id,
+        attKeyB64: keyB64,
+      })
+      if (!plaintext) {
+        throw new CloudBackupReadError(
+          'item_unavailable',
+          'attachment_not_found',
+          true,
+        )
+      }
+      return plaintext
+    }
+    return this.fetchLegacyAttachment(value.id, legacyKeyB64!)
+  }
+
   // Part of the v0/v1 → v2 attachment migration. Safe to remove once
   // the controlplane `chat_attachments_legacy` table is drained and
   // no client (web or iOS) still depends on this fallback.
@@ -576,12 +673,30 @@ export class CloudStorageService {
     attachmentId: string,
     keyB64: string,
   ): Promise<Uint8Array> {
-    const response = await fetch(
-      `${API_BASE_URL}/api/storage/attachment/${attachmentId}`,
-    )
-    if (!response.ok || response.status === LEGACY_ATTACHMENT_GONE_STATUS) {
-      throw new Error(`Failed to fetch legacy attachment: ${response.status}`)
+    let response: Response
+    try {
+      response = await fetch(
+        `${API_BASE_URL}/api/storage/attachment/${attachmentId}`,
+      )
+    } catch (error) {
+      if (error instanceof TypeError)
+        throw new SyncNetworkError({ cause: error })
+      throw error
     }
+    if (
+      response.status === 404 ||
+      response.status === LEGACY_ATTACHMENT_GONE_STATUS
+    )
+      throw new CloudBackupReadError(
+        'item_unavailable',
+        'attachment_not_found',
+        true,
+      )
+    if (!response.ok)
+      throw new SyncEnclaveError(
+        'Legacy attachment request failed',
+        response.status,
+      )
     const encrypted = new Uint8Array(await response.arrayBuffer())
     return decryptAttachment(encrypted, base64ToUint8Array(keyB64))
   }

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -4,6 +4,7 @@ import { isLocalRecoveryEnvelope } from '@/types/chat-recovery'
 import {
   base64ToUint8Array,
   decryptAttachment,
+  EncryptedAttachmentValidationError,
   uint8ArrayToBase64,
 } from '@/utils/binary-codec'
 import { logError, logWarning } from '@/utils/error-handling'
@@ -46,11 +47,6 @@ const PROJECT_CHAT_LIST_LIMIT = 500
 const ATTACHMENT_NOT_FOUND_STATUS = 404
 const LEGACY_ATTACHMENT_GONE_STATUS = 410
 const ATTACHMENT_IDEMPOTENCY_KEY_BYTES = 16
-const LEGACY_ATTACHMENT_DATA_ERROR_NAMES = new Set([
-  'DataError',
-  'InvalidCharacterError',
-  'OperationError',
-])
 
 /**
  * Lean chat list entry. Anything the caller needs beyond (id,
@@ -730,13 +726,32 @@ export class CloudStorageService {
         response.status,
       )
     const encrypted = new Uint8Array(await response.arrayBuffer())
+    let key: Uint8Array
     try {
-      return await decryptAttachment(encrypted, base64ToUint8Array(keyB64))
+      key = base64ToUint8Array(keyB64)
     } catch (error) {
-      if (
-        error instanceof Error &&
-        LEGACY_ATTACHMENT_DATA_ERROR_NAMES.has(error.name)
-      )
+      if (error instanceof Error && error.name === 'InvalidCharacterError')
+        throw new CloudBackupReadError(
+          'item_invalid',
+          'attachment_key_invalid',
+          true,
+          { cause: error },
+        )
+      throw error
+    }
+    try {
+      return await decryptAttachment(encrypted, key)
+    } catch (error) {
+      if (error instanceof EncryptedAttachmentValidationError)
+        throw new CloudBackupReadError(
+          'item_invalid',
+          error.code === 'invalid_key_length'
+            ? 'attachment_key_invalid'
+            : 'attachment_payload_invalid',
+          true,
+          { cause: error },
+        )
+      if (error instanceof Error && error.name === 'OperationError')
         throw new CloudBackupReadError(
           'item_invalid',
           'attachment_payload_invalid',

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -22,7 +22,10 @@ import {
   SyncEnclaveError,
 } from '../sync-enclave/sync-api'
 import type { AccountOperationGuard } from './account-operation'
-import { CloudBackupReadError } from './backup-read-error'
+import {
+  CloudBackupReadError,
+  validateBackupPullItem,
+} from './backup-read-error'
 import { pullKey, requirePrimaryKeyB64 } from './cek-encoding'
 import { canWriteToCloud } from './cloud-key-authorization'
 import { ProjectDataSchema, ProjectDocumentPlaintextSchema } from './schemas'
@@ -217,7 +220,7 @@ export class ProjectStorageService {
 
   async getProject(
     projectId: string,
-    options: { strictBackupRead?: boolean } = {},
+    options: { strictBackupRead?: boolean; expectedEtag?: string } = {},
   ): Promise<Project | null> {
     try {
       const keys = pullKey()
@@ -236,7 +239,10 @@ export class ProjectStorageService {
         ids: [projectId],
         keys,
       })
-      const item = resp.items[0]
+      const item =
+        options.expectedEtag !== undefined
+          ? validateBackupPullItem(resp.items, projectId, options.expectedEtag)
+          : resp.items[0]
       if (!item || !item.ok) {
         if (item && item.code === 'NOT_FOUND') return null
         if (options.strictBackupRead)
@@ -317,8 +323,11 @@ export class ProjectStorageService {
     }
   }
 
-  getProjectForBackup(projectId: string): Promise<Project | null> {
-    return this.getProject(projectId, { strictBackupRead: true })
+  getProjectForBackup(
+    projectId: string,
+    expectedEtag: string,
+  ): Promise<Project | null> {
+    return this.getProject(projectId, { strictBackupRead: true, expectedEtag })
   }
 
   // Batch variant of getProject: pulls every requested project in a
@@ -587,7 +596,7 @@ export class ProjectStorageService {
   async getDocument(
     projectId: string,
     documentId: string,
-    options: { strictBackupRead?: boolean } = {},
+    options: { strictBackupRead?: boolean; expectedEtag?: string } = {},
   ): Promise<ProjectDocument | null> {
     try {
       const keys = pullKey()
@@ -606,7 +615,11 @@ export class ProjectStorageService {
         ids: [projectDocumentId(projectId, documentId)],
         keys,
       })
-      const item = resp.items[0]
+      const wireId = projectDocumentId(projectId, documentId)
+      const item =
+        options.expectedEtag !== undefined
+          ? validateBackupPullItem(resp.items, wireId, options.expectedEtag)
+          : resp.items[0]
       if (!item || !item.ok) {
         if (item && item.code === 'NOT_FOUND') return null
         if (options.strictBackupRead)
@@ -688,8 +701,12 @@ export class ProjectStorageService {
   getDocumentForBackup(
     projectId: string,
     documentId: string,
+    expectedEtag: string,
   ): Promise<ProjectDocument | null> {
-    return this.getDocument(projectId, documentId, { strictBackupRead: true })
+    return this.getDocument(projectId, documentId, {
+      strictBackupRead: true,
+      expectedEtag,
+    })
   }
 
   // Batch variant of getDocument: pulls every requested document for a

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -19,8 +19,10 @@ import {
   push as enclavePush,
   newIdempotencyKey,
   pullItemPlaintext,
+  SyncEnclaveError,
 } from '../sync-enclave/sync-api'
 import type { AccountOperationGuard } from './account-operation'
+import { CloudBackupReadError } from './backup-read-error'
 import { pullKey, requirePrimaryKeyB64 } from './cek-encoding'
 import { canWriteToCloud } from './cloud-key-authorization'
 import { ProjectDataSchema, ProjectDocumentPlaintextSchema } from './schemas'
@@ -213,10 +215,21 @@ export class ProjectStorageService {
     }
   }
 
-  async getProject(projectId: string): Promise<Project | null> {
+  async getProject(
+    projectId: string,
+    options: { strictBackupRead?: boolean } = {},
+  ): Promise<Project | null> {
     try {
       const keys = pullKey()
-      if (keys.length === 0) return null
+      if (keys.length === 0) {
+        if (options.strictBackupRead)
+          throw new CloudBackupReadError(
+            'key_unavailable',
+            'cloud_key_unavailable',
+            false,
+          )
+        return null
+      }
 
       const resp = await enclavePull({
         scope: PROJECT_SCOPE,
@@ -226,14 +239,47 @@ export class ProjectStorageService {
       const item = resp.items[0]
       if (!item || !item.ok) {
         if (item && item.code === 'NOT_FOUND') return null
+        if (options.strictBackupRead)
+          throw new SyncEnclaveError(
+            'Project pull returned an invalid item',
+            undefined,
+            item?.code,
+          )
         return null
       }
       const plaintextBytes = pullItemPlaintext(item)
-      if (!plaintextBytes) return null
+      if (!plaintextBytes) {
+        if (options.strictBackupRead)
+          throw new CloudBackupReadError(
+            'item_invalid',
+            'project_payload_unavailable',
+            true,
+          )
+        return null
+      }
 
-      const parsed = JSON.parse(new TextDecoder().decode(plaintextBytes))
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(new TextDecoder().decode(plaintextBytes))
+      } catch (error) {
+        if (options.strictBackupRead && error instanceof SyntaxError)
+          throw new CloudBackupReadError(
+            'item_invalid',
+            'project_payload_invalid',
+            true,
+            { cause: error },
+          )
+        throw error
+      }
       const projectValidation = ProjectDataSchema.safeParse(parsed)
       if (!projectValidation.success) {
+        if (options.strictBackupRead)
+          throw new CloudBackupReadError(
+            'item_invalid',
+            'project_payload_invalid',
+            true,
+            { cause: projectValidation.error },
+          )
         logError('Discarding project with invalid shape', undefined, {
           component: 'ProjectStorage',
           action: 'getProject',
@@ -261,6 +307,7 @@ export class ProjectStorageService {
         syncVersion: etagToSyncVersion(item.etag),
       }
     } catch (error) {
+      if (options.strictBackupRead) throw error
       logError(`Failed to get project ${projectId}`, error, {
         component: 'ProjectStorage',
         action: 'getProject',
@@ -268,6 +315,10 @@ export class ProjectStorageService {
       })
       return null
     }
+  }
+
+  getProjectForBackup(projectId: string): Promise<Project | null> {
+    return this.getProject(projectId, { strictBackupRead: true })
   }
 
   // Batch variant of getProject: pulls every requested project in a
@@ -536,10 +587,19 @@ export class ProjectStorageService {
   async getDocument(
     projectId: string,
     documentId: string,
+    options: { strictBackupRead?: boolean } = {},
   ): Promise<ProjectDocument | null> {
     try {
       const keys = pullKey()
-      if (keys.length === 0) return null
+      if (keys.length === 0) {
+        if (options.strictBackupRead)
+          throw new CloudBackupReadError(
+            'key_unavailable',
+            'cloud_key_unavailable',
+            false,
+          )
+        return null
+      }
 
       const resp = await enclavePull({
         scope: PROJECT_DOCUMENT_SCOPE,
@@ -549,15 +609,48 @@ export class ProjectStorageService {
       const item = resp.items[0]
       if (!item || !item.ok) {
         if (item && item.code === 'NOT_FOUND') return null
+        if (options.strictBackupRead)
+          throw new SyncEnclaveError(
+            'Project document pull returned an invalid item',
+            undefined,
+            item?.code,
+          )
         return null
       }
       const plaintextBytes = pullItemPlaintext(item)
-      if (!plaintextBytes) return null
+      if (!plaintextBytes) {
+        if (options.strictBackupRead)
+          throw new CloudBackupReadError(
+            'item_invalid',
+            'document_payload_unavailable',
+            true,
+          )
+        return null
+      }
 
-      const documentValidation = ProjectDocumentPlaintextSchema.safeParse(
-        JSON.parse(new TextDecoder().decode(plaintextBytes)),
-      )
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(new TextDecoder().decode(plaintextBytes))
+      } catch (error) {
+        if (options.strictBackupRead && error instanceof SyntaxError)
+          throw new CloudBackupReadError(
+            'item_invalid',
+            'document_payload_invalid',
+            true,
+            { cause: error },
+          )
+        throw error
+      }
+      const documentValidation =
+        ProjectDocumentPlaintextSchema.safeParse(parsed)
       if (!documentValidation.success) {
+        if (options.strictBackupRead)
+          throw new CloudBackupReadError(
+            'item_invalid',
+            'document_payload_invalid',
+            true,
+            { cause: documentValidation.error },
+          )
         logError('Discarding document with invalid shape', undefined, {
           component: 'ProjectStorage',
           action: 'getDocument',
@@ -582,6 +675,7 @@ export class ProjectStorageService {
         content: decoded.content,
       }
     } catch (error) {
+      if (options.strictBackupRead) throw error
       logError(`Failed to get document ${documentId}`, error, {
         component: 'ProjectStorage',
         action: 'getDocument',
@@ -589,6 +683,13 @@ export class ProjectStorageService {
       })
       return null
     }
+  }
+
+  getDocumentForBackup(
+    projectId: string,
+    documentId: string,
+  ): Promise<ProjectDocument | null> {
+    return this.getDocument(projectId, documentId, { strictBackupRead: true })
   }
 
   // Batch variant of getDocument: pulls every requested document for a

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -370,15 +370,14 @@ export class ProjectStorageService {
           wireId,
           expectedEtag,
         )
-        if (!item.ok) {
-          if (item.code === 'NOT_FOUND')
-            return { ok: true as const, value: null }
+        // validateBackupPullItem throws for NOT_FOUND, so any failed
+        // item that survives it carries an unexpected error code.
+        if (!item.ok)
           throw new SyncEnclaveError(
             'Backup pull returned an invalid item',
             undefined,
             item.code,
           )
-        }
         return { ok: true as const, value: decode(item, index) }
       } catch (error) {
         return { ok: false as const, error }

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -20,11 +20,14 @@ import {
   newIdempotencyKey,
   pullItemPlaintext,
   SyncEnclaveError,
+  type PullItem,
 } from '../sync-enclave/sync-api'
 import type { AccountOperationGuard } from './account-operation'
 import {
   CloudBackupReadError,
+  groupBackupPullItems,
   validateBackupPullItem,
+  type BackupPullResult,
 } from './backup-read-error'
 import { pullKey, requirePrimaryKeyB64 } from './cek-encoding'
 import { canWriteToCloud } from './cloud-key-authorization'
@@ -220,7 +223,7 @@ export class ProjectStorageService {
 
   async getProject(
     projectId: string,
-    options: { strictBackupRead?: boolean; expectedEtag?: string } = {},
+    options: { strictBackupRead?: boolean } = {},
   ): Promise<Project | null> {
     try {
       const keys = pullKey()
@@ -239,10 +242,7 @@ export class ProjectStorageService {
         ids: [projectId],
         keys,
       })
-      const item =
-        options.expectedEtag !== undefined
-          ? validateBackupPullItem(resp.items, projectId, options.expectedEtag)
-          : resp.items[0]
+      const item = resp.items[0]
       if (!item || !item.ok) {
         if (item && item.code === 'NOT_FOUND') return null
         if (options.strictBackupRead)
@@ -323,11 +323,117 @@ export class ProjectStorageService {
     }
   }
 
-  getProjectForBackup(
+  /**
+   * Batched strict backup read for projects: one enclave round trip,
+   * each item validated against its captured inventory ETag. Results
+   * align positionally with `requests` and settle per record.
+   */
+  async getProjectsForBackup(
+    requests: ReadonlyArray<{ id: string; expectedEtag: string }>,
+  ): Promise<BackupPullResult<Project | null>[]> {
+    return this.pullBatchForBackup(
+      PROJECT_SCOPE,
+      requests.map(({ id, expectedEtag }) => ({
+        wireId: id,
+        expectedEtag,
+      })),
+      (item, index) => this.decodeProjectBackupItem(item, requests[index].id),
+    )
+  }
+
+  private async pullBatchForBackup<T>(
+    scope: typeof PROJECT_SCOPE | typeof PROJECT_DOCUMENT_SCOPE,
+    requests: ReadonlyArray<{ wireId: string; expectedEtag: string }>,
+    decode: (item: PullItem, index: number) => T | null,
+  ): Promise<BackupPullResult<T | null>[]> {
+    if (requests.length === 0) return []
+    const keys = pullKey()
+    if (keys.length === 0)
+      throw new CloudBackupReadError(
+        'key_unavailable',
+        'cloud_key_unavailable',
+        false,
+      )
+    const resp = await enclavePull({
+      scope,
+      ids: requests.map(({ wireId }) => wireId),
+      keys,
+    })
+    const grouped = groupBackupPullItems(
+      resp.items,
+      requests.map(({ wireId }) => wireId),
+    )
+    return requests.map(({ wireId, expectedEtag }, index) => {
+      try {
+        const item = validateBackupPullItem(
+          grouped.get(wireId) ?? [],
+          wireId,
+          expectedEtag,
+        )
+        if (!item.ok) {
+          if (item.code === 'NOT_FOUND')
+            return { ok: true as const, value: null }
+          throw new SyncEnclaveError(
+            'Backup pull returned an invalid item',
+            undefined,
+            item.code,
+          )
+        }
+        return { ok: true as const, value: decode(item, index) }
+      } catch (error) {
+        return { ok: false as const, error }
+      }
+    })
+  }
+
+  private decodeProjectBackupItem(
+    item: PullItem,
     projectId: string,
-    expectedEtag: string,
-  ): Promise<Project | null> {
-    return this.getProject(projectId, { strictBackupRead: true, expectedEtag })
+  ): Project | null {
+    const plaintextBytes = pullItemPlaintext(item)
+    if (!plaintextBytes)
+      throw new CloudBackupReadError(
+        'item_invalid',
+        'project_payload_unavailable',
+        true,
+      )
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(new TextDecoder().decode(plaintextBytes))
+    } catch (error) {
+      if (error instanceof SyntaxError)
+        throw new CloudBackupReadError(
+          'item_invalid',
+          'project_payload_invalid',
+          true,
+          { cause: error },
+        )
+      throw error
+    }
+    const projectValidation = ProjectDataSchema.safeParse(parsed)
+    if (!projectValidation.success)
+      throw new CloudBackupReadError(
+        'item_invalid',
+        'project_payload_invalid',
+        true,
+        { cause: projectValidation.error },
+      )
+    const decoded = parsed as ProjectData
+
+    // Same timestamp-synthesis rationale as getProject: the
+    // controlplane listing path owns the authoritative values.
+    const now = new Date().toISOString()
+    return {
+      id: projectId,
+      name: decoded.name,
+      description: decoded.description,
+      systemInstructions: decoded.systemInstructions,
+      color: decoded.color,
+      memory: decoded.memory || [],
+      createdAt: now,
+      updatedAt: now,
+      syncVersion: etagToSyncVersion(item.etag),
+    }
   }
 
   // Batch variant of getProject: pulls every requested project in a
@@ -596,7 +702,7 @@ export class ProjectStorageService {
   async getDocument(
     projectId: string,
     documentId: string,
-    options: { strictBackupRead?: boolean; expectedEtag?: string } = {},
+    options: { strictBackupRead?: boolean } = {},
   ): Promise<ProjectDocument | null> {
     try {
       const keys = pullKey()
@@ -615,11 +721,7 @@ export class ProjectStorageService {
         ids: [projectDocumentId(projectId, documentId)],
         keys,
       })
-      const wireId = projectDocumentId(projectId, documentId)
-      const item =
-        options.expectedEtag !== undefined
-          ? validateBackupPullItem(resp.items, wireId, options.expectedEtag)
-          : resp.items[0]
+      const item = resp.items[0]
       if (!item || !item.ok) {
         if (item && item.code === 'NOT_FOUND') return null
         if (options.strictBackupRead)
@@ -698,15 +800,82 @@ export class ProjectStorageService {
     }
   }
 
-  getDocumentForBackup(
+  /**
+   * Batched strict backup read for project documents: one enclave
+   * round trip, each item validated against its captured inventory
+   * ETag. Results align positionally with `requests`.
+   */
+  async getDocumentsForBackup(
+    requests: ReadonlyArray<{
+      projectId: string
+      id: string
+      expectedEtag: string
+    }>,
+  ): Promise<BackupPullResult<ProjectDocument | null>[]> {
+    return this.pullBatchForBackup(
+      PROJECT_DOCUMENT_SCOPE,
+      requests.map(({ projectId, id, expectedEtag }) => ({
+        wireId: projectDocumentId(projectId, id),
+        expectedEtag,
+      })),
+      (item, index) =>
+        this.decodeDocumentBackupItem(
+          item,
+          requests[index].projectId,
+          requests[index].id,
+        ),
+    )
+  }
+
+  private decodeDocumentBackupItem(
+    item: PullItem,
     projectId: string,
     documentId: string,
-    expectedEtag: string,
-  ): Promise<ProjectDocument | null> {
-    return this.getDocument(projectId, documentId, {
-      strictBackupRead: true,
-      expectedEtag,
-    })
+  ): ProjectDocument | null {
+    const plaintextBytes = pullItemPlaintext(item)
+    if (!plaintextBytes)
+      throw new CloudBackupReadError(
+        'item_invalid',
+        'document_payload_unavailable',
+        true,
+      )
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(new TextDecoder().decode(plaintextBytes))
+    } catch (error) {
+      if (error instanceof SyntaxError)
+        throw new CloudBackupReadError(
+          'item_invalid',
+          'document_payload_invalid',
+          true,
+          { cause: error },
+        )
+      throw error
+    }
+    const documentValidation = ProjectDocumentPlaintextSchema.safeParse(parsed)
+    if (!documentValidation.success)
+      throw new CloudBackupReadError(
+        'item_invalid',
+        'document_payload_invalid',
+        true,
+        { cause: documentValidation.error },
+      )
+    const decoded = documentValidation.data
+
+    // Same timestamp-synthesis rationale as getProject: the
+    // controlplane listing path owns the authoritative values.
+    const now = new Date().toISOString()
+    return {
+      id: documentId,
+      projectId,
+      filename: decoded.filename || '',
+      contentType: decoded.contentType || '',
+      sizeBytes: resolveDocumentSizeBytes(decoded.content, decoded.sizeBytes),
+      syncVersion: etagToSyncVersion(item.etag),
+      createdAt: now,
+      updatedAt: now,
+      content: decoded.content,
+    }
   }
 
   // Batch variant of getDocument: pulls every requested document for a

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -43,6 +43,7 @@ import {
   type NativeBackupImageCandidate,
 } from './sanitize'
 const STABLE_READ_ATTEMPTS = 3
+const ATTACHMENT_DOWNLOAD_CONCURRENCY = 4
 const encoder = new TextEncoder()
 type CloudInventoryItem = BackupInventoryItem
 type DocumentItem = BackupInventoryItem & { project_id: string }
@@ -121,6 +122,17 @@ function failItem(
     true,
   )
 }
+function isOmittableCollectionError(
+  error: unknown,
+): error is NativeBackupCollectionError & {
+  category: NativeBackupOmission['category']
+} {
+  return (
+    error instanceof NativeBackupCollectionError &&
+    error.omittable &&
+    error.category !== 'systemic'
+  )
+}
 async function wait<T>(s: AbortSignal | undefined, read: () => Promise<T>) {
   s?.throwIfAborted()
   const value = await read()
@@ -176,6 +188,36 @@ function groupCloudInventory(
     else documents.push(item as DocumentItem)
   }
   return { chats, projects, documents, discovered: response.total_items }
+}
+async function mapLimitInOrder<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  fn: (value: T) => Promise<R>,
+  signal?: AbortSignal,
+): Promise<R[]> {
+  const output = new Array<R>(values.length)
+  let nextIndex = 0
+  let stopped = false
+  let firstError: unknown
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+      while (nextIndex < values.length && !stopped) {
+        const index = nextIndex++
+        try {
+          signal?.throwIfAborted()
+          output[index] = await fn(values[index])
+          signal?.throwIfAborted()
+        } catch (error) {
+          if (!stopped) {
+            stopped = true
+            firstError = error
+          }
+        }
+      }
+    }),
+  )
+  if (stopped) throw firstError
+  return output
 }
 type Pending = [number, number, number, number, number]
 const budgetLimits: Array<[string, number]> = [
@@ -289,10 +331,7 @@ async function readRecord<T>(
           error.category === 'snapshot_changed'
         )
           throw lastError
-      } else if (
-        error instanceof NativeBackupCollectionError &&
-        error.omittable
-      ) {
+      } else if (isOmittableCollectionError(error)) {
         lastError = error
       } else {
         throw error
@@ -367,7 +406,7 @@ function localInventoryToken(chats: StoredChat[], userId: string): string {
     try {
       return [[chat.id, localToken(chat)]]
     } catch (error) {
-      if (error instanceof NativeBackupCollectionError && error.omittable)
+      if (isOmittableCollectionError(error))
         return [[chat.id, error.category, error.reason]]
       throw error
     }
@@ -400,17 +439,19 @@ async function collectChat(
     candidate: NativeBackupImageCandidate
     failure: NativeBackupCollectionError
   }> = []
-  for (const candidate of candidates) {
-    try {
-      const attachment =
-        candidate.attachmentIndex === undefined
-          ? undefined
-          : chat.messages[candidate.messageIndex].attachments?.[
-              candidate.attachmentIndex
-            ]
-      const base64 = imagePayload(chat, candidate)
-      let bytes: Uint8Array | null = null
+  const results = await mapLimitInOrder(
+    candidates,
+    ATTACHMENT_DOWNLOAD_CONCURRENCY,
+    async (candidate) => {
       try {
+        const attachment =
+          candidate.attachmentIndex === undefined
+            ? undefined
+            : chat.messages[candidate.messageIndex].attachments?.[
+                candidate.attachmentIndex
+              ]
+        const base64 = imagePayload(chat, candidate)
+        let bytes: Uint8Array | null = null
         if (base64) {
           try {
             bytes = base64ToUint8Array(base64)
@@ -441,52 +482,51 @@ async function collectChat(
             },
           )
         }
+        if (!bytes)
+          failItem(
+            'image',
+            candidate.sourceKey,
+            'image bytes are missing',
+            'unavailable',
+            'attachment_not_found',
+          )
+        const mimeType =
+          detectNativeBackupImageMimeType(bytes) ??
+          failItem(
+            'image',
+            candidate.sourceKey,
+            'image type is unsupported',
+            'invalid',
+            'attachment_type_unsupported',
+          )
+        const metadata = valid('image', candidate.sourceKey, () =>
+          sanitizeNativeBackupImage({
+            ...candidate,
+            id: candidate.sourceKey,
+            mimeType,
+            sizeBytes: bytes.length,
+          }),
+        )
+        return { candidate, bytes, metadata, mimeType }
       } catch (error) {
-        signal?.throwIfAborted()
-        throwIfAuthenticationError(error)
-        throw error
+        if (!allowPartial || !isOmittableCollectionError(error)) throw error
+        return { candidate, failure: error }
       }
-      if (!bytes)
-        failItem(
-          'image',
-          candidate.sourceKey,
-          'image bytes are missing',
-          'unavailable',
-          'attachment_not_found',
-        )
-      const mimeType =
-        detectNativeBackupImageMimeType(bytes) ??
-        failItem(
-          'image',
-          candidate.sourceKey,
-          'image type is unsupported',
-          'invalid',
-          'attachment_type_unsupported',
-        )
-      if (candidate.legacyIndex !== undefined)
-        value.messages[candidate.messageIndex].imageData![
-          candidate.legacyIndex
-        ].mimeType = mimeType
-      const metadata = valid('image', candidate.sourceKey, () =>
-        sanitizeNativeBackupImage({
-          ...candidate,
-          id: candidate.sourceKey,
-          mimeType,
-          sizeBytes: bytes.length,
-        }),
-      )
-      if (allowPartial) budget.imageSize(bytes)
-      else budget.image(pending!, metadata, bytes)
-      images.push({ metadata, bytes })
-    } catch (error) {
-      if (
-        !allowPartial ||
-        !(error instanceof NativeBackupCollectionError) ||
-        !error.omittable
-      )
-        throw error
-      omitted.push({ candidate, failure: error })
+    },
+    signal,
+  )
+  for (const result of results) {
+    if (result.failure) {
+      omitted.push({ candidate: result.candidate, failure: result.failure })
+      continue
     }
+    const { candidate, bytes, metadata, mimeType } = result
+    if (candidate.legacyIndex !== undefined)
+      value.messages[candidate.messageIndex].imageData![
+        candidate.legacyIndex
+      ].mimeType = mimeType
+    if (!allowPartial) budget.image(pending!, metadata, bytes)
+    images.push({ metadata, bytes })
   }
   if (omitted.length) removeOmittedImageReferences(value, omitted, images)
   if (allowPartial) {
@@ -646,17 +686,12 @@ async function collectNativeBackupAttempt(
     error: unknown,
     parentSourceId?: string,
   ) => {
-    if (
-      !allowPartial ||
-      !(error instanceof NativeBackupCollectionError) ||
-      !error.omittable
-    )
-      throw error
+    if (!allowPartial || !isOmittableCollectionError(error)) throw error
     addOmission({
       kind,
       source_id: sourceId,
       ...(parentSourceId ? { parent_source_id: parentSourceId } : {}),
-      category: error.category as NativeBackupOmission['category'],
+      category: error.category,
       reason: error.reason,
     })
   }

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -16,6 +16,11 @@ import {
   type StoredChat,
 } from '@/services/storage/indexed-db'
 import { SyncEnclaveError } from '@/services/sync-enclave'
+import {
+  backupInventory,
+  type BackupInventoryItem,
+  type BackupInventoryResponse,
+} from '@/services/sync-enclave/sync-api'
 import type { Project, ProjectDocument } from '@/types/project'
 import { base64ToUint8Array } from '@/utils/binary-codec'
 import { z } from 'zod'
@@ -37,25 +42,23 @@ import {
   sanitizeNativeBackupRelationships,
   type NativeBackupImageCandidate,
 } from './sanitize'
-const PAGE_SIZE = 500
-const CONCURRENCY = 4
 const STABLE_READ_ATTEMPTS = 3
 const encoder = new TextEncoder()
-type Listed = { id: string; syncVersion: number }
-type Timed = Listed & { createdAt: string; updatedAt: string }
-type DocumentItem = Timed & { projectId: string }
-type Page<T> = Promise<{ items: T[]; next?: string }>
+type CloudInventoryItem = BackupInventoryItem
+type DocumentItem = BackupInventoryItem & { project_id: string }
 export interface NativeBackupCollectionDependencies {
   isAuthenticated(): Promise<boolean>
   activeUserId(): string | null
   requireUnlockedCek(): void
-  listChats(token?: string): Page<Listed>
-  getCloudChat(id: string): Promise<StoredChat | null>
+  getCloudInventory(signal?: AbortSignal): Promise<BackupInventoryResponse>
+  getCloudChat(id: string, expectedEtag: string): Promise<StoredChat | null>
   getCloudImage(value: Attachment): Promise<Uint8Array | null>
-  listProjects(token?: string): Page<Timed>
-  getProject(id: string): Promise<Project | null>
-  listDocuments(projectId: string): Promise<DocumentItem[]>
-  getDocument(projectId: string, id: string): Promise<ProjectDocument | null>
+  getProject(id: string, expectedEtag: string): Promise<Project | null>
+  getDocument(
+    projectId: string,
+    id: string,
+    expectedEtag: string,
+  ): Promise<ProjectDocument | null>
   getLocalChats(): Promise<StoredChat[]>
   getLocalChat(id: string): Promise<StoredChat | null>
 }
@@ -88,27 +91,14 @@ const defaults: NativeBackupCollectionDependencies = {
   isAuthenticated: () => authTokenManager.isAuthenticated(),
   activeUserId,
   requireUnlockedCek: () => void requirePrimaryKeyB64(),
-  listChats: async (continuationToken) => {
-    const page = await cloudStorage.listChats({
-      limit: PAGE_SIZE,
-      continuationToken,
-    })
-    return { items: page.conversations, next: page.nextContinuationToken }
-  },
-  getCloudChat: (id) => cloudStorage.downloadChatForBackup(id),
+  getCloudInventory: backupInventory,
+  getCloudChat: (id, expectedEtag) =>
+    cloudStorage.downloadChatForBackup(id, expectedEtag),
   getCloudImage: (value) => cloudStorage.loadChatImageForBackup(value),
-  listProjects: async (continuationToken) => {
-    const page = await projectStorage.listProjects({
-      limit: PAGE_SIZE,
-      continuationToken,
-    })
-    return { items: page.projects, next: page.nextContinuationToken }
-  },
-  getProject: (id) => projectStorage.getProjectForBackup(id),
-  listDocuments: async (id) =>
-    (await projectStorage.listDocuments(id)).documents,
-  getDocument: (projectId, id) =>
-    projectStorage.getDocumentForBackup(projectId, id),
+  getProject: (id, expectedEtag) =>
+    projectStorage.getProjectForBackup(id, expectedEtag),
+  getDocument: (projectId, id, expectedEtag) =>
+    projectStorage.getDocumentForBackup(projectId, id, expectedEtag),
   getLocalChats: () => indexedDBStorage.getAllChats(),
   getLocalChat: (id) => indexedDBStorage.getChat(id),
 }
@@ -160,18 +150,6 @@ function valid<T>(kind: string, id: string, parse: () => T): T {
     )
   }
 }
-function unique<T extends Listed>(
-  values: T[],
-  key: (value: T) => string = ({ id }) => id,
-): T[] {
-  const byId = new Map<string, T>()
-  for (const value of values) {
-    const identity = key(value)
-    const old = byId.get(identity)
-    if (!old || value.syncVersion >= old.syncVersion) byId.set(identity, value)
-  }
-  return [...byId.values()]
-}
 function throwIfAuthenticationError(error: unknown) {
   if (
     error instanceof AuthTokenUnavailableError ||
@@ -180,111 +158,24 @@ function throwIfAuthenticationError(error: unknown) {
   )
     throw error
 }
-async function pages<T extends Listed>(
-  fn: (t?: string) => Page<T>,
-  s?: AbortSignal,
-  onDiscovered?: (count: number) => void,
-) {
-  const values: T[] = []
-  let token: string | undefined
-  do {
-    const page = await wait(s, () => fn(token))
-    onDiscovered?.(page.items.length)
-    values.push(...page.items)
-    token = page.next
-  } while (token)
-  return unique(values)
-}
 type CloudInventory = {
-  chats: Listed[]
-  projects: Timed[]
+  chats: CloudInventoryItem[]
+  projects: CloudInventoryItem[]
   documents: DocumentItem[]
   discovered: number
 }
-async function discoverCloudInventory(
-  deps: NativeBackupCollectionDependencies,
-  signal?: AbortSignal,
-): Promise<CloudInventory> {
-  let discovered = 0
-  const add = (count: number) => {
-    signal?.throwIfAborted()
-    discovered += count
-    if (discovered > NATIVE_BACKUP_LIMITS.discoveredRecords)
-      fail('limits', 'collection', 'discovered record limit exceeded')
+function groupCloudInventory(
+  response: BackupInventoryResponse,
+): CloudInventory {
+  const chats: CloudInventoryItem[] = []
+  const projects: CloudInventoryItem[] = []
+  const documents: DocumentItem[] = []
+  for (const item of response.items) {
+    if (item.scope === 'chat') chats.push(item)
+    else if (item.scope === 'project') projects.push(item)
+    else documents.push(item as DocumentItem)
   }
-  const [chats, projects] = await Promise.all([
-    pages(deps.listChats, signal, add),
-    pages(deps.listProjects, signal, add),
-  ])
-  const documents = unique(
-    (
-      await mapLimit(
-        projects,
-        async ({ id }) => {
-          const items = await deps.listDocuments(id)
-          add(items.length)
-          return items
-        },
-        signal,
-      )
-    ).flat(),
-    ({ projectId, id }) => JSON.stringify([projectId, id]),
-  )
-  return { chats, projects, documents, discovered }
-}
-function inventoryToken(inventory: CloudInventory): string {
-  const keys = [
-    ...inventory.chats.map(({ id, syncVersion }) => ['chat', id, syncVersion]),
-    ...inventory.projects.map(({ id, syncVersion }) => [
-      'project',
-      id,
-      syncVersion,
-    ]),
-    ...inventory.documents.map(({ projectId, id, syncVersion }) => [
-      'document',
-      projectId,
-      id,
-      syncVersion,
-    ]),
-  ]
-  keys.sort((left, right) => {
-    const a = JSON.stringify(left)
-    const b = JSON.stringify(right)
-    return a < b ? -1 : a > b ? 1 : 0
-  })
-  return JSON.stringify(keys)
-}
-async function refreshListed<T extends Listed>(
-  kind: string,
-  id: string,
-  refresh: () => Promise<T[]>,
-  signal?: AbortSignal,
-): Promise<T> {
-  for (let attempt = 0; attempt < STABLE_READ_ATTEMPTS; attempt++) {
-    const item = unique(await wait(signal, refresh)).find(
-      (candidate) => candidate.id === id,
-    )
-    if (item) return item
-  }
-  return failItem(kind, id, 'record was deleted', 'deleted', 'record_deleted')
-}
-async function mapLimit<T, R>(
-  v: T[],
-  fn: (v: T) => Promise<R>,
-  s?: AbortSignal,
-) {
-  const output = new Array<R>(v.length)
-  let next = 0
-  await Promise.all(
-    Array.from({ length: Math.min(CONCURRENCY, v.length) }, async () => {
-      while (next < v.length) {
-        s?.throwIfAborted()
-        const index = next++
-        output[index] = await wait(s, () => fn(v[index]))
-      }
-    }),
-  )
-  return output
+  return { chats, projects, documents, discovered: response.total_items }
 }
 type Pending = [number, number, number, number, number]
 const budgetLimits: Array<[string, number]> = [
@@ -372,11 +263,22 @@ async function readRecord<T>(
         lastError = new NativeBackupCollectionError(
           kind,
           id,
-          'record could not be decoded',
-          error.category === 'item_invalid' ? 'invalid' : 'unavailable',
+          'record could not be read at the captured version',
+          error.category === 'item_invalid'
+            ? 'invalid'
+            : error.category === 'snapshot_deleted'
+              ? 'deleted'
+              : error.category === 'snapshot_changed'
+                ? 'unstable'
+                : 'unavailable',
           error.reason,
           true,
         )
+        if (
+          error.category === 'snapshot_deleted' ||
+          error.category === 'snapshot_changed'
+        )
+          throw lastError
       } else if (
         error instanceof NativeBackupCollectionError &&
         error.omittable
@@ -389,42 +291,20 @@ async function readRecord<T>(
   }
   throw lastError!
 }
-async function stable<T extends { syncVersion?: number }, I extends Listed>(
+async function collectTimedInventoryItem<T, R>(
   kind: string,
-  initial: I,
+  item: CloudInventoryItem,
   read: () => Promise<T | null>,
-  refresh: () => Promise<I[]>,
-  signal?: AbortSignal,
-): Promise<{ value: T; item: I }> {
-  let item = initial
-  for (let attempt = 0; attempt < STABLE_READ_ATTEMPTS; attempt++) {
-    const value = await readRecord(kind, item.id, read, signal)
-    if (value.syncVersion === item.syncVersion) return { value, item }
-    item = await refreshListed(kind, item.id, refresh, signal)
-  }
-  return failItem(
-    kind,
-    item.id,
-    'version changed during collection',
-    'unstable',
-    'version_did_not_converge',
-  )
-}
-async function timed<T extends { syncVersion?: number }, I extends Timed, R>(
-  kind: string,
-  item: I,
-  read: () => Promise<T | null>,
-  refresh: () => Promise<I[]>,
   sanitize: (value: unknown) => R,
   budget: Budget,
   signal?: AbortSignal,
 ) {
-  const current = await stable(kind, item, read, refresh, signal)
+  const current = await readRecord(kind, item.id, read, signal)
   const value = valid(kind, item.id, () =>
     sanitize({
-      ...current.value,
-      createdAt: current.item.createdAt,
-      updatedAt: current.item.updatedAt,
+      ...current,
+      createdAt: item.created_at,
+      updatedAt: item.updated_at,
     }),
   )
   budget.json(value, true)
@@ -693,8 +573,6 @@ async function collectNativeBackup(
   deps: NativeBackupCollectionDependencies = defaults,
   signal?: AbortSignal,
   allowPartial = false,
-  inventoryAttempt = 0,
-  localInventoryAttempt = 0,
 ): Promise<NativeBackupV2Input> {
   if (!(await wait(signal, () => deps.isAuthenticated())))
     fail('account', 'active', 'signed-in user is required')
@@ -705,10 +583,27 @@ async function collectNativeBackup(
   } catch {
     fail('account', userId, 'cloud encryption key is locked or unavailable')
   }
-  const [inventory, localSnapshots] = await Promise.all([
-    discoverCloudInventory(deps, signal),
-    wait(signal, () => deps.getLocalChats()),
-  ])
+  const response = await wait(signal, () => deps.getCloudInventory(signal))
+  if (response.total_items > NATIVE_BACKUP_LIMITS.discoveredRecords)
+    fail('limits', 'collection', 'discovered record limit exceeded')
+  return collectNativeBackupAttempt(
+    deps,
+    groupCloudInventory(response),
+    userId,
+    signal,
+    allowPartial,
+  )
+}
+
+async function collectNativeBackupAttempt(
+  deps: NativeBackupCollectionDependencies,
+  inventory: CloudInventory,
+  userId: string,
+  signal?: AbortSignal,
+  allowPartial = false,
+  localInventoryAttempt = 0,
+): Promise<NativeBackupV2Input> {
+  const localSnapshots = await wait(signal, () => deps.getLocalChats())
   if (
     inventory.discovered + localSnapshots.length >
     NATIVE_BACKUP_LIMITS.discoveredRecords
@@ -751,11 +646,10 @@ async function collectNativeBackup(
   for (const item of projectItems) {
     try {
       projects.push(
-        await timed(
+        await collectTimedInventoryItem(
           'project',
           item,
-          () => deps.getProject(item.id),
-          () => pages(deps.listProjects, signal),
+          () => deps.getProject(item.id, item.etag),
           sanitizeNativeBackupProject,
           budget,
           signal,
@@ -766,32 +660,31 @@ async function collectNativeBackup(
     }
   }
   const includedProjectIds = new Set(projects.map(({ id }) => id))
-  const documentItems = allDocumentItems.filter(({ projectId }) =>
-    includedProjectIds.has(projectId),
+  const documentItems = allDocumentItems.filter(({ project_id }) =>
+    includedProjectIds.has(project_id),
   )
   const projectDocuments = []
   for (const item of documentItems) {
     try {
       projectDocuments.push(
-        await timed(
+        await collectTimedInventoryItem(
           'project document',
           item,
-          () => deps.getDocument(item.projectId, item.id),
-          () => deps.listDocuments(item.projectId),
+          () => deps.getDocument(item.project_id, item.id, item.etag),
           sanitizeNativeBackupProjectDocument,
           budget,
           signal,
         ),
       )
     } catch (error) {
-      omit('project_document', item.id, error, item.projectId)
+      omit('project_document', item.id, error, item.project_id)
     }
   }
   for (const item of projectItems.filter(
     ({ id }) => !includedProjectIds.has(id),
   )) {
     for (const document of allDocumentItems.filter(
-      ({ projectId }) => projectId === item.id,
+      ({ project_id }) => project_id === item.id,
     ))
       addOmission({
         kind: 'project_document',
@@ -804,26 +697,27 @@ async function collectNativeBackup(
   const cloudResults = []
   for (const listed of chatItems) {
     try {
-      const result = await retryChat(
+      const chat = await readRecord(
         'cloud chat',
         listed.id,
-        listed.syncVersion,
-        () => deps.getCloudChat(listed.id),
-        ({ syncVersion }) => syncVersion,
-        (chat) => classifyNativeBackupChat(chat, 'cloud') !== null,
-        async () =>
-          (
-            await refreshListed(
-              'cloud chat',
-              listed.id,
-              () => pages(deps.listChats, signal),
-              signal,
-            )
-          ).syncVersion,
-        (chat) => collectChat(chat, true, deps, budget, signal, allowPartial),
+        () => deps.getCloudChat(listed.id, listed.etag),
         signal,
       )
-      if (!result) continue
+      const capturedChat = {
+        ...chat,
+        createdAt: listed.created_at,
+        updatedAt: listed.updated_at,
+        projectId: listed.project_id,
+      }
+      if (classifyNativeBackupChat(capturedChat, 'cloud') === null) continue
+      const result = await collectChat(
+        capturedChat,
+        true,
+        deps,
+        budget,
+        signal,
+        allowPartial,
+      )
       budget.commit(result.pending, true)
       cloudResults.push(result)
       for (const { failure } of result.omitted)
@@ -888,38 +782,23 @@ async function collectNativeBackup(
   })
   budget.json(relationships)
   signal?.throwIfAborted()
-  const [finalInventory, finalLocalSnapshots] = await Promise.all([
-    discoverCloudInventory(deps, signal),
-    wait(signal, () => deps.getLocalChats()),
-  ])
+  const finalLocalSnapshots = await wait(signal, () => deps.getLocalChats())
   if (
-    finalInventory.discovered + finalLocalSnapshots.length >
+    inventory.discovered + finalLocalSnapshots.length >
     NATIVE_BACKUP_LIMITS.discoveredRecords
   )
     fail('limits', 'collection', 'discovered record limit exceeded')
-  const cloudChanged =
-    inventoryToken(finalInventory) !== inventoryToken(inventory)
   const localChanged =
     localInventoryToken(finalLocalSnapshots, userId) !==
     initialLocalInventoryToken
-  if (cloudChanged) {
-    if (inventoryAttempt + 1 >= NATIVE_BACKUP_LIMITS.inventoryAttempts)
-      fail('inventory', 'cloud', 'cloud inventory did not converge')
-    return collectNativeBackup(
-      deps,
-      signal,
-      allowPartial,
-      inventoryAttempt + 1,
-      localChanged ? localInventoryAttempt + 1 : localInventoryAttempt,
-    )
-  }
   if (localChanged) {
-    if (localInventoryAttempt + 1 < NATIVE_BACKUP_LIMITS.inventoryAttempts)
-      return collectNativeBackup(
+    if (localInventoryAttempt + 1 < NATIVE_BACKUP_LIMITS.localInventoryAttempts)
+      return collectNativeBackupAttempt(
         deps,
+        inventory,
+        userId,
         signal,
         allowPartial,
-        inventoryAttempt,
         localInventoryAttempt + 1,
       )
     if (!allowPartial)

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -5,6 +5,10 @@ import {
   AuthTokenUnavailableError,
   authTokenManager,
 } from '@/services/auth'
+import {
+  unwrapBackupPullResult,
+  type BackupPullResult,
+} from '@/services/cloud/backup-read-error'
 import { requirePrimaryKeyB64 } from '@/services/cloud/cek-encoding'
 import {
   CloudBackupReadError,
@@ -44,22 +48,31 @@ import {
 } from './sanitize'
 const STABLE_READ_ATTEMPTS = 3
 const ATTACHMENT_DOWNLOAD_CONCURRENCY = 4
+// One enclave pull carries this many records. Bounds response size
+// while collapsing per-record round trips on large accounts.
+const CLOUD_PULL_BATCH_SIZE = 20
 const encoder = new TextEncoder()
 type CloudInventoryItem = BackupInventoryItem
 type DocumentItem = BackupInventoryItem & { project_id: string }
+export type BackupReadRequest = { id: string; expectedEtag: string }
+export type BackupDocumentReadRequest = BackupReadRequest & {
+  projectId: string
+}
 export interface NativeBackupCollectionDependencies {
   isAuthenticated(): Promise<boolean>
   activeUserId(): string | null
   requireUnlockedCek(): void
   getCloudInventory(signal?: AbortSignal): Promise<BackupInventoryResponse>
-  getCloudChat(id: string, expectedEtag: string): Promise<StoredChat | null>
+  getCloudChats(
+    requests: readonly BackupReadRequest[],
+  ): Promise<BackupPullResult<StoredChat | null>[]>
   getCloudImage(value: Attachment): Promise<Uint8Array | null>
-  getProject(id: string, expectedEtag: string): Promise<Project | null>
-  getDocument(
-    projectId: string,
-    id: string,
-    expectedEtag: string,
-  ): Promise<ProjectDocument | null>
+  getProjects(
+    requests: readonly BackupReadRequest[],
+  ): Promise<BackupPullResult<Project | null>[]>
+  getDocuments(
+    requests: readonly BackupDocumentReadRequest[],
+  ): Promise<BackupPullResult<ProjectDocument | null>[]>
   getLocalChats(): Promise<StoredChat[]>
   getLocalChat(id: string): Promise<StoredChat | null>
 }
@@ -93,13 +106,10 @@ const defaults: NativeBackupCollectionDependencies = {
   activeUserId,
   requireUnlockedCek: () => void requirePrimaryKeyB64(),
   getCloudInventory: backupInventory,
-  getCloudChat: (id, expectedEtag) =>
-    cloudStorage.downloadChatForBackup(id, expectedEtag),
+  getCloudChats: (requests) => cloudStorage.downloadChatsForBackup(requests),
   getCloudImage: (value) => cloudStorage.loadChatImageForBackup(value),
-  getProject: (id, expectedEtag) =>
-    projectStorage.getProjectForBackup(id, expectedEtag),
-  getDocument: (projectId, id, expectedEtag) =>
-    projectStorage.getDocumentForBackup(projectId, id, expectedEtag),
+  getProjects: (requests) => projectStorage.getProjectsForBackup(requests),
+  getDocuments: (requests) => projectStorage.getDocumentsForBackup(requests),
   getLocalChats: () => indexedDBStorage.getAllChats(),
   getLocalChat: (id) => indexedDBStorage.getChat(id),
 }
@@ -188,6 +198,36 @@ function groupCloudInventory(
     else documents.push(item as DocumentItem)
   }
   return { chats, projects, documents, discovered: response.total_items }
+}
+/**
+ * Walk inventory items in fixed-size batches, one enclave round trip
+ * per batch. Each item is handed a `read` thunk that consumes the
+ * prefetched batch slot on its first call and falls back to a
+ * single-record batch on retries, so `readRecord`'s per-record retry
+ * semantics are unchanged.
+ */
+async function collectInBatches<I, R>(
+  items: readonly I[],
+  fetchBatch: (batch: readonly I[]) => Promise<BackupPullResult<R>[]>,
+  handle: (item: I, read: () => Promise<R>) => Promise<void>,
+  signal?: AbortSignal,
+) {
+  for (let start = 0; start < items.length; start += CLOUD_PULL_BATCH_SIZE) {
+    const batch = items.slice(start, start + CLOUD_PULL_BATCH_SIZE)
+    const results = await wait(signal, () => fetchBatch(batch))
+    for (const [index, item] of batch.entries()) {
+      let prefetched: BackupPullResult<R> | undefined = results[index]
+      const read = async () => {
+        if (prefetched) {
+          const result = prefetched
+          prefetched = undefined
+          return unwrapBackupPullResult(result)
+        }
+        return unwrapBackupPullResult((await fetchBatch([item]))[0])
+      }
+      await handle(item, read)
+    }
+  }
 }
 async function mapLimitInOrder<T, R>(
   values: readonly T[],
@@ -710,44 +750,66 @@ async function collectNativeBackupAttempt(
       reason: error.reason,
     })
   }
-  const projects = []
-  for (const item of projectItems) {
-    try {
-      projects.push(
-        await collectTimedInventoryItem(
-          'project',
-          item,
-          () => deps.getProject(item.id, item.etag),
-          sanitizeNativeBackupProject,
-          budget,
-          signal,
-        ),
-      )
-    } catch (error) {
-      omit('project', item.id, error)
-    }
-  }
+  const projects: ReturnType<typeof sanitizeNativeBackupProject>[] = []
+  await collectInBatches(
+    projectItems,
+    (batch) =>
+      deps.getProjects(
+        batch.map(({ id, etag }) => ({ id, expectedEtag: etag })),
+      ),
+    async (item, read) => {
+      try {
+        projects.push(
+          await collectTimedInventoryItem(
+            'project',
+            item,
+            read,
+            sanitizeNativeBackupProject,
+            budget,
+            signal,
+          ),
+        )
+      } catch (error) {
+        omit('project', item.id, error)
+      }
+    },
+    signal,
+  )
   const includedProjectIds = new Set(projects.map(({ id }) => id))
   const documentItems = allDocumentItems.filter(({ project_id }) =>
     includedProjectIds.has(project_id),
   )
-  const projectDocuments = []
-  for (const item of documentItems) {
-    try {
-      projectDocuments.push(
-        await collectTimedInventoryItem(
-          'project document',
-          item,
-          () => deps.getDocument(item.project_id, item.id, item.etag),
-          sanitizeNativeBackupProjectDocument,
-          budget,
-          signal,
-        ),
-      )
-    } catch (error) {
-      omit('project_document', item.id, error, item.project_id)
-    }
-  }
+  const projectDocuments: ReturnType<
+    typeof sanitizeNativeBackupProjectDocument
+  >[] = []
+  await collectInBatches(
+    documentItems,
+    (batch) =>
+      deps.getDocuments(
+        batch.map(({ project_id, id, etag }) => ({
+          projectId: project_id,
+          id,
+          expectedEtag: etag,
+        })),
+      ),
+    async (item, read) => {
+      try {
+        projectDocuments.push(
+          await collectTimedInventoryItem(
+            'project document',
+            item,
+            read,
+            sanitizeNativeBackupProjectDocument,
+            budget,
+            signal,
+          ),
+        )
+      } catch (error) {
+        omit('project_document', item.id, error, item.project_id)
+      }
+    },
+    signal,
+  )
   for (const item of projectItems.filter(
     ({ id }) => !includedProjectIds.has(id),
   )) {
@@ -762,38 +824,41 @@ async function collectNativeBackupAttempt(
         reason: 'parent_project_omitted',
       })
   }
-  const cloudResults = []
-  for (const listed of chatItems) {
-    try {
-      const chat = await readRecord(
-        'cloud chat',
-        listed.id,
-        () => deps.getCloudChat(listed.id, listed.etag),
-        signal,
-      )
-      const capturedChat = {
-        ...chat,
-        createdAt: listed.created_at,
-        updatedAt: listed.updated_at,
-        projectId: listed.project_id,
+  const cloudResults: Awaited<ReturnType<typeof collectChat>>[] = []
+  await collectInBatches(
+    chatItems,
+    (batch) =>
+      deps.getCloudChats(
+        batch.map(({ id, etag }) => ({ id, expectedEtag: etag })),
+      ),
+    async (listed, read) => {
+      try {
+        const chat = await readRecord('cloud chat', listed.id, read, signal)
+        const capturedChat = {
+          ...chat,
+          createdAt: listed.created_at,
+          updatedAt: listed.updated_at,
+          projectId: listed.project_id,
+        }
+        if (classifyNativeBackupChat(capturedChat, 'cloud') === null) return
+        const result = await collectChat(
+          capturedChat,
+          true,
+          deps,
+          budget,
+          signal,
+          allowPartial,
+        )
+        budget.commit(result.pending, true)
+        cloudResults.push(result)
+        for (const { failure } of result.omitted)
+          omit('attachment', failure.recordId, failure, listed.id)
+      } catch (error) {
+        omit('cloud_chat', listed.id, error)
       }
-      if (classifyNativeBackupChat(capturedChat, 'cloud') === null) continue
-      const result = await collectChat(
-        capturedChat,
-        true,
-        deps,
-        budget,
-        signal,
-        allowPartial,
-      )
-      budget.commit(result.pending, true)
-      cloudResults.push(result)
-      for (const { failure } of result.omitted)
-        omit('attachment', failure.recordId, failure, listed.id)
-    } catch (error) {
-      omit('cloud_chat', listed.id, error)
-    }
-  }
+    },
+    signal,
+  )
   const localResults = []
   for (const snapshot of localSnapshots) {
     if (!localEligible(snapshot, userId)) continue

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -202,8 +202,18 @@ class Budget {
     this.check(pending)
     return pending
   }
-  image(pending: Pending, metadata: unknown, bytes: Uint8Array) {
+  preflightChat(value: ReturnType<typeof sanitizeNativeBackupChat>) {
+    this.limit(
+      'message',
+      this.used[0] + value.messages.length,
+      NATIVE_BACKUP_LIMITS.messages,
+    )
+  }
+  imageSize(bytes: Uint8Array) {
     this.limit('image size', bytes.length, NATIVE_BACKUP_LIMITS.imageBytes)
+  }
+  image(pending: Pending, metadata: unknown, bytes: Uint8Array) {
+    this.imageSize(bytes)
     const json = jsonSize(metadata)
     pending[2] += json
     pending[3] += json + bytes.length
@@ -379,7 +389,9 @@ async function collectChat(
   const value = valid(cloud ? 'cloud chat' : 'local chat', chat.id, () =>
     portable(chat, candidates),
   )
-  const pending = budget.chat(value)
+  let pending: Pending | undefined
+  if (allowPartial) budget.preflightChat(value)
+  else pending = budget.chat(value)
   const images: Array<{
     metadata: ReturnType<typeof sanitizeNativeBackupImage>
     bytes: Uint8Array
@@ -463,7 +475,8 @@ async function collectChat(
           sizeBytes: bytes.length,
         }),
       )
-      budget.image(pending, metadata, bytes)
+      if (allowPartial) budget.imageSize(bytes)
+      else budget.image(pending!, metadata, bytes)
       images.push({ metadata, bytes })
     } catch (error) {
       if (
@@ -476,7 +489,12 @@ async function collectChat(
     }
   }
   if (omitted.length) removeOmittedImageReferences(value, omitted, images)
-  return { chat: value, images, pending, omitted }
+  if (allowPartial) {
+    pending = budget.chat(value)
+    for (const image of images)
+      budget.image(pending, image.metadata, image.bytes)
+  }
+  return { chat: value, images, pending: pending!, omitted }
 }
 
 function removeOmittedImageReferences(

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -195,9 +195,8 @@ async function mapLimitInOrder<T, R>(
   fn: (value: T) => Promise<R>,
   consume: (result: R) => void,
   signal?: AbortSignal,
-): Promise<void> {
-  type Settled = { ok: true; value: R } | { ok: false; error: unknown }
-  const started = new Map<number, Promise<Settled>>()
+): Promise<R[]> {
+  const output = new Array<R>(values.length)
   let nextIndex = 0
   let stopped = false
   let firstError: unknown
@@ -206,36 +205,26 @@ async function mapLimitInOrder<T, R>(
     stopped = true
     firstError = error
   }
-  const start = () => {
-    const index = nextIndex++
-    started.set(
-      index,
-      Promise.resolve()
-        .then(() => fn(values[index]))
-        .then(
-          (value) => ({ ok: true as const, value }),
-          (error: unknown) => {
-            stop(error)
-            return { ok: false as const, error }
-          },
-        ),
-    )
-  }
-  while (nextIndex < Math.min(concurrency, values.length)) start()
-  try {
-    for (let index = 0; index < values.length; index++) {
-      const result = await wait(signal, () => started.get(index)!)
-      started.delete(index)
-      if (stopped) throw firstError
-      if (!result.ok) throw result.error
-      consume(result.value)
-      if (!stopped && nextIndex < values.length) start()
+  const worker = async () => {
+    while (!stopped) {
+      const index = nextIndex++
+      if (index >= values.length) return
+      try {
+        const result = await wait(signal, () => fn(values[index]))
+        if (stopped) return
+        consume(result)
+        output[index] = result
+      } catch (error) {
+        stop(error)
+        return
+      }
     }
-  } catch (error) {
-    stop(error)
-    await Promise.all(started.values())
-    throw firstError
   }
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, worker),
+  )
+  if (stopped) throw firstError
+  return output
 }
 type Pending = [number, number, number, number, number]
 const budgetLimits: Array<[string, number]> = [
@@ -451,35 +440,18 @@ async function collectChat(
     candidate: NativeBackupImageCandidate
     failure: NativeBackupCollectionError
   }> = []
-  const partialPending = (prospective: SuccessfulImage[]): Pending => {
-    const progressiveValue = structuredClone(value)
-    for (const image of prospective) {
-      if (image.candidate.legacyIndex !== undefined)
-        progressiveValue.messages[image.candidate.messageIndex].imageData![
-          image.candidate.legacyIndex
-        ].mimeType = image.mimeType
-    }
-    const included = new Set(
-      prospective.map(({ candidate }) => candidate.sourceKey),
-    )
-    const progressiveImages = prospective.map(({ metadata, bytes }) => ({
-      metadata: structuredClone(metadata),
-      bytes,
-    }))
+  if (allowPartial) {
+    const allImagesOmitted = structuredClone(value)
     removeOmittedImageReferences(
-      progressiveValue,
-      candidates
-        .filter(({ sourceKey }) => !included.has(sourceKey))
-        .map((candidate) => ({ candidate })),
-      progressiveImages,
+      allImagesOmitted,
+      candidates.map((candidate) => ({ candidate })),
+      [],
     )
-    const nextPending = budget.chat(progressiveValue)
-    for (const image of progressiveImages)
-      budget.image(nextPending, image.metadata, image.bytes)
-    return nextPending
+    pending = budget.chat(allImagesOmitted)
+  } else {
+    pending = budget.chat(value)
   }
-  pending = allowPartial ? partialPending([]) : budget.chat(value)
-  await mapLimitInOrder(
+  const results = await mapLimitInOrder(
     candidates,
     ATTACHMENT_DOWNLOAD_CONCURRENCY,
     async (candidate) => {
@@ -554,25 +526,22 @@ async function collectChat(
       }
     },
     (result) => {
-      if (result.failure) {
-        omitted.push({ candidate: result.candidate, failure: result.failure })
-        return
-      }
-      const { candidate, bytes, metadata, mimeType } = result
-      if (allowPartial)
-        pending = partialPending([
-          ...successful,
-          { candidate, bytes, metadata, mimeType },
-        ])
-      else budget.image(pending!, metadata, bytes)
-      if (candidate.legacyIndex !== undefined)
-        value.messages[candidate.messageIndex].imageData![
-          candidate.legacyIndex
-        ].mimeType = mimeType
-      successful.push({ candidate, bytes, metadata, mimeType })
+      if (!result.failure) budget.image(pending!, result.metadata, result.bytes)
     },
     signal,
   )
+  for (const result of results) {
+    if (result.failure) {
+      omitted.push({ candidate: result.candidate, failure: result.failure })
+      continue
+    }
+    const { candidate, bytes, metadata, mimeType } = result
+    if (candidate.legacyIndex !== undefined)
+      value.messages[candidate.messageIndex].imageData![
+        candidate.legacyIndex
+      ].mimeType = mimeType
+    successful.push({ candidate, bytes, metadata, mimeType })
+  }
   const images = successful.map(({ metadata, bytes }) => ({ metadata, bytes }))
   if (omitted.length) removeOmittedImageReferences(value, omitted, images)
   if (allowPartial) {

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -193,31 +193,49 @@ async function mapLimitInOrder<T, R>(
   values: readonly T[],
   concurrency: number,
   fn: (value: T) => Promise<R>,
+  consume: (result: R) => void,
   signal?: AbortSignal,
-): Promise<R[]> {
-  const output = new Array<R>(values.length)
+): Promise<void> {
+  type Settled = { ok: true; value: R } | { ok: false; error: unknown }
+  const started = new Map<number, Promise<Settled>>()
   let nextIndex = 0
   let stopped = false
   let firstError: unknown
-  await Promise.all(
-    Array.from({ length: Math.min(concurrency, values.length) }, async () => {
-      while (nextIndex < values.length && !stopped) {
-        const index = nextIndex++
-        try {
-          signal?.throwIfAborted()
-          output[index] = await fn(values[index])
-          signal?.throwIfAborted()
-        } catch (error) {
-          if (!stopped) {
-            stopped = true
-            firstError = error
-          }
-        }
-      }
-    }),
-  )
-  if (stopped) throw firstError
-  return output
+  const stop = (error: unknown) => {
+    if (stopped) return
+    stopped = true
+    firstError = error
+  }
+  const start = () => {
+    const index = nextIndex++
+    started.set(
+      index,
+      Promise.resolve()
+        .then(() => fn(values[index]))
+        .then(
+          (value) => ({ ok: true as const, value }),
+          (error: unknown) => {
+            stop(error)
+            return { ok: false as const, error }
+          },
+        ),
+    )
+  }
+  while (nextIndex < Math.min(concurrency, values.length)) start()
+  try {
+    for (let index = 0; index < values.length; index++) {
+      const result = await wait(signal, () => started.get(index)!)
+      started.delete(index)
+      if (stopped) throw firstError
+      if (!result.ok) throw result.error
+      consume(result.value)
+      if (!stopped && nextIndex < values.length) start()
+    }
+  } catch (error) {
+    stop(error)
+    await Promise.all(started.values())
+    throw firstError
+  }
 }
 type Pending = [number, number, number, number, number]
 const budgetLimits: Array<[string, number]> = [
@@ -243,13 +261,6 @@ class Budget {
     const pending: Pending = [value.messages.length, count, bytes, bytes, 1]
     this.check(pending)
     return pending
-  }
-  preflightChat(value: ReturnType<typeof sanitizeNativeBackupChat>) {
-    this.limit(
-      'message',
-      this.used[0] + value.messages.length,
-      NATIVE_BACKUP_LIMITS.messages,
-    )
   }
   imageSize(bytes: Uint8Array) {
     this.limit('image size', bytes.length, NATIVE_BACKUP_LIMITS.imageBytes)
@@ -428,18 +439,47 @@ async function collectChat(
   const value = valid(cloud ? 'cloud chat' : 'local chat', chat.id, () =>
     portable(chat, candidates),
   )
-  let pending: Pending | undefined
-  if (allowPartial) budget.preflightChat(value)
-  else pending = budget.chat(value)
-  const images: Array<{
+  type SuccessfulImage = {
+    candidate: NativeBackupImageCandidate
     metadata: ReturnType<typeof sanitizeNativeBackupImage>
     bytes: Uint8Array
-  }> = []
+    mimeType: string
+  }
+  let pending: Pending | undefined
+  const successful: SuccessfulImage[] = []
   const omitted: Array<{
     candidate: NativeBackupImageCandidate
     failure: NativeBackupCollectionError
   }> = []
-  const results = await mapLimitInOrder(
+  const partialPending = (prospective: SuccessfulImage[]): Pending => {
+    const progressiveValue = structuredClone(value)
+    for (const image of prospective) {
+      if (image.candidate.legacyIndex !== undefined)
+        progressiveValue.messages[image.candidate.messageIndex].imageData![
+          image.candidate.legacyIndex
+        ].mimeType = image.mimeType
+    }
+    const included = new Set(
+      prospective.map(({ candidate }) => candidate.sourceKey),
+    )
+    const progressiveImages = prospective.map(({ metadata, bytes }) => ({
+      metadata: structuredClone(metadata),
+      bytes,
+    }))
+    removeOmittedImageReferences(
+      progressiveValue,
+      candidates
+        .filter(({ sourceKey }) => !included.has(sourceKey))
+        .map((candidate) => ({ candidate })),
+      progressiveImages,
+    )
+    const nextPending = budget.chat(progressiveValue)
+    for (const image of progressiveImages)
+      budget.image(nextPending, image.metadata, image.bytes)
+    return nextPending
+  }
+  pending = allowPartial ? partialPending([]) : budget.chat(value)
+  await mapLimitInOrder(
     candidates,
     ATTACHMENT_DOWNLOAD_CONCURRENCY,
     async (candidate) => {
@@ -513,21 +553,27 @@ async function collectChat(
         return { candidate, failure: error }
       }
     },
+    (result) => {
+      if (result.failure) {
+        omitted.push({ candidate: result.candidate, failure: result.failure })
+        return
+      }
+      const { candidate, bytes, metadata, mimeType } = result
+      if (allowPartial)
+        pending = partialPending([
+          ...successful,
+          { candidate, bytes, metadata, mimeType },
+        ])
+      else budget.image(pending!, metadata, bytes)
+      if (candidate.legacyIndex !== undefined)
+        value.messages[candidate.messageIndex].imageData![
+          candidate.legacyIndex
+        ].mimeType = mimeType
+      successful.push({ candidate, bytes, metadata, mimeType })
+    },
     signal,
   )
-  for (const result of results) {
-    if (result.failure) {
-      omitted.push({ candidate: result.candidate, failure: result.failure })
-      continue
-    }
-    const { candidate, bytes, metadata, mimeType } = result
-    if (candidate.legacyIndex !== undefined)
-      value.messages[candidate.messageIndex].imageData![
-        candidate.legacyIndex
-      ].mimeType = mimeType
-    if (!allowPartial) budget.image(pending!, metadata, bytes)
-    images.push({ metadata, bytes })
-  }
+  const images = successful.map(({ metadata, bytes }) => ({ metadata, bytes }))
   if (omitted.length) removeOmittedImageReferences(value, omitted, images)
   if (allowPartial) {
     pending = budget.chat(value)

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -1,4 +1,4 @@
-import type { Attachment, Message } from '@/components/chat/types'
+import type { Attachment } from '@/components/chat/types'
 import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
 import {
   AuthTokenRefreshError,
@@ -6,7 +6,10 @@ import {
   authTokenManager,
 } from '@/services/auth'
 import { requirePrimaryKeyB64 } from '@/services/cloud/cek-encoding'
-import { cloudStorage } from '@/services/cloud/cloud-storage'
+import {
+  CloudBackupReadError,
+  cloudStorage,
+} from '@/services/cloud/cloud-storage'
 import { projectStorage } from '@/services/cloud/project-storage'
 import {
   indexedDBStorage,
@@ -15,10 +18,17 @@ import {
 import { SyncEnclaveError } from '@/services/sync-enclave'
 import type { Project, ProjectDocument } from '@/types/project'
 import { base64ToUint8Array } from '@/utils/binary-codec'
+import { z } from 'zod'
 import { NATIVE_BACKUP_LIMITS } from './constants'
-import type { NativeBackupV1Input } from './format'
+import {
+  deriveNativeBackupWarnings,
+  type NativeBackupOmission,
+  type NativeBackupV1Input,
+  type NativeBackupV2Input,
+} from './format'
 import { detectNativeBackupImageMimeType } from './image-mime'
 import {
+  NativeBackupDataValidationError,
   classifyNativeBackupChat,
   sanitizeNativeBackupChat,
   sanitizeNativeBackupImage,
@@ -29,6 +39,7 @@ import {
 } from './sanitize'
 const PAGE_SIZE = 500
 const CONCURRENCY = 4
+const STABLE_READ_ATTEMPTS = 3
 const encoder = new TextEncoder()
 type Listed = { id: string; syncVersion: number }
 type Timed = Listed & { createdAt: string; updatedAt: string }
@@ -53,6 +64,14 @@ export class NativeBackupCollectionError extends Error {
     public readonly kind: string,
     public readonly recordId: string,
     detail: string,
+    public readonly category:
+      | 'deleted'
+      | 'unavailable'
+      | 'invalid'
+      | 'unstable'
+      | 'systemic' = 'systemic',
+    public readonly reason = 'collection_failed',
+    public readonly omittable = false,
   ) {
     super(`Native backup collection failed for ${kind} ${recordId}: ${detail}`)
     this.name = 'NativeBackupCollectionError'
@@ -76,12 +95,8 @@ const defaults: NativeBackupCollectionDependencies = {
     })
     return { items: page.conversations, next: page.nextContinuationToken }
   },
-  getCloudChat: (id) => cloudStorage.downloadChat(id),
-  getCloudImage: async (value) => {
-    const message = { attachments: [value] } as Message
-    const encoded = (await cloudStorage.loadChatImages('', [message]))[value.id]
-    return encoded ? base64ToUint8Array(encoded) : null
-  },
+  getCloudChat: (id) => cloudStorage.downloadChatForBackup(id),
+  getCloudImage: (value) => cloudStorage.loadChatImageForBackup(value),
   listProjects: async (continuationToken) => {
     const page = await projectStorage.listProjects({
       limit: PAGE_SIZE,
@@ -89,15 +104,32 @@ const defaults: NativeBackupCollectionDependencies = {
     })
     return { items: page.projects, next: page.nextContinuationToken }
   },
-  getProject: (id) => projectStorage.getProject(id),
+  getProject: (id) => projectStorage.getProjectForBackup(id),
   listDocuments: async (id) =>
     (await projectStorage.listDocuments(id)).documents,
-  getDocument: (projectId, id) => projectStorage.getDocument(projectId, id),
+  getDocument: (projectId, id) =>
+    projectStorage.getDocumentForBackup(projectId, id),
   getLocalChats: () => indexedDBStorage.getAllChats(),
   getLocalChat: (id) => indexedDBStorage.getChat(id),
 }
 function fail(kind: string, id: string, detail: string): never {
   throw new NativeBackupCollectionError(kind, id, detail)
+}
+function failItem(
+  kind: string,
+  id: string,
+  detail: string,
+  category: NativeBackupOmission['category'],
+  reason: string,
+): never {
+  throw new NativeBackupCollectionError(
+    kind,
+    id,
+    detail,
+    category,
+    reason,
+    true,
+  )
 }
 async function wait<T>(s: AbortSignal | undefined, read: () => Promise<T>) {
   s?.throwIfAborted()
@@ -114,7 +146,18 @@ function valid<T>(kind: string, id: string, parse: () => T): T {
     return parse()
   } catch (error) {
     if (error instanceof NativeBackupCollectionError) throw error
-    return fail(kind, id, `record is invalid: ${detail(error)}`)
+    if (
+      !(error instanceof NativeBackupDataValidationError) &&
+      !(error instanceof z.ZodError)
+    )
+      throw error
+    return failItem(
+      kind,
+      id,
+      `record is invalid: ${detail(error)}`,
+      'invalid',
+      'record_invalid',
+    )
   }
 }
 function unique<T extends Listed>(
@@ -140,15 +183,90 @@ function throwIfAuthenticationError(error: unknown) {
 async function pages<T extends Listed>(
   fn: (t?: string) => Page<T>,
   s?: AbortSignal,
+  onDiscovered?: (count: number) => void,
 ) {
   const values: T[] = []
   let token: string | undefined
   do {
     const page = await wait(s, () => fn(token))
+    onDiscovered?.(page.items.length)
     values.push(...page.items)
     token = page.next
   } while (token)
   return unique(values)
+}
+type CloudInventory = {
+  chats: Listed[]
+  projects: Timed[]
+  documents: DocumentItem[]
+  discovered: number
+}
+async function discoverCloudInventory(
+  deps: NativeBackupCollectionDependencies,
+  signal?: AbortSignal,
+): Promise<CloudInventory> {
+  let discovered = 0
+  const add = (count: number) => {
+    signal?.throwIfAborted()
+    discovered += count
+    if (discovered > NATIVE_BACKUP_LIMITS.discoveredRecords)
+      fail('limits', 'collection', 'discovered record limit exceeded')
+  }
+  const [chats, projects] = await Promise.all([
+    pages(deps.listChats, signal, add),
+    pages(deps.listProjects, signal, add),
+  ])
+  const documents = unique(
+    (
+      await mapLimit(
+        projects,
+        async ({ id }) => {
+          const items = await deps.listDocuments(id)
+          add(items.length)
+          return items
+        },
+        signal,
+      )
+    ).flat(),
+    ({ projectId, id }) => JSON.stringify([projectId, id]),
+  )
+  return { chats, projects, documents, discovered }
+}
+function inventoryToken(inventory: CloudInventory): string {
+  const keys = [
+    ...inventory.chats.map(({ id, syncVersion }) => ['chat', id, syncVersion]),
+    ...inventory.projects.map(({ id, syncVersion }) => [
+      'project',
+      id,
+      syncVersion,
+    ]),
+    ...inventory.documents.map(({ projectId, id, syncVersion }) => [
+      'document',
+      projectId,
+      id,
+      syncVersion,
+    ]),
+  ]
+  keys.sort((left, right) => {
+    const a = JSON.stringify(left)
+    const b = JSON.stringify(right)
+    return a < b ? -1 : a > b ? 1 : 0
+  })
+  return JSON.stringify(keys)
+}
+async function refreshListed<T extends Listed>(
+  kind: string,
+  id: string,
+  refresh: () => Promise<T[]>,
+  signal?: AbortSignal,
+): Promise<T> {
+  for (let attempt = 0; attempt < STABLE_READ_ATTEMPTS; attempt++) {
+    const item = unique(await wait(signal, refresh)).find(
+      (candidate) => candidate.id === id,
+    )
+    if (item) return item
+  }
+  return failItem(kind, id, 'record was deleted', 'deleted', 'record_deleted')
 }
 async function mapLimit<T, R>(
   v: T[],
@@ -201,9 +319,13 @@ class Budget {
     pending[4] += 2
     this.check(pending)
   }
-  json(value: unknown) {
+  json(value: unknown, entity = false) {
     const bytes = jsonSize(value)
-    this.commit([0, 0, bytes, bytes, 1])
+    this.commit([0, 0, bytes, bytes, 1], entity)
+  }
+  metadata(value: unknown) {
+    const bytes = jsonSize(value) + 1
+    this.commit([0, 0, bytes, bytes, 0])
   }
   commit(value: Pending, entity = false) {
     if (entity) this.entities(1)
@@ -224,16 +346,48 @@ async function readRecord<T>(
   id: string,
   read: () => Promise<T | null>,
   signal?: AbortSignal,
+  missing: {
+    detail: string
+    category: NativeBackupOmission['category']
+    reason: string
+  } = {
+    detail: 'record is missing',
+    category: 'deleted',
+    reason: 'record_not_found',
+  },
 ) {
-  try {
-    const value = await wait(signal, read)
-    return value ?? fail(kind, id, 'record is missing or invalid')
-  } catch (error) {
-    signal?.throwIfAborted()
-    throwIfAuthenticationError(error)
-    if (error instanceof NativeBackupCollectionError) throw error
-    return fail(kind, id, `read failed: ${detail(error)}`)
+  let lastError: NativeBackupCollectionError | undefined
+  for (let attempt = 0; attempt < STABLE_READ_ATTEMPTS; attempt++) {
+    try {
+      const value = await wait(signal, read)
+      return (
+        value ??
+        failItem(kind, id, missing.detail, missing.category, missing.reason)
+      )
+    } catch (error) {
+      signal?.throwIfAborted()
+      throwIfAuthenticationError(error)
+      if (error instanceof CloudBackupReadError) {
+        if (!error.omittable) throw error
+        lastError = new NativeBackupCollectionError(
+          kind,
+          id,
+          'record could not be decoded',
+          error.category === 'item_invalid' ? 'invalid' : 'unavailable',
+          error.reason,
+          true,
+        )
+      } else if (
+        error instanceof NativeBackupCollectionError &&
+        error.omittable
+      ) {
+        lastError = error
+      } else {
+        throw error
+      }
+    }
   }
+  throw lastError!
 }
 async function stable<T extends { syncVersion?: number }, I extends Listed>(
   kind: string,
@@ -243,14 +397,18 @@ async function stable<T extends { syncVersion?: number }, I extends Listed>(
   signal?: AbortSignal,
 ): Promise<{ value: T; item: I }> {
   let item = initial
-  for (let attempt = 0; attempt < 2; attempt++) {
+  for (let attempt = 0; attempt < STABLE_READ_ATTEMPTS; attempt++) {
     const value = await readRecord(kind, item.id, read, signal)
     if (value.syncVersion === item.syncVersion) return { value, item }
-    item =
-      unique(await wait(signal, refresh)).find(({ id }) => id === item.id) ??
-      fail(kind, item.id, 'record is missing or invalid')
+    item = await refreshListed(kind, item.id, refresh, signal)
   }
-  return fail(kind, item.id, 'version changed during collection')
+  return failItem(
+    kind,
+    item.id,
+    'version changed during collection',
+    'unstable',
+    'version_did_not_converge',
+  )
 }
 async function timed<T extends { syncVersion?: number }, I extends Timed, R>(
   kind: string,
@@ -269,7 +427,7 @@ async function timed<T extends { syncVersion?: number }, I extends Timed, R>(
       updatedAt: current.item.updatedAt,
     }),
   )
-  budget.json(value)
+  budget.json(value, true)
   return value
 }
 function portable(chat: StoredChat, images?: NativeBackupImageCandidate[]) {
@@ -313,21 +471,45 @@ function localEligible(chat: StoredChat, userId: string) {
       'local'
   )
 }
+function localInventoryToken(chats: StoredChat[], userId: string): string {
+  const values = chats.flatMap((chat) => {
+    if (!localEligible(chat, userId)) return []
+    try {
+      return [[chat.id, localToken(chat)]]
+    } catch (error) {
+      if (error instanceof NativeBackupCollectionError && error.omittable)
+        return [[chat.id, error.category, error.reason]]
+      throw error
+    }
+  })
+  values.sort((left, right) =>
+    left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0,
+  )
+  return JSON.stringify(values)
+}
 async function collectChat(
   chat: StoredChat,
   cloud: boolean,
   deps: NativeBackupCollectionDependencies,
   budget: Budget,
   signal?: AbortSignal,
+  allowPartial = false,
 ) {
   const candidates: NativeBackupImageCandidate[] = []
   const value = valid(cloud ? 'cloud chat' : 'local chat', chat.id, () =>
     portable(chat, candidates),
   )
   const pending = budget.chat(value)
-  const images = await mapLimit(
-    candidates,
-    async (candidate) => {
+  const images: Array<{
+    metadata: ReturnType<typeof sanitizeNativeBackupImage>
+    bytes: Uint8Array
+  }> = []
+  const omitted: Array<{
+    candidate: NativeBackupImageCandidate
+    failure: NativeBackupCollectionError
+  }> = []
+  for (const candidate of candidates) {
+    try {
       const attachment =
         candidate.attachmentIndex === undefined
           ? undefined
@@ -337,20 +519,58 @@ async function collectChat(
       const base64 = imagePayload(chat, candidate)
       let bytes: Uint8Array | null = null
       try {
-        bytes = base64
-          ? base64ToUint8Array(base64)
-          : cloud && attachment
-            ? await wait(signal, () => deps.getCloudImage(attachment))
-            : null
+        if (base64) {
+          try {
+            bytes = base64ToUint8Array(base64)
+          } catch (error) {
+            if (
+              !(error instanceof Error) ||
+              error.name !== 'InvalidCharacterError'
+            )
+              throw error
+            failItem(
+              'image',
+              candidate.sourceKey,
+              'image bytes are invalid',
+              'invalid',
+              'attachment_payload_invalid',
+            )
+          }
+        } else if (cloud && attachment) {
+          bytes = await readRecord(
+            'image',
+            candidate.sourceKey,
+            () => deps.getCloudImage(attachment),
+            signal,
+            {
+              detail: 'image bytes are missing',
+              category: 'unavailable',
+              reason: 'attachment_not_found',
+            },
+          )
+        }
       } catch (error) {
         signal?.throwIfAborted()
         throwIfAuthenticationError(error)
-        fail('image', candidate.sourceKey, 'image bytes are invalid')
+        throw error
       }
-      if (!bytes) fail('image', candidate.sourceKey, 'image bytes are missing')
+      if (!bytes)
+        failItem(
+          'image',
+          candidate.sourceKey,
+          'image bytes are missing',
+          'unavailable',
+          'attachment_not_found',
+        )
       const mimeType =
         detectNativeBackupImageMimeType(bytes) ??
-        fail('image', candidate.sourceKey, 'image type is unsupported')
+        failItem(
+          'image',
+          candidate.sourceKey,
+          'image type is unsupported',
+          'invalid',
+          'attachment_type_unsupported',
+        )
       if (candidate.legacyIndex !== undefined)
         value.messages[candidate.messageIndex].imageData![
           candidate.legacyIndex
@@ -364,11 +584,77 @@ async function collectChat(
         }),
       )
       budget.image(pending, metadata, bytes)
-      return { metadata, bytes }
-    },
-    signal,
+      images.push({ metadata, bytes })
+    } catch (error) {
+      if (
+        !allowPartial ||
+        !(error instanceof NativeBackupCollectionError) ||
+        !error.omittable
+      )
+        throw error
+      omitted.push({ candidate, failure: error })
+    }
+  }
+  if (omitted.length) removeOmittedImageReferences(value, omitted, images)
+  return { chat: value, images, pending, omitted }
+}
+
+function removeOmittedImageReferences(
+  chat: ReturnType<typeof sanitizeNativeBackupChat>,
+  omitted: Array<{ candidate: NativeBackupImageCandidate }>,
+  images: Array<{ metadata: ReturnType<typeof sanitizeNativeBackupImage> }>,
+) {
+  const candidates = omitted.map(({ candidate }) => candidate)
+  const pageCandidates = candidates.filter(
+    ({ page, legacyIndex }) => page !== undefined && legacyIndex === undefined,
   )
-  return { chat: value, images, pending }
+  for (const candidate of pageCandidates) {
+    const message = chat.messages[candidate.messageIndex]
+    const attachment = message.attachments?.[candidate.attachmentIndex!]
+    if (attachment?.type === 'document') {
+      const page = attachment.pages?.find(({ page }) => page === candidate.page)
+      if (page) delete page.imageId
+    }
+  }
+
+  const directCandidates = candidates
+    .filter(
+      ({ attachmentIndex, page, legacyIndex }) =>
+        attachmentIndex !== undefined &&
+        page === undefined &&
+        legacyIndex === undefined,
+    )
+    .sort(
+      (left, right) =>
+        right.messageIndex - left.messageIndex ||
+        right.attachmentIndex! - left.attachmentIndex!,
+    )
+  for (const candidate of directCandidates)
+    chat.messages[candidate.messageIndex].attachments?.splice(
+      candidate.attachmentIndex!,
+      1,
+    )
+
+  const legacyCandidates = candidates
+    .filter(({ legacyIndex }) => legacyIndex !== undefined)
+    .sort(
+      (left, right) =>
+        right.messageIndex - left.messageIndex ||
+        right.legacyIndex! - left.legacyIndex!,
+    )
+  for (const candidate of legacyCandidates)
+    chat.messages[candidate.messageIndex].imageData?.splice(
+      candidate.legacyIndex!,
+      1,
+    )
+  for (const { metadata } of images) {
+    if (metadata.legacyIndex === undefined) continue
+    metadata.legacyIndex -= legacyCandidates.filter(
+      (candidate) =>
+        candidate.messageIndex === metadata.messageIndex &&
+        candidate.legacyIndex! < metadata.legacyIndex!,
+    ).length
+  }
 }
 async function retryChat<K>(
   kind: string,
@@ -381,7 +667,7 @@ async function retryChat<K>(
   collect: (chat: StoredChat) => ReturnType<typeof collectChat>,
   signal?: AbortSignal,
 ) {
-  for (let attempt = 0; attempt < 2; attempt++) {
+  for (let attempt = 0; attempt < STABLE_READ_ATTEMPTS; attempt++) {
     const chat = await readRecord(kind, id, read, signal)
     const current = revision(chat)
     if (current !== expected) {
@@ -394,12 +680,22 @@ async function retryChat<K>(
     if (revision(verify) === current) return result
     expected = await wait(signal, () => refresh(verify))
   }
-  return fail(kind, id, 'version changed during collection')
+  return failItem(
+    kind,
+    id,
+    'version changed during collection',
+    'unstable',
+    'version_did_not_converge',
+  )
 }
-export async function collectNativeBackupV1(
+
+async function collectNativeBackup(
   deps: NativeBackupCollectionDependencies = defaults,
   signal?: AbortSignal,
-): Promise<NativeBackupV1Input> {
+  allowPartial = false,
+  inventoryAttempt = 0,
+  localInventoryAttempt = 0,
+): Promise<NativeBackupV2Input> {
   if (!(await wait(signal, () => deps.isAuthenticated())))
     fail('account', 'active', 'signed-in user is required')
   const userId = deps.activeUserId()
@@ -409,87 +705,171 @@ export async function collectNativeBackupV1(
   } catch {
     fail('account', userId, 'cloud encryption key is locked or unavailable')
   }
-  const [chatItems, projectItems, localSnapshots] = await Promise.all([
-    pages(deps.listChats, signal),
-    pages(deps.listProjects, signal),
+  const [inventory, localSnapshots] = await Promise.all([
+    discoverCloudInventory(deps, signal),
     wait(signal, () => deps.getLocalChats()),
   ])
-  const documentItems = unique(
-    (
-      await mapLimit(projectItems, ({ id }) => deps.listDocuments(id), signal)
-    ).flat(),
-    ({ projectId, id }) => JSON.stringify([projectId, id]),
+  if (
+    inventory.discovered + localSnapshots.length >
+    NATIVE_BACKUP_LIMITS.discoveredRecords
   )
+    fail('limits', 'collection', 'discovered record limit exceeded')
+  const chatItems = inventory.chats
+  const projectItems = inventory.projects
+  const allDocumentItems = inventory.documents
+  const initialLocalInventoryToken = localInventoryToken(localSnapshots, userId)
   const budget = new Budget()
-  budget.entities(projectItems.length + documentItems.length)
-  const projects = await mapLimit(
-    projectItems,
-    (item) =>
-      timed(
-        'project',
-        item,
-        () => deps.getProject(item.id),
-        () => pages(deps.listProjects, signal),
-        sanitizeNativeBackupProject,
-        budget,
-        signal,
-      ),
-    signal,
+  const omissions: NativeBackupOmission[] = []
+  const addOmission = (omission: NativeBackupOmission) => {
+    signal?.throwIfAborted()
+    if (omissions.length >= NATIVE_BACKUP_LIMITS.omissions)
+      fail('limits', 'collection', 'omission limit exceeded')
+    budget.metadata(omission)
+    omissions.push(omission)
+  }
+  const omit = (
+    kind: NativeBackupOmission['kind'],
+    sourceId: string,
+    error: unknown,
+    parentSourceId?: string,
+  ) => {
+    if (
+      !allowPartial ||
+      !(error instanceof NativeBackupCollectionError) ||
+      !error.omittable
+    )
+      throw error
+    addOmission({
+      kind,
+      source_id: sourceId,
+      ...(parentSourceId ? { parent_source_id: parentSourceId } : {}),
+      category: error.category as NativeBackupOmission['category'],
+      reason: error.reason,
+    })
+  }
+  const projects = []
+  for (const item of projectItems) {
+    try {
+      projects.push(
+        await timed(
+          'project',
+          item,
+          () => deps.getProject(item.id),
+          () => pages(deps.listProjects, signal),
+          sanitizeNativeBackupProject,
+          budget,
+          signal,
+        ),
+      )
+    } catch (error) {
+      omit('project', item.id, error)
+    }
+  }
+  const includedProjectIds = new Set(projects.map(({ id }) => id))
+  const documentItems = allDocumentItems.filter(({ projectId }) =>
+    includedProjectIds.has(projectId),
   )
-  const projectDocuments = await mapLimit(
-    documentItems,
-    (item) =>
-      timed(
-        'project document',
-        item,
-        () => deps.getDocument(item.projectId, item.id),
-        () => deps.listDocuments(item.projectId),
-        sanitizeNativeBackupProjectDocument,
-        budget,
-        signal,
-      ),
-    signal,
-  )
+  const projectDocuments = []
+  for (const item of documentItems) {
+    try {
+      projectDocuments.push(
+        await timed(
+          'project document',
+          item,
+          () => deps.getDocument(item.projectId, item.id),
+          () => deps.listDocuments(item.projectId),
+          sanitizeNativeBackupProjectDocument,
+          budget,
+          signal,
+        ),
+      )
+    } catch (error) {
+      omit('project_document', item.id, error, item.projectId)
+    }
+  }
+  for (const item of projectItems.filter(
+    ({ id }) => !includedProjectIds.has(id),
+  )) {
+    for (const document of allDocumentItems.filter(
+      ({ projectId }) => projectId === item.id,
+    ))
+      addOmission({
+        kind: 'project_document',
+        source_id: document.id,
+        parent_source_id: item.id,
+        category: 'unavailable',
+        reason: 'parent_project_omitted',
+      })
+  }
   const cloudResults = []
   for (const listed of chatItems) {
-    const result = await retryChat(
-      'cloud chat',
-      listed.id,
-      listed.syncVersion,
-      () => deps.getCloudChat(listed.id),
-      ({ syncVersion }) => syncVersion,
-      (chat) => classifyNativeBackupChat(chat, 'cloud') !== null,
-      async () =>
-        (await pages(deps.listChats, signal)).find(({ id }) => id === listed.id)
-          ?.syncVersion ??
-        fail('cloud chat', listed.id, 'record is missing or invalid'),
-      (chat) => collectChat(chat, true, deps, budget, signal),
-      signal,
-    )
-    if (!result) continue
-    budget.commit(result.pending, true)
-    cloudResults.push(result)
+    try {
+      const result = await retryChat(
+        'cloud chat',
+        listed.id,
+        listed.syncVersion,
+        () => deps.getCloudChat(listed.id),
+        ({ syncVersion }) => syncVersion,
+        (chat) => classifyNativeBackupChat(chat, 'cloud') !== null,
+        async () =>
+          (
+            await refreshListed(
+              'cloud chat',
+              listed.id,
+              () => pages(deps.listChats, signal),
+              signal,
+            )
+          ).syncVersion,
+        (chat) => collectChat(chat, true, deps, budget, signal, allowPartial),
+        signal,
+      )
+      if (!result) continue
+      budget.commit(result.pending, true)
+      cloudResults.push(result)
+      for (const { failure } of result.omitted)
+        omit('attachment', failure.recordId, failure, listed.id)
+    } catch (error) {
+      omit('cloud_chat', listed.id, error)
+    }
   }
   const localResults = []
   for (const snapshot of localSnapshots) {
     if (!localEligible(snapshot, userId)) continue
-    const result = await retryChat(
-      'local chat',
-      snapshot.id,
-      localToken(snapshot),
-      () => deps.getLocalChat(snapshot.id),
-      localToken,
-      (chat) => localEligible(chat, userId),
-      async (chat) => localToken(chat),
-      (chat) => collectChat(chat, false, deps, budget, signal),
-      signal,
-    )
-    if (!result) continue
-    budget.commit(result.pending, true)
-    localResults.push(result)
+    try {
+      const result = await retryChat(
+        'local chat',
+        snapshot.id,
+        localToken(snapshot),
+        () => deps.getLocalChat(snapshot.id),
+        localToken,
+        (chat) => localEligible(chat, userId),
+        async (chat) => localToken(chat),
+        (chat) => collectChat(chat, false, deps, budget, signal, allowPartial),
+        signal,
+      )
+      if (!result) continue
+      budget.commit(result.pending, true)
+      localResults.push(result)
+      for (const { failure } of result.omitted)
+        omit('attachment', failure.recordId, failure, snapshot.id)
+    } catch (error) {
+      omit('local_chat', snapshot.id, error)
+    }
   }
   const cloudChats = cloudResults.map(({ chat }) => chat)
   const localChats = localResults.map(({ chat }) => chat)
+  for (const chat of [...cloudChats, ...localChats]) {
+    if (chat.projectId && !includedProjectIds.has(chat.projectId)) {
+      addOmission({
+        kind: 'relationship',
+        source_id: chat.id,
+        parent_source_id: chat.projectId,
+        category: 'unavailable',
+        reason: 'project_reference_unavailable',
+      })
+      delete chat.projectId
+    }
+  }
   const images = [...cloudResults, ...localResults].flatMap(
     ({ images }) => images,
   )
@@ -507,7 +887,53 @@ export async function collectNativeBackupV1(
     })),
   })
   budget.json(relationships)
-  const input: NativeBackupV1Input = {
+  signal?.throwIfAborted()
+  const [finalInventory, finalLocalSnapshots] = await Promise.all([
+    discoverCloudInventory(deps, signal),
+    wait(signal, () => deps.getLocalChats()),
+  ])
+  if (
+    finalInventory.discovered + finalLocalSnapshots.length >
+    NATIVE_BACKUP_LIMITS.discoveredRecords
+  )
+    fail('limits', 'collection', 'discovered record limit exceeded')
+  const cloudChanged =
+    inventoryToken(finalInventory) !== inventoryToken(inventory)
+  const localChanged =
+    localInventoryToken(finalLocalSnapshots, userId) !==
+    initialLocalInventoryToken
+  if (cloudChanged) {
+    if (inventoryAttempt + 1 >= NATIVE_BACKUP_LIMITS.inventoryAttempts)
+      fail('inventory', 'cloud', 'cloud inventory did not converge')
+    return collectNativeBackup(
+      deps,
+      signal,
+      allowPartial,
+      inventoryAttempt + 1,
+      localChanged ? localInventoryAttempt + 1 : localInventoryAttempt,
+    )
+  }
+  if (localChanged) {
+    if (localInventoryAttempt + 1 < NATIVE_BACKUP_LIMITS.inventoryAttempts)
+      return collectNativeBackup(
+        deps,
+        signal,
+        allowPartial,
+        inventoryAttempt,
+        localInventoryAttempt + 1,
+      )
+    if (!allowPartial)
+      fail('inventory', 'local', 'local inventory did not converge')
+    addOmission({
+      kind: 'local_inventory',
+      source_id: 'eligible_local_chats',
+      category: 'unstable',
+      reason: 'inventory_did_not_converge',
+    })
+  }
+  const warnings = deriveNativeBackupWarnings(omissions)
+  for (const warning of warnings) budget.metadata(warning)
+  const input: NativeBackupV2Input = {
     backupId: crypto.randomUUID(),
     createdAt: new Date().toISOString(),
     projects,
@@ -516,7 +942,22 @@ export async function collectNativeBackupV1(
     localChats,
     relationships,
     images,
+    omissions,
+    warnings,
   }
-  signal?.throwIfAborted()
   return input
+}
+
+export async function collectNativeBackupV1(
+  deps: NativeBackupCollectionDependencies = defaults,
+  signal?: AbortSignal,
+): Promise<NativeBackupV1Input> {
+  return collectNativeBackup(deps, signal, false)
+}
+
+export async function collectNativeBackupV2(
+  deps: NativeBackupCollectionDependencies = defaults,
+  signal?: AbortSignal,
+): Promise<NativeBackupV2Input> {
+  return collectNativeBackup(deps, signal, true)
 }

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -50,7 +50,7 @@ const STABLE_READ_ATTEMPTS = 3
 const ATTACHMENT_DOWNLOAD_CONCURRENCY = 4
 // One enclave pull carries this many records. Bounds response size
 // while collapsing per-record round trips on large accounts.
-const CLOUD_PULL_BATCH_SIZE = 20
+export const CLOUD_PULL_BATCH_SIZE = 20
 const encoder = new TextEncoder()
 type CloudInventoryItem = BackupInventoryItem
 type DocumentItem = BackupInventoryItem & { project_id: string }

--- a/src/services/native-backup/constants.ts
+++ b/src/services/native-backup/constants.ts
@@ -1,10 +1,14 @@
 export const NATIVE_BACKUP_FORMAT = 'tinfoil-native-backup' as const
 export const NATIVE_BACKUP_VERSION = 1 as const
+export const NATIVE_BACKUP_VERSION_V2 = 2 as const
 
 export const NATIVE_BACKUP_LIMITS = {
   archiveBytes: 512 * 1024 * 1024,
   entries: 50_000,
   entities: 100_000,
+  discoveredRecords: 100_000,
+  omissions: 100_000,
+  inventoryAttempts: 3,
   messages: 2_000_000,
   attachments: 100_000,
   imageBytes: 32 * 1024 * 1024,

--- a/src/services/native-backup/constants.ts
+++ b/src/services/native-backup/constants.ts
@@ -8,7 +8,7 @@ export const NATIVE_BACKUP_LIMITS = {
   entities: 100_000,
   discoveredRecords: 100_000,
   omissions: 100_000,
-  inventoryAttempts: 3,
+  localInventoryAttempts: 3,
   messages: 2_000_000,
   attachments: 100_000,
   imageBytes: 32 * 1024 * 1024,

--- a/src/services/native-backup/export.ts
+++ b/src/services/native-backup/export.ts
@@ -1,7 +1,7 @@
 import * as auth from '@/services/auth'
 import { SyncEnclaveError } from '@/services/sync-enclave'
-import { collectNativeBackupV1, NativeBackupCollectionError } from './collect'
-import { formatNativeBackupV1 } from './format'
+import { collectNativeBackupV2, NativeBackupCollectionError } from './collect'
+import { formatNativeBackupV2 } from './format'
 import {
   NativeBackupWriterError,
   prepareNativeBackupArchiveDestination,
@@ -10,11 +10,18 @@ import {
 } from './write'
 
 export type NativeBackupExportProgress = 'collecting' | 'formatting' | 'writing'
+export type NativeBackupExportResult = {
+  complete: boolean
+  omitted: number
+  adjustedRelationships: number
+  localInventoryUnstable: boolean
+  warnings: number
+}
 
 export interface NativeBackupExportDependencies {
   prepare?: typeof prepareNativeBackupArchiveDestination
-  collect: (signal: AbortSignal) => ReturnType<typeof collectNativeBackupV1>
-  format: typeof formatNativeBackupV1
+  collect: (signal: AbortSignal) => ReturnType<typeof collectNativeBackupV2>
+  format: typeof formatNativeBackupV2
   write: typeof writeNativeBackupArchive
   download: (result: NativeBackupArchiveResult) => void
 }
@@ -33,8 +40,8 @@ const download = (result: NativeBackupArchiveResult) => {
 
 const defaults: NativeBackupExportDependencies = {
   prepare: prepareNativeBackupArchiveDestination,
-  collect: (signal) => collectNativeBackupV1(undefined, signal),
-  format: formatNativeBackupV1,
+  collect: (signal) => collectNativeBackupV2(undefined, signal),
+  format: formatNativeBackupV2,
   write: writeNativeBackupArchive,
   download,
 }
@@ -43,7 +50,7 @@ export async function runNativeBackupExport(
   signal: AbortSignal,
   onProgress: (progress: NativeBackupExportProgress) => void,
   dependencies: NativeBackupExportDependencies = defaults,
-): Promise<void> {
+): Promise<NativeBackupExportResult> {
   signal.throwIfAborted()
   const destination = await dependencies.prepare?.()
   signal.throwIfAborted()
@@ -57,6 +64,21 @@ export async function runNativeBackupExport(
   const result = await dependencies.write(formatted, { signal, destination })
   if (result.kind === 'blob') signal.throwIfAborted()
   dependencies.download(result)
+  const omitted = collected.omissions.filter(
+    ({ kind }) => kind !== 'relationship' && kind !== 'local_inventory',
+  ).length
+  const adjustedRelationships = collected.omissions.filter(
+    ({ kind }) => kind === 'relationship',
+  ).length
+  return {
+    complete: collected.omissions.length === 0,
+    omitted,
+    adjustedRelationships,
+    localInventoryUnstable: collected.omissions.some(
+      ({ kind }) => kind === 'local_inventory',
+    ),
+    warnings: collected.warnings.length,
+  }
 }
 
 export function nativeBackupExportError(error: unknown): string {

--- a/src/services/native-backup/export.ts
+++ b/src/services/native-backup/export.ts
@@ -1,7 +1,7 @@
 import * as auth from '@/services/auth'
 import { SyncEnclaveError } from '@/services/sync-enclave'
 import { collectNativeBackupV2, NativeBackupCollectionError } from './collect'
-import { formatNativeBackupV2 } from './format'
+import { formatNativeBackupV2, type NativeBackupWarning } from './format'
 import {
   NativeBackupWriterError,
   prepareNativeBackupArchiveDestination,
@@ -64,19 +64,17 @@ export async function runNativeBackupExport(
   const result = await dependencies.write(formatted, { signal, destination })
   if (result.kind === 'blob') signal.throwIfAborted()
   dependencies.download(result)
-  const omitted = collected.omissions.filter(
-    ({ kind }) => kind !== 'relationship' && kind !== 'local_inventory',
-  ).length
-  const adjustedRelationships = collected.omissions.filter(
-    ({ kind }) => kind === 'relationship',
-  ).length
+  const warningCount = (code: NativeBackupWarning['code']) =>
+    collected.warnings.find((warning) => warning.code === code)?.count ?? 0
+  const omitted = warningCount('source_items_omitted')
+  const adjustedRelationships = warningCount(
+    'chats_detached_from_omitted_projects',
+  )
   return {
     complete: collected.omissions.length === 0,
     omitted,
     adjustedRelationships,
-    localInventoryUnstable: collected.omissions.some(
-      ({ kind }) => kind === 'local_inventory',
-    ),
+    localInventoryUnstable: warningCount('local_inventory_unstable') > 0,
     warnings: collected.warnings.length,
   }
 }

--- a/src/services/native-backup/format.ts
+++ b/src/services/native-backup/format.ts
@@ -378,7 +378,7 @@ export function assertNativeBackupOmissionsConsistent(
       const chat = chatById.get(omission.source_id)
       if (
         !chat ||
-        chat.projectId !== undefined ||
+        (chat.projectId !== undefined && chat.projectId !== null) ||
         projectIds.has(omission.parent_source_id!) ||
         projectChatRelations.has(
           relationKey(omission.parent_source_id!, omission.source_id),

--- a/src/services/native-backup/format.ts
+++ b/src/services/native-backup/format.ts
@@ -6,6 +6,7 @@ import {
   NATIVE_BACKUP_FORMAT,
   NATIVE_BACKUP_LIMITS,
   NATIVE_BACKUP_VERSION,
+  NATIVE_BACKUP_VERSION_V2,
   type NativeBackupEntityKind,
 } from './constants'
 import {
@@ -49,6 +50,49 @@ export interface NativeBackupFormatInput {
   images: readonly NativeBackupImageInput[]
 }
 
+export const NATIVE_BACKUP_OMISSION_KINDS = [
+  'project',
+  'project_document',
+  'cloud_chat',
+  'local_chat',
+  'attachment',
+  'relationship',
+  'local_inventory',
+] as const
+export const NATIVE_BACKUP_FAILURE_CATEGORIES = [
+  'deleted',
+  'unavailable',
+  'invalid',
+  'unstable',
+] as const
+export type NativeBackupOmission = {
+  kind: (typeof NATIVE_BACKUP_OMISSION_KINDS)[number]
+  source_id: string
+  parent_source_id?: string
+  category: (typeof NATIVE_BACKUP_FAILURE_CATEGORIES)[number]
+  reason: string
+}
+export type NativeBackupWarning =
+  | {
+      code: 'source_items_omitted'
+      category: 'source_coverage'
+      count: number
+    }
+  | {
+      code: 'chats_detached_from_omitted_projects'
+      category: 'relationship_adjustment'
+      count: number
+    }
+  | {
+      code: 'local_inventory_unstable'
+      category: 'source_coverage'
+      count: number
+    }
+export interface NativeBackupV2Input extends NativeBackupFormatInput {
+  omissions: readonly NativeBackupOmission[]
+  warnings: readonly NativeBackupWarning[]
+}
+
 export interface NativeBackupManifestV1 {
   format: typeof NATIVE_BACKUP_FORMAT
   version: typeof NATIVE_BACKUP_VERSION
@@ -65,9 +109,22 @@ export interface NativeBackupManifestV1 {
   }>
 }
 
+export interface NativeBackupManifestV2 extends Omit<
+  NativeBackupManifestV1,
+  'version' | 'complete'
+> {
+  version: typeof NATIVE_BACKUP_VERSION_V2
+  complete: boolean
+  omissions: NativeBackupOmission[]
+  warnings: NativeBackupWarning[]
+}
+
+export type NativeBackupManifest =
+  NativeBackupManifestV1 | NativeBackupManifestV2
+
 export type NativeBackupV1Input = NativeBackupFormatInput
 
-const manifestSchema: z.ZodType<NativeBackupManifestV1> = strict({
+const manifestSchema = strict({
   format: z.literal(NATIVE_BACKUP_FORMAT),
   version: z.literal(NATIVE_BACKUP_VERSION),
   backup_id: z.string().uuid(),
@@ -96,8 +153,50 @@ const manifestSchema: z.ZodType<NativeBackupManifestV1> = strict({
   ),
 })
 
+const omissionSchema = strict({
+  kind: z.enum(NATIVE_BACKUP_OMISSION_KINDS),
+  source_id: z.string().min(1).max(2048),
+  parent_source_id: z.string().min(1).max(2048).optional(),
+  category: z.enum(NATIVE_BACKUP_FAILURE_CATEGORIES),
+  reason: z.string().min(1).max(128),
+})
+const warningSchema = z.discriminatedUnion('code', [
+  strict({
+    code: z.literal('source_items_omitted'),
+    category: z.literal('source_coverage'),
+    count: countSchema,
+  }),
+  strict({
+    code: z.literal('chats_detached_from_omitted_projects'),
+    category: z.literal('relationship_adjustment'),
+    count: countSchema,
+  }),
+  strict({
+    code: z.literal('local_inventory_unstable'),
+    category: z.literal('source_coverage'),
+    count: countSchema,
+  }),
+])
+const manifestV2Schema: z.ZodType<NativeBackupManifestV2> = manifestSchema
+  .omit({ version: true, complete: true })
+  .extend({
+    version: z.literal(NATIVE_BACKUP_VERSION_V2),
+    complete: z.boolean(),
+    omissions: z.array(omissionSchema),
+    warnings: z.array(warningSchema),
+  })
+  .strict()
+
 export const parseNativeBackupManifestV1 = (bytes: Uint8Array) =>
   manifestSchema.parse(parseJson(bytes, MANIFEST_PATH))
+
+export const parseNativeBackupManifest = (bytes: Uint8Array) => {
+  const value = parseJson(bytes, MANIFEST_PATH)
+  const manifest = z.union([manifestSchema, manifestV2Schema]).parse(value)
+  if (manifest.version === NATIVE_BACKUP_VERSION_V2)
+    assertNativeBackupV2Metadata(manifest)
+  return manifest
+}
 
 function fail(message: string): never {
   throw new Error(`Invalid native backup: ${message}`)
@@ -119,6 +218,176 @@ const relationshipCount = (value: NativeBackupRelationships) =>
   value.projectChats.length +
   value.projectDocuments.length +
   value.chatImages.length
+
+const omissionIdentity = (omission: NativeBackupOmission) =>
+  JSON.stringify([
+    omission.kind,
+    omission.source_id,
+    omission.parent_source_id ?? null,
+  ])
+
+export function deriveNativeBackupWarnings(
+  omissions: readonly NativeBackupOmission[],
+): NativeBackupWarning[] {
+  const omittedItems = omissions.filter(
+    ({ kind }) => kind !== 'relationship' && kind !== 'local_inventory',
+  ).length
+  const relationshipAdjustments = omissions.filter(
+    ({ kind }) => kind === 'relationship',
+  ).length
+  const unstableLocalInventories = omissions.filter(
+    ({ kind }) => kind === 'local_inventory',
+  ).length
+  return [
+    ...(omittedItems
+      ? [
+          {
+            code: 'source_items_omitted' as const,
+            category: 'source_coverage' as const,
+            count: omittedItems,
+          },
+        ]
+      : []),
+    ...(relationshipAdjustments
+      ? [
+          {
+            code: 'chats_detached_from_omitted_projects' as const,
+            category: 'relationship_adjustment' as const,
+            count: relationshipAdjustments,
+          },
+        ]
+      : []),
+    ...(unstableLocalInventories
+      ? [
+          {
+            code: 'local_inventory_unstable' as const,
+            category: 'source_coverage' as const,
+            count: unstableLocalInventories,
+          },
+        ]
+      : []),
+  ]
+}
+
+function assertNativeBackupV2Metadata(manifest: NativeBackupManifestV2) {
+  if (manifest.omissions.length > NATIVE_BACKUP_LIMITS.omissions)
+    fail('V2 omission limit exceeded')
+  if (manifest.complete !== (manifest.omissions.length === 0))
+    fail('V2 completeness does not match omissions')
+  const identities = new Set<string>()
+  for (const omission of manifest.omissions) {
+    const identity = omissionIdentity(omission)
+    if (identities.has(identity)) fail('duplicate or contradictory V2 omission')
+    identities.add(identity)
+    if (
+      omission.kind === 'relationship' &&
+      (!omission.parent_source_id ||
+        omission.category !== 'unavailable' ||
+        omission.reason !== 'project_reference_unavailable')
+    )
+      fail('invalid V2 relationship adjustment')
+    if (omission.kind === 'project_document' && !omission.parent_source_id)
+      fail('invalid V2 project document omission')
+    if (omission.kind === 'attachment' && !omission.parent_source_id)
+      fail('invalid V2 attachment omission')
+    if (
+      (omission.kind === 'project' ||
+        omission.kind === 'cloud_chat' ||
+        omission.kind === 'local_chat') &&
+      omission.parent_source_id
+    )
+      fail('invalid V2 entity omission')
+    if (
+      omission.kind === 'local_inventory' &&
+      (omission.source_id !== 'eligible_local_chats' ||
+        omission.parent_source_id ||
+        omission.category !== 'unstable' ||
+        omission.reason !== 'inventory_did_not_converge')
+    )
+      fail('invalid V2 local inventory omission')
+  }
+  const expected = deriveNativeBackupWarnings(manifest.omissions)
+  if (JSON.stringify(manifest.warnings) !== JSON.stringify(expected))
+    fail('V2 warnings do not match omissions')
+}
+
+export function assertNativeBackupOmissionsConsistent(
+  omissions: readonly NativeBackupOmission[],
+  projects: readonly NativeBackupProject[],
+  documents: readonly NativeBackupProjectDocument[],
+  cloudChats: readonly NativeBackupChat[],
+  localChats: readonly NativeBackupChat[],
+  relationships: NativeBackupRelationships,
+  images: readonly NativeBackupImage[],
+) {
+  const projectIds = new Set(projects.map(({ id }) => id))
+  const documentIds = new Set(
+    documents.map(({ projectId, id }) => relationKey(projectId, id)),
+  )
+  const cloudChatIds = new Set(cloudChats.map(({ id }) => id))
+  const localChatIds = new Set(localChats.map(({ id }) => id))
+  const chats = [...cloudChats, ...localChats]
+  const chatById = new Map(chats.map((chat) => [chat.id, chat]))
+  const imageIds = new Set(images.map(({ id }) => id))
+  const referencedImageIds = new Set(
+    chats.flatMap(({ messages }) =>
+      messages.flatMap((message) => [
+        ...(message.attachments ?? []).flatMap((attachment) =>
+          attachment.type === 'image'
+            ? [attachment.imageId]
+            : (attachment.pages ?? []).flatMap(({ imageId }) =>
+                imageId ? [imageId] : [],
+              ),
+        ),
+        ...(message.imageData ?? []).map(({ imageId }) => imageId),
+      ]),
+    ),
+  )
+  const projectChatRelations = new Set(
+    relationships.projectChats.map(({ projectId, chatId }) =>
+      relationKey(projectId, chatId),
+    ),
+  )
+  for (const omission of omissions) {
+    if (omission.kind === 'project' && projectIds.has(omission.source_id))
+      fail('project omission conflicts with included entity')
+    if (
+      omission.kind === 'project_document' &&
+      omission.parent_source_id &&
+      documentIds.has(
+        relationKey(omission.parent_source_id, omission.source_id),
+      )
+    )
+      fail('project document omission conflicts with included entity')
+    if (omission.kind === 'cloud_chat' && cloudChatIds.has(omission.source_id))
+      fail('cloud chat omission conflicts with included entity')
+    if (omission.kind === 'local_chat' && localChatIds.has(omission.source_id))
+      fail('local chat omission conflicts with included entity')
+    if (
+      omission.kind === 'attachment' &&
+      (!omission.parent_source_id || !chatById.has(omission.parent_source_id))
+    )
+      fail('attachment omission does not identify an included chat')
+    if (
+      omission.kind === 'attachment' &&
+      (imageIds.has(omission.source_id) ||
+        referencedImageIds.has(omission.source_id))
+    )
+      fail('attachment omission conflicts with included image reference')
+    if (omission.kind === 'relationship') {
+      const chat = chatById.get(omission.source_id)
+      if (
+        !chat ||
+        chat.projectId !== undefined ||
+        projectIds.has(omission.parent_source_id!) ||
+        projectChatRelations.has(
+          relationKey(omission.parent_source_id!, omission.source_id),
+        )
+      )
+        fail('relationship adjustment conflicts with included relation')
+    }
+  }
+}
 
 function expectedPathKind(path: string): NativeBackupEntityKind | null {
   if (path === 'relationships.json') return 'relationships'
@@ -318,6 +587,40 @@ export function formatNativeBackupV1(input: NativeBackupFormatInput): {
     files.map(({ path, bytes }) => ({ path, sizeBytes: bytes.length })),
   )
   return { manifestBytes, files }
+}
+
+export function formatNativeBackupV2(input: NativeBackupV2Input): {
+  manifestBytes: Uint8Array
+  files: NativeBackupFileEntry[]
+} {
+  assertNativeBackupOmissionsConsistent(
+    input.omissions,
+    input.projects,
+    input.projectDocuments,
+    input.cloudChats,
+    input.localChats,
+    input.relationships,
+    input.images.map(({ metadata }) => metadata),
+  )
+  const formatted = formatNativeBackupV1(input)
+  const v1 = parseNativeBackupManifestV1(formatted.manifestBytes)
+  const manifest: NativeBackupManifestV2 = manifestV2Schema.parse({
+    ...v1,
+    version: NATIVE_BACKUP_VERSION_V2,
+    complete: input.omissions.length === 0,
+    omissions: input.omissions,
+    warnings: input.warnings,
+  })
+  assertNativeBackupV2Metadata(manifest)
+  const manifestBytes = jsonBytes(manifest)
+  assertNativeBackupSizeLimits(
+    manifestBytes.length,
+    formatted.files.map(({ path, bytes }) => ({
+      path,
+      sizeBytes: bytes.length,
+    })),
+  )
+  return { manifestBytes, files: formatted.files }
 }
 
 function exactRelations(values: string[], wanted: Set<string>, name: string) {
@@ -539,4 +842,68 @@ export function assertValidNativeBackupV1(
   if (entities > NATIVE_BACKUP_LIMITS.entities) fail('entity limit exceeded')
   assertSemanticContent(projects, documents, chats, relationships[0], images)
   return manifest as NativeBackupManifestV1
+}
+
+function contentFromValidatedFiles(files: readonly NativeBackupFileEntry[]) {
+  const projects: NativeBackupProject[] = []
+  const documents: NativeBackupProjectDocument[] = []
+  const cloudChats: NativeBackupChat[] = []
+  const localChats: NativeBackupChat[] = []
+  const images: NativeBackupImage[] = []
+  let relationships: NativeBackupRelationships | undefined
+  for (const file of files) {
+    if (file.path.endsWith('.bin')) continue
+    const value = parseJson(file.bytes, file.path)
+    if (file.kind === 'projects')
+      projects.push(NativeBackupProjectSchema.parse(value))
+    if (file.kind === 'project_documents')
+      documents.push(NativeBackupProjectDocumentSchema.parse(value))
+    if (file.kind === 'cloud_chats')
+      cloudChats.push(NativeBackupChatSchema.parse(value))
+    if (file.kind === 'local_chats')
+      localChats.push(NativeBackupChatSchema.parse(value))
+    if (file.kind === 'images' && file.path.endsWith('.json'))
+      images.push(NativeBackupImageSchema.parse(value))
+    if (file.kind === 'relationships')
+      relationships = NativeBackupRelationshipsSchema.parse(value)
+  }
+  return {
+    projects,
+    documents,
+    cloudChats,
+    localChats,
+    images,
+    relationships: relationships!,
+  }
+}
+
+export function assertValidNativeBackupV2(
+  manifestBytes: Uint8Array,
+  files: readonly NativeBackupFileEntry[],
+): NativeBackupManifestV2 {
+  const manifest = parseNativeBackupManifest(manifestBytes)
+  if (manifest.version !== NATIVE_BACKUP_VERSION_V2)
+    fail('V2 manifest is required')
+  const v1Bytes = jsonBytes({
+    ...manifest,
+    version: NATIVE_BACKUP_VERSION,
+    complete: true,
+    omissions: undefined,
+    warnings: undefined,
+  })
+  const v1 = JSON.parse(decoder.decode(v1Bytes)) as Record<string, unknown>
+  delete v1.omissions
+  delete v1.warnings
+  assertValidNativeBackupV1(jsonBytes(v1), files)
+  const content = contentFromValidatedFiles(files)
+  assertNativeBackupOmissionsConsistent(
+    manifest.omissions,
+    content.projects,
+    content.documents,
+    content.cloudChats,
+    content.localChats,
+    content.relationships,
+    content.images,
+  )
+  return manifest
 }

--- a/src/services/native-backup/orchestrate.ts
+++ b/src/services/native-backup/orchestrate.ts
@@ -70,6 +70,57 @@ function emptyReport(): NativeRestoreResult['report'] {
   }
 }
 
+function applySourceBackupWarnings(
+  validated: ValidatedNativeRestore,
+  report: NativeRestoreResult['report'],
+) {
+  if (validated.backup.version !== 2 || validated.backup.complete) return
+  const targets: Partial<
+    Record<
+      (typeof validated.backup.omissions)[number]['kind'],
+      NativeRestoreKind
+    >
+  > = {
+    project: 'projects',
+    project_document: 'project_documents',
+    cloud_chat: 'cloud_chats',
+    local_chat: 'local_chats',
+    attachment: 'attachments',
+  }
+  const counts = new Map<NativeRestoreKind, number>()
+  for (const omission of validated.backup.omissions) {
+    const target = targets[omission.kind]
+    if (!target) continue
+    counts.set(target, (counts.get(target) ?? 0) + 1)
+  }
+  const labels: Record<NativeRestoreKind, [string, string]> = {
+    projects: ['project', 'projects'],
+    project_documents: ['project document', 'project documents'],
+    cloud_chats: ['cloud chat', 'cloud chats'],
+    local_chats: ['local chat', 'local chats'],
+    attachments: ['attachment', 'attachments'],
+  }
+  for (const [kind, count] of counts)
+    report[kind].warnings.push(
+      `Source archive omitted ${count} ${labels[kind][count === 1 ? 0 : 1]}.`,
+    )
+  const adjusted = validated.backup.warnings
+    .filter(({ category }) => category === 'relationship_adjustment')
+    .reduce((sum, warning) => sum + warning.count, 0)
+  if (adjusted)
+    report.cloud_chats.warnings.push(
+      `Source archive adjusted ${adjusted} relationship${adjusted === 1 ? '' : 's'} to keep restored data valid.`,
+    )
+  if (
+    validated.backup.warnings.some(
+      ({ code }) => code === 'local_inventory_unstable',
+    )
+  )
+    report.local_chats.warnings.push(
+      'Local chats changed repeatedly during export; included local chats are a partial snapshot.',
+    )
+}
+
 // prettier-ignore
 function destinationChatId(ownerId: string, backupId: string, sourceId: string) {
   const input = new TextEncoder().encode(`${ownerId}\0${backupId}\0${sourceId}`)
@@ -236,6 +287,7 @@ export async function restoreNativeBackup(
   if (!ownerId.trim()) throw new Error('Sign in before restoring a backup')
   const report = emptyReport()
   const validated = await dependencies.validate(file, { signal })
+  applySourceBackupWarnings(validated, report)
   let status: ImportStatusResponse | null = null
   let jobId: string | undefined
   if (validated.cloud) {

--- a/src/services/native-backup/orchestrate.ts
+++ b/src/services/native-backup/orchestrate.ts
@@ -6,6 +6,7 @@ import { importStatus,type ImportStatusResponse } from '@/services/sync-enclave/
 import { uint8ArrayToBase64 } from '@/utils/binary-codec'
 import { sha256 } from '@noble/hashes/sha2.js'
 import { bytesToHex } from '@noble/hashes/utils.js'
+import { NATIVE_BACKUP_VERSION_V2 } from './constants'
 import {
   forEachNativeBackupLocalImage,
   validateAndPackageNativeBackup,
@@ -74,7 +75,11 @@ function applySourceBackupWarnings(
   validated: ValidatedNativeRestore,
   report: NativeRestoreResult['report'],
 ) {
-  if (validated.backup.version !== 2 || validated.backup.complete) return
+  if (
+    validated.backup.version !== NATIVE_BACKUP_VERSION_V2 ||
+    validated.backup.complete
+  )
+    return
   const targets: Partial<
     Record<
       (typeof validated.backup.omissions)[number]['kind'],

--- a/src/services/native-backup/orchestrate.ts
+++ b/src/services/native-backup/orchestrate.ts
@@ -104,12 +104,18 @@ function applySourceBackupWarnings(
     report[kind].warnings.push(
       `Source archive omitted ${count} ${labels[kind][count === 1 ? 0 : 1]}.`,
     )
-  const adjusted = validated.backup.warnings
-    .filter(({ category }) => category === 'relationship_adjustment')
-    .reduce((sum, warning) => sum + warning.count, 0)
-  if (adjusted)
-    report.cloud_chats.warnings.push(
-      `Source archive adjusted ${adjusted} relationship${adjusted === 1 ? '' : 's'} to keep restored data valid.`,
+  const localChatIds = new Set(validated.local.chats.map(({ id }) => id))
+  const relationshipCounts = new Map<NativeRestoreKind, number>()
+  for (const omission of validated.backup.omissions) {
+    if (omission.kind !== 'relationship') continue
+    const target = localChatIds.has(omission.source_id)
+      ? 'local_chats'
+      : 'cloud_chats'
+    relationshipCounts.set(target, (relationshipCounts.get(target) ?? 0) + 1)
+  }
+  for (const [target, count] of relationshipCounts)
+    report[target].warnings.push(
+      `Source archive adjusted ${count} relationship${count === 1 ? '' : 's'} to keep restored data valid.`,
     )
   if (
     validated.backup.warnings.some(

--- a/src/services/native-backup/restore.ts
+++ b/src/services/native-backup/restore.ts
@@ -11,9 +11,10 @@ import {
 } from '@zip.js/zip.js'
 import { NATIVE_BACKUP_ENTITY_KINDS, NATIVE_BACKUP_LIMITS } from './constants'
 import {
+  assertNativeBackupOmissionsConsistent,
   assertSemanticContent,
-  parseNativeBackupManifestV1,
-  type NativeBackupManifestV1,
+  parseNativeBackupManifest,
+  type NativeBackupManifest,
 } from './format'
 import { detectNativeBackupImageMimeType } from './image-mime'
 import {
@@ -50,9 +51,9 @@ export type NativeCloudUpload = { kind: 'blob'; blob: Blob; filename: string } |
 // prettier-ignore
 export type NativeBackupImageSource = { metadata: NativeBackupImage; source: { file: File; path: string; sizeBytes: number; sha256: string } }
 // prettier-ignore
-export type ValidatedNativeRestore = { backup: NativeBackupManifestV1; local: { chats: NativeBackupChat[]; images: NativeBackupImageSource[] }; cloud: { manifest: NativeCloudImportManifestV1; upload: NativeCloudUpload } | null }
+export type ValidatedNativeRestore = { backup: NativeBackupManifest; local: { chats: NativeBackupChat[]; images: NativeBackupImageSource[] }; cloud: { manifest: NativeCloudImportManifestV1; upload: NativeCloudUpload } | null }
 // prettier-ignore
-type ParsedBackup = { backup: NativeBackupManifestV1; projects: NativeBackupProject[]; documents: NativeBackupProjectDocument[]; cloudChats: NativeBackupChat[]; localChats: NativeBackupChat[]; relationships: NativeBackupRelationships; images: Array<{ metadata: NativeBackupImage; entry: NativeRestoreEntry; sha256: string }> }
+type ParsedBackup = { backup: NativeBackupManifest; projects: NativeBackupProject[]; documents: NativeBackupProjectDocument[]; cloudChats: NativeBackupChat[]; localChats: NativeBackupChat[]; relationships: NativeBackupRelationships; images: Array<{ metadata: NativeBackupImage; entry: NativeRestoreEntry; sha256: string }> }
 function fail(message: string): never {
   throw new Error(`Invalid native backup restore: ${message}`)
 }
@@ -142,11 +143,11 @@ async function parseArchive(
 ): Promise<ParsedBackup> {
   const manifestEntry = byPath.get(MANIFEST_PATH) ?? fail('manifest is missing')
   const manifestRead = await manifestEntry.read(signal)
-  let backup: NativeBackupManifestV1
+  let backup: NativeBackupManifest
   try {
     if (manifestRead.bytes.length !== manifestEntry.uncompressedSize)
       fail('manifest size mismatch')
-    backup = parseNativeBackupManifestV1(manifestRead.bytes)
+    backup = parseNativeBackupManifest(manifestRead.bytes)
   } finally {
     manifestRead.release()
   }
@@ -240,6 +241,16 @@ async function parseArchive(
     relationValue,
     images.map(({ metadata }) => metadata),
   )
+  if (backup.version === 2)
+    assertNativeBackupOmissionsConsistent(
+      backup.omissions,
+      projects,
+      documents,
+      cloudChats,
+      localChats,
+      relationValue,
+      images.map(({ metadata }) => metadata),
+    )
   // prettier-ignore
   const counts = {
     projects: projects.length, project_documents: documents.length, cloud_chats: cloudChats.length, local_chats: localChats.length, relationships: Object.values(relationValue).reduce((sum, values) => sum + values.length, 0), images: images.length, files: backup.files.length,

--- a/src/services/native-backup/restore.ts
+++ b/src/services/native-backup/restore.ts
@@ -9,7 +9,11 @@ import {
   ZipReader,
   ZipWriter,
 } from '@zip.js/zip.js'
-import { NATIVE_BACKUP_ENTITY_KINDS, NATIVE_BACKUP_LIMITS } from './constants'
+import {
+  NATIVE_BACKUP_ENTITY_KINDS,
+  NATIVE_BACKUP_LIMITS,
+  NATIVE_BACKUP_VERSION_V2,
+} from './constants'
 import {
   assertNativeBackupOmissionsConsistent,
   assertSemanticContent,
@@ -241,7 +245,7 @@ async function parseArchive(
     relationValue,
     images.map(({ metadata }) => metadata),
   )
-  if (backup.version === 2)
+  if (backup.version === NATIVE_BACKUP_VERSION_V2)
     assertNativeBackupOmissionsConsistent(
       backup.omissions,
       projects,

--- a/src/services/native-backup/sanitize.ts
+++ b/src/services/native-backup/sanitize.ts
@@ -18,16 +18,27 @@ export type NativeBackupImageCollector = (
   candidate: NativeBackupImageCandidate,
 ) => string
 
+export class NativeBackupDataValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NativeBackupDataValidationError'
+  }
+}
+
 function row(value: unknown): Row {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('Native backup records must be objects')
+    throw new NativeBackupDataValidationError(
+      'Native backup records must be objects',
+    )
   }
   return value as Row
 }
 function rows(value: unknown): Row[] {
   if (value === undefined) return []
   if (!Array.isArray(value))
-    throw new Error('Native backup collections must be arrays')
+    throw new NativeBackupDataValidationError(
+      'Native backup collections must be arrays',
+    )
   return value.map(row)
 }
 const list = (value: unknown, clean: Cleaner) =>
@@ -45,11 +56,11 @@ const iso = (value: unknown): string => {
     typeof value !== 'string' &&
     typeof value !== 'number'
   )
-    throw new Error('Invalid backup timestamp')
+    throw new NativeBackupDataValidationError('Invalid backup timestamp')
   const parsed =
     value instanceof Date ? value : new Date(value as string | number)
   if (Number.isNaN(parsed.getTime()))
-    throw new Error('Invalid backup timestamp')
+    throw new NativeBackupDataValidationError('Invalid backup timestamp')
   return parsed.toISOString()
 }
 export function sanitizeNativeBackupProject(value: unknown) {
@@ -112,7 +123,10 @@ const timelineFields: Record<string, readonly string[]> = {
 function cleanTimeline(value: unknown): unknown {
   const source = row(value)
   const fields = timelineFields[String(source.type)]
-  if (!fields) throw new Error('Unsupported native backup timeline block')
+  if (!fields)
+    throw new NativeBackupDataValidationError(
+      'Unsupported native backup timeline block',
+    )
   const output = pick(source, fields)
   if (source.type === 'web_search') output.state = cleanSearch(source.state)
   if (source.type === 'url_fetches') {
@@ -249,7 +263,9 @@ function cleanMessage(
 }
 
 const missingImageCollector: NativeBackupImageCollector = () => {
-  throw new Error('Native backup image collector is required')
+  throw new NativeBackupDataValidationError(
+    'Native backup image collector is required',
+  )
 }
 export function sanitizeNativeBackupChat(
   value: unknown,

--- a/src/services/sync-enclave/index.ts
+++ b/src/services/sync-enclave/index.ts
@@ -29,6 +29,10 @@ export type { RetryConfig, RetryScheduler } from './retry-policy'
 export * as syncApi from './sync-api'
 export type {
   AddBundleRequest,
+  BackupInventoryItem,
+  BackupInventoryProtocolErrorCode,
+  BackupInventoryResponse,
+  BackupInventoryScope,
   DeleteRequest,
   KeyCurrentBundle,
   KeyCurrentResponse,

--- a/src/services/sync-enclave/sync-api.ts
+++ b/src/services/sync-enclave/sync-api.ts
@@ -21,6 +21,7 @@
  */
 
 import { base64ToUint8Array, uint8ArrayToBase64 } from '@/utils/binary-codec'
+import { z } from 'zod'
 import { SyncEnclaveError, getSyncEnclaveClient } from './sync-enclave-client'
 
 export type Scope = 'profile' | 'chat' | 'project' | 'project_document'
@@ -90,6 +91,8 @@ export interface PullItem {
   plaintext?: string
   key_id?: string
   etag?: string
+  /** ETag replaced by a successful lazy rewrap during this pull. */
+  previous_etag?: string
   project_id_set?: boolean
   project_id?: string | null
   needs_rewrap?: boolean
@@ -101,6 +104,44 @@ export interface PullItem {
 export interface PullResponse {
   items: PullItem[]
   next_cursor?: string
+}
+
+export type BackupInventoryScope = 'chat' | 'project' | 'project_document'
+
+export interface BackupInventoryItem {
+  scope: BackupInventoryScope
+  id: string
+  etag: string
+  project_id?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface BackupInventoryResponse {
+  captured_at: string
+  total_items: number
+  items: BackupInventoryItem[]
+}
+
+export type BackupInventoryProtocolErrorCode =
+  | 'malformed_response'
+  | 'invalid_total'
+  | 'invalid_timestamp'
+  | 'unsupported_scope'
+  | 'duplicate_item'
+  | 'invalid_order'
+  | 'invalid_relationship'
+  | 'missing_id'
+  | 'missing_etag'
+
+export class BackupInventoryProtocolError extends Error {
+  constructor(
+    public readonly code: BackupInventoryProtocolErrorCode,
+    public readonly itemIndex?: number,
+  ) {
+    super('Sync enclave returned an invalid backup inventory')
+    this.name = 'BackupInventoryProtocolError'
+  }
 }
 
 export interface ListStatusRequest {
@@ -594,6 +635,169 @@ export async function pull(req: PullRequest): Promise<PullResponse> {
   // downstream `for (const item of resp.items)` consumer. Force a
   // stable [] at the boundary so callers can iterate without guards.
   return { ...resp, items: resp.items ?? [] }
+}
+
+const BACKUP_INVENTORY_SCOPES: readonly BackupInventoryScope[] = [
+  'chat',
+  'project',
+  'project_document',
+]
+const BACKUP_INVENTORY_RESPONSE_FIELDS = [
+  'captured_at',
+  'total_items',
+  'items',
+] as const
+const BACKUP_INVENTORY_ITEM_FIELDS = [
+  'scope',
+  'id',
+  'etag',
+  'project_id',
+  'created_at',
+  'updated_at',
+] as const
+const BACKUP_INVENTORY_TIMESTAMP_SCHEMA = z.string().datetime({ offset: true })
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasExactFields(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  required: readonly string[],
+): boolean {
+  const keys = Object.keys(value)
+  return (
+    keys.every((key) => allowed.includes(key)) &&
+    required.every((key) => Object.hasOwn(value, key))
+  )
+}
+
+function parseInventoryTimestamp(
+  value: unknown,
+  itemIndex?: number,
+): { value: string; milliseconds: number } {
+  if (
+    typeof value !== 'string' ||
+    !BACKUP_INVENTORY_TIMESTAMP_SCHEMA.safeParse(value).success
+  )
+    throw new BackupInventoryProtocolError('invalid_timestamp', itemIndex)
+  const milliseconds = Date.parse(value)
+  if (!Number.isFinite(milliseconds))
+    throw new BackupInventoryProtocolError('invalid_timestamp', itemIndex)
+  return { value, milliseconds }
+}
+
+function validateBackupInventory(value: unknown): BackupInventoryResponse {
+  if (
+    !isObject(value) ||
+    !hasExactFields(
+      value,
+      BACKUP_INVENTORY_RESPONSE_FIELDS,
+      BACKUP_INVENTORY_RESPONSE_FIELDS,
+    ) ||
+    !Array.isArray(value.items)
+  )
+    throw new BackupInventoryProtocolError('malformed_response')
+  if (
+    typeof value.total_items !== 'number' ||
+    !Number.isSafeInteger(value.total_items) ||
+    value.total_items < 0 ||
+    value.total_items !== value.items.length
+  )
+    throw new BackupInventoryProtocolError('invalid_total')
+
+  const captured = parseInventoryTimestamp(value.captured_at)
+  const seen = new Set<string>()
+  let previousOrderKey: string | undefined
+  const items = value.items.map((candidate, itemIndex): BackupInventoryItem => {
+    if (
+      !isObject(candidate) ||
+      !hasExactFields(candidate, BACKUP_INVENTORY_ITEM_FIELDS, [
+        'scope',
+        'id',
+        'etag',
+        'created_at',
+        'updated_at',
+      ])
+    )
+      throw new BackupInventoryProtocolError('malformed_response', itemIndex)
+    if (
+      typeof candidate.scope !== 'string' ||
+      !BACKUP_INVENTORY_SCOPES.includes(candidate.scope as BackupInventoryScope)
+    )
+      throw new BackupInventoryProtocolError('unsupported_scope', itemIndex)
+    const scope = candidate.scope as BackupInventoryScope
+    if (typeof candidate.id !== 'string' || candidate.id.trim().length === 0)
+      throw new BackupInventoryProtocolError('missing_id', itemIndex)
+    if (
+      typeof candidate.etag !== 'string' ||
+      candidate.etag.trim().length === 0
+    )
+      throw new BackupInventoryProtocolError('missing_etag', itemIndex)
+    const hasProjectId = Object.hasOwn(candidate, 'project_id')
+    if (
+      (hasProjectId &&
+        (typeof candidate.project_id !== 'string' ||
+          candidate.project_id.trim().length === 0)) ||
+      (scope === 'project_document' && !hasProjectId) ||
+      (scope === 'project' && hasProjectId)
+    )
+      throw new BackupInventoryProtocolError('invalid_relationship', itemIndex)
+
+    const created = parseInventoryTimestamp(candidate.created_at, itemIndex)
+    const updated = parseInventoryTimestamp(candidate.updated_at, itemIndex)
+    if (
+      created.milliseconds > updated.milliseconds ||
+      updated.milliseconds > captured.milliseconds
+    )
+      throw new BackupInventoryProtocolError('invalid_order', itemIndex)
+
+    const identity = `${scope}\u0000${candidate.project_id ?? ''}\u0000${candidate.id}`
+    if (seen.has(identity))
+      throw new BackupInventoryProtocolError('duplicate_item', itemIndex)
+    seen.add(identity)
+    const orderKey = `${String(BACKUP_INVENTORY_SCOPES.indexOf(scope)).padStart(2, '0')}\u0000${candidate.id}\u0000${candidate.project_id ?? ''}`
+    if (previousOrderKey !== undefined && orderKey <= previousOrderKey)
+      throw new BackupInventoryProtocolError('invalid_order', itemIndex)
+    previousOrderKey = orderKey
+
+    return {
+      scope,
+      id: candidate.id,
+      etag: candidate.etag,
+      ...(hasProjectId ? { project_id: candidate.project_id as string } : {}),
+      created_at: created.value,
+      updated_at: updated.value,
+    }
+  })
+  const projectIds = new Set(
+    items.filter(({ scope }) => scope === 'project').map(({ id }) => id),
+  )
+  items.forEach((item, itemIndex) => {
+    if (item.project_id && !projectIds.has(item.project_id))
+      throw new BackupInventoryProtocolError('invalid_relationship', itemIndex)
+  })
+  return {
+    captured_at: captured.value,
+    total_items: value.total_items,
+    items,
+  }
+}
+
+export async function backupInventory(
+  signal?: AbortSignal,
+): Promise<BackupInventoryResponse> {
+  signal?.throwIfAborted()
+  const client = await getSyncEnclaveClient(signal)
+  const response = await client.post<unknown>(
+    '/v1/sync/backup-inventory',
+    {},
+    undefined,
+    { signal, requestScope: 'cloud-sync' },
+  )
+  signal?.throwIfAborted()
+  return validateBackupInventory(response)
 }
 
 export async function pullOne(

--- a/src/utils/binary-codec.ts
+++ b/src/utils/binary-codec.ts
@@ -1,5 +1,17 @@
 const AES_GCM = 'AES-GCM'
 const IV_LENGTH = 12
+const AES_GCM_TAG_LENGTH = 16
+const AES_256_KEY_LENGTH = 32
+
+export type EncryptedAttachmentValidationErrorCode =
+  'ciphertext_too_short' | 'invalid_key_length'
+
+export class EncryptedAttachmentValidationError extends Error {
+  constructor(public readonly code: EncryptedAttachmentValidationErrorCode) {
+    super('Encrypted attachment structure is invalid')
+    this.name = 'EncryptedAttachmentValidationError'
+  }
+}
 
 /** Get a safe ArrayBuffer copy from a Uint8Array subview. */
 function toBuffer(view: Uint8Array): ArrayBuffer {
@@ -18,12 +30,12 @@ function packIvCiphertext(iv: Uint8Array, ciphertext: ArrayBuffer): Uint8Array {
 }
 
 /** Split IV(12) || ciphertext, validating minimum length. */
-function unpackIvCiphertext(
-  data: Uint8Array,
-  errorMsg: string,
-): { iv: Uint8Array; ciphertext: Uint8Array } {
-  if (data.length <= IV_LENGTH) {
-    throw new Error(errorMsg)
+function unpackIvCiphertext(data: Uint8Array): {
+  iv: Uint8Array
+  ciphertext: Uint8Array
+} {
+  if (data.length < IV_LENGTH + AES_GCM_TAG_LENGTH) {
+    throw new EncryptedAttachmentValidationError('ciphertext_too_short')
   }
   return {
     iv: data.subarray(0, IV_LENGTH),
@@ -116,10 +128,9 @@ export async function decryptAttachment(
   encryptedData: Uint8Array,
   key: Uint8Array,
 ): Promise<Uint8Array> {
-  const { iv, ciphertext } = unpackIvCiphertext(
-    encryptedData,
-    'Encrypted attachment too short',
-  )
+  if (key.length !== AES_256_KEY_LENGTH)
+    throw new EncryptedAttachmentValidationError('invalid_key_length')
+  const { iv, ciphertext } = unpackIvCiphertext(encryptedData)
 
   const cryptoKey = await crypto.subtle.importKey(
     'raw',

--- a/tests/components/native-backup-export.test.tsx
+++ b/tests/components/native-backup-export.test.tsx
@@ -67,6 +67,27 @@ describe('NativeBackupExport', () => {
     expect(mocks.runExport.mock.calls[0][0].aborted).toBe(true)
   })
 
+  it('reports a successful partial save without exposing source identifiers', async () => {
+    mocks.runExport.mockResolvedValue({
+      complete: false,
+      omitted: 2,
+      adjustedRelationships: 0,
+      localInventoryUnstable: false,
+      warnings: 1,
+    })
+    render(<NativeBackupExport available />)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Create Tinfoil Backup' }),
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: 'I understand, create backup' }),
+    )
+
+    expect(await screen.findByText(/saved with warnings/)).toHaveTextContent(
+      '2 source items could not be included',
+    )
+  })
+
   it('cancels an active export when availability is lost', async () => {
     mocks.runExport.mockImplementation(
       (signal: AbortSignal, onProgress: (value: 'collecting') => void) => {

--- a/tests/services/cloud/cloud-storage.test.ts
+++ b/tests/services/cloud/cloud-storage.test.ts
@@ -1,5 +1,9 @@
 import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
-import { CloudStorageService } from '@/services/cloud/cloud-storage'
+import {
+  CloudBackupReadError,
+  CloudStorageService,
+} from '@/services/cloud/cloud-storage'
+import { SyncNetworkError } from '@/services/sync-enclave'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetAuthHeaders = vi.fn()
@@ -137,6 +141,116 @@ describe('CloudStorageService auth readiness', () => {
     await expect(
       storage.downloadChats(['chat-1'], { tolerateNotFound: true }),
     ).rejects.toThrow('incomplete chat batch')
+  })
+
+  it('preserves structured backup attachment failures instead of swallowing them', async () => {
+    const storage = new CloudStorageService()
+    const attachment = {
+      id: 'attachment',
+      type: 'image' as const,
+      fileName: 'image.png',
+      encryptionKey: 'key',
+    }
+    const network = new SyncNetworkError()
+    mockAttachmentGet.mockRejectedValueOnce(network)
+    await expect(storage.loadChatImageForBackup(attachment)).rejects.toBe(
+      network,
+    )
+
+    mockAttachmentGet.mockResolvedValueOnce(null)
+    const missing = await storage
+      .loadChatImageForBackup(attachment)
+      .catch((error: unknown) => error)
+    expect(missing).toBeInstanceOf(CloudBackupReadError)
+    expect(missing).toMatchObject({
+      category: 'item_unavailable',
+      reason: 'attachment_not_found',
+      omittable: true,
+    })
+
+    const locked = await storage
+      .loadChatImageForBackup({
+        id: 'missing-key',
+        type: 'image',
+        fileName: 'image.png',
+      })
+      .catch((error: unknown) => error)
+    expect(locked).toBeInstanceOf(CloudBackupReadError)
+    expect(locked).toMatchObject({
+      category: 'item_invalid',
+      reason: 'attachment_key_unavailable',
+      omittable: true,
+    })
+  })
+
+  it('omits only structured chat decode failures in the strict backup adapter', async () => {
+    const storage = new CloudStorageService()
+    mockEnclavePull.mockResolvedValue({
+      items: [
+        {
+          id: 'chat',
+          ok: true,
+          etag: '1',
+          plaintext: btoa('{'),
+        },
+      ],
+    })
+    const malformed = await storage
+      .downloadChatForBackup('chat')
+      .catch((error: unknown) => error)
+    expect(malformed).toBeInstanceOf(CloudBackupReadError)
+    expect(malformed).toMatchObject({
+      category: 'item_invalid',
+      reason: 'chat_payload_invalid',
+      omittable: true,
+    })
+
+    const runtimeFailure = new Error('unexpected JSON runtime failure')
+    const parse = vi.spyOn(JSON, 'parse').mockImplementationOnce(() => {
+      throw runtimeFailure
+    })
+    mockEnclavePull.mockResolvedValue({
+      items: [
+        {
+          id: 'chat',
+          ok: true,
+          etag: '1',
+          plaintext: btoa('{}'),
+        },
+      ],
+    })
+    try {
+      await expect(storage.downloadChatForBackup('chat')).rejects.toBe(
+        runtimeFailure,
+      )
+    } finally {
+      parse.mockRestore()
+    }
+  })
+
+  it('keeps unknown legacy attachment runtime failures fatal', async () => {
+    const runtimeFailure = new Error('unexpected response failure')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => {
+          throw runtimeFailure
+        },
+      }),
+    )
+
+    await expect(
+      new CloudStorageService().loadChatImageForBackup({
+        id: 'legacy',
+        type: 'image',
+        fileName: 'legacy.png',
+        key: 'AA==',
+      } as unknown as Parameters<
+        CloudStorageService['loadChatImageForBackup']
+      >[0]),
+    ).rejects.toBe(runtimeFailure)
   })
 
   it('preserves an explicit project delete on a single conflict pull', async () => {

--- a/tests/services/cloud/cloud-storage.test.ts
+++ b/tests/services/cloud/cloud-storage.test.ts
@@ -3,7 +3,7 @@ import {
   CloudBackupReadError,
   CloudStorageService,
 } from '@/services/cloud/cloud-storage'
-import { SyncNetworkError } from '@/services/sync-enclave'
+import { SyncEnclaveError, SyncNetworkError } from '@/services/sync-enclave'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetAuthHeaders = vi.fn()
@@ -183,6 +183,54 @@ describe('CloudStorageService auth readiness', () => {
     })
   })
 
+  it('translates only structured modern attachment not-found errors', async () => {
+    const storage = new CloudStorageService()
+    const attachment = {
+      id: 'attachment',
+      type: 'image' as const,
+      fileName: 'image.png',
+      encryptionKey: 'key',
+    }
+    const missingByStatus = new SyncEnclaveError(
+      'Attachment missing',
+      404,
+      'ATTACHMENT_MISSING',
+    )
+    mockAttachmentGet.mockRejectedValueOnce(missingByStatus)
+    await expect(
+      storage.loadChatImageForBackup(attachment),
+    ).rejects.toMatchObject({
+      category: 'item_unavailable',
+      reason: 'attachment_not_found',
+      cause: missingByStatus,
+    })
+
+    const missingByCode = new SyncEnclaveError(
+      'Attachment missing',
+      undefined,
+      'NOT_FOUND',
+    )
+    mockAttachmentGet.mockRejectedValueOnce(missingByCode)
+    await expect(
+      storage.loadChatImageForBackup(attachment),
+    ).rejects.toMatchObject({
+      category: 'item_unavailable',
+      reason: 'attachment_not_found',
+      cause: missingByCode,
+    })
+
+    for (const fatal of [
+      new SyncEnclaveError('Server failed', 500, 'INTERNAL'),
+      new SyncEnclaveError('Unauthorized', 401, 'UNAUTHORIZED'),
+      new Error('Unexpected attachment failure'),
+    ]) {
+      mockAttachmentGet.mockRejectedValueOnce(fatal)
+      await expect(storage.loadChatImageForBackup(attachment)).rejects.toBe(
+        fatal,
+      )
+    }
+  })
+
   it('omits only structured chat decode failures in the strict backup adapter', async () => {
     const storage = new CloudStorageService()
     mockEnclavePull.mockResolvedValue({
@@ -196,7 +244,7 @@ describe('CloudStorageService auth readiness', () => {
       ],
     })
     const malformed = await storage
-      .downloadChatForBackup('chat')
+      .downloadChatForBackup('chat', '1')
       .catch((error: unknown) => error)
     expect(malformed).toBeInstanceOf(CloudBackupReadError)
     expect(malformed).toMatchObject({
@@ -220,12 +268,150 @@ describe('CloudStorageService auth readiness', () => {
       ],
     })
     try {
-      await expect(storage.downloadChatForBackup('chat')).rejects.toBe(
+      await expect(storage.downloadChatForBackup('chat', '1')).rejects.toBe(
         runtimeFailure,
       )
     } finally {
       parse.mockRestore()
     }
+  })
+
+  it('requires the captured opaque ETag and exact item identity for backup reads', async () => {
+    const storage = new CloudStorageService()
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [
+        { id: 'chat', ok: true, etag: 'new-etag', plaintext: btoa('{}') },
+      ],
+    })
+    await expect(
+      storage.downloadChatForBackup('chat', 'captured-etag'),
+    ).rejects.toMatchObject({
+      category: 'snapshot_changed',
+      reason: 'record_changed_after_snapshot',
+      omittable: true,
+    })
+
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [{ id: 'other-chat', ok: true, etag: 'captured-etag' }],
+    })
+    await expect(
+      storage.downloadChatForBackup('chat', 'captured-etag'),
+    ).rejects.toMatchObject({ code: 'unexpected_item' })
+
+    mockEnclavePull.mockResolvedValueOnce({ items: [] })
+    await expect(
+      storage.downloadChatForBackup('chat', 'captured-etag'),
+    ).rejects.toMatchObject({ code: 'missing_item' })
+
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [{ id: 'chat', ok: true, plaintext: btoa('{}') }],
+    })
+    await expect(
+      storage.downloadChatForBackup('chat', 'captured-etag'),
+    ).rejects.toMatchObject({ code: 'missing_etag' })
+
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'chat',
+          ok: false,
+          code: 'UNKNOWN_KEY',
+          etag: 'captured-etag',
+          previous_etag: 7,
+        },
+      ],
+    })
+    await expect(
+      storage.downloadChatForBackup('chat', 'captured-etag'),
+    ).rejects.toMatchObject({ code: 'invalid_previous_etag' })
+
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [{ id: 'chat', ok: false, code: 'NOT_FOUND' }],
+    })
+    await expect(
+      storage.downloadChatForBackup('chat', 'captured-etag'),
+    ).rejects.toMatchObject({
+      category: 'snapshot_deleted',
+      reason: 'record_deleted_after_snapshot',
+    })
+  })
+
+  it('accepts a successful lazy rewrap only through a valid previous ETag', async () => {
+    const storage = new CloudStorageService()
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'chat',
+          ok: true,
+          etag: 'rewrapped-etag',
+          previous_etag: 'captured-etag',
+          plaintext: btoa('{"title":"Rewrapped","messages":[]}'),
+        },
+      ],
+    })
+
+    await expect(
+      storage.downloadChatForBackup('chat', 'captured-etag'),
+    ).resolves.toMatchObject({ id: 'chat', title: 'Rewrapped' })
+
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'chat',
+          ok: true,
+          etag: 'captured-etag',
+          previous_etag: '',
+          plaintext: btoa('{}'),
+        },
+      ],
+    })
+    await expect(
+      storage.downloadChatForBackup('chat', 'captured-etag'),
+    ).rejects.toMatchObject({ code: 'invalid_previous_etag' })
+  })
+
+  it('checks failed pull versions before preserving key failures', async () => {
+    const storage = new CloudStorageService()
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [{ id: 'chat', ok: false, code: 'UNKNOWN_KEY', etag: 'new-etag' }],
+    })
+    await expect(
+      storage.downloadChatForBackup('chat', 'captured-etag'),
+    ).rejects.toMatchObject({
+      category: 'snapshot_changed',
+      reason: 'record_changed_after_snapshot',
+    })
+
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'chat',
+          ok: false,
+          code: 'UNKNOWN_KEY',
+          etag: 'rewrapped-etag',
+          previous_etag: 'captured-etag',
+        },
+      ],
+    })
+    const matchingKeyFailure = await storage
+      .downloadChatForBackup('chat', 'captured-etag')
+      .catch((error: unknown) => error)
+    expect(matchingKeyFailure).toBeInstanceOf(SyncEnclaveError)
+    expect(matchingKeyFailure).toMatchObject({ code: 'UNKNOWN_KEY' })
+
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [{ id: 'chat', ok: false, code: 'UNKNOWN_KEY' }],
+    })
+    await expect(
+      storage.downloadChatForBackup('chat', 'captured-etag'),
+    ).rejects.toMatchObject({ code: 'missing_etag' })
+
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [{ id: 'chat', ok: false, code: 'NOT_FOUND', etag: 'new-etag' }],
+    })
+    await expect(
+      storage.downloadChatForBackup('chat', 'captured-etag'),
+    ).rejects.toMatchObject({ category: 'snapshot_changed' })
   })
 
   it('keeps unknown legacy attachment runtime failures fatal', async () => {

--- a/tests/services/cloud/cloud-storage.test.ts
+++ b/tests/services/cloud/cloud-storage.test.ts
@@ -1,4 +1,5 @@
 import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
+import { unwrapBackupPullResult } from '@/services/cloud/backup-read-error'
 import {
   CloudBackupReadError,
   CloudStorageService,
@@ -55,6 +56,16 @@ vi.mock('@/services/sync-enclave/sync-api', async () => {
     attachmentGet: (...args: any[]) => mockAttachmentGet(...args),
   }
 })
+
+async function downloadChatForBackup(
+  storage: CloudStorageService,
+  id: string,
+  expectedEtag: string,
+) {
+  return unwrapBackupPullResult(
+    (await storage.downloadChatsForBackup([{ id, expectedEtag }]))[0],
+  )
+}
 
 describe('CloudStorageService auth readiness', () => {
   beforeEach(() => {
@@ -244,9 +255,9 @@ describe('CloudStorageService auth readiness', () => {
         },
       ],
     })
-    const malformed = await storage
-      .downloadChatForBackup('chat', '1')
-      .catch((error: unknown) => error)
+    const malformed = await downloadChatForBackup(storage, 'chat', '1').catch(
+      (error: unknown) => error,
+    )
     expect(malformed).toBeInstanceOf(CloudBackupReadError)
     expect(malformed).toMatchObject({
       category: 'item_invalid',
@@ -269,7 +280,7 @@ describe('CloudStorageService auth readiness', () => {
       ],
     })
     try {
-      await expect(storage.downloadChatForBackup('chat', '1')).rejects.toBe(
+      await expect(downloadChatForBackup(storage, 'chat', '1')).rejects.toBe(
         runtimeFailure,
       )
     } finally {
@@ -285,7 +296,7 @@ describe('CloudStorageService auth readiness', () => {
       ],
     })
     await expect(
-      storage.downloadChatForBackup('chat', 'captured-etag'),
+      downloadChatForBackup(storage, 'chat', 'captured-etag'),
     ).rejects.toMatchObject({
       category: 'snapshot_changed',
       reason: 'record_changed_after_snapshot',
@@ -296,19 +307,19 @@ describe('CloudStorageService auth readiness', () => {
       items: [{ id: 'other-chat', ok: true, etag: 'captured-etag' }],
     })
     await expect(
-      storage.downloadChatForBackup('chat', 'captured-etag'),
+      downloadChatForBackup(storage, 'chat', 'captured-etag'),
     ).rejects.toMatchObject({ code: 'unexpected_item' })
 
     mockEnclavePull.mockResolvedValueOnce({ items: [] })
     await expect(
-      storage.downloadChatForBackup('chat', 'captured-etag'),
+      downloadChatForBackup(storage, 'chat', 'captured-etag'),
     ).rejects.toMatchObject({ code: 'missing_item' })
 
     mockEnclavePull.mockResolvedValueOnce({
       items: [{ id: 'chat', ok: true, plaintext: btoa('{}') }],
     })
     await expect(
-      storage.downloadChatForBackup('chat', 'captured-etag'),
+      downloadChatForBackup(storage, 'chat', 'captured-etag'),
     ).rejects.toMatchObject({ code: 'missing_etag' })
 
     mockEnclavePull.mockResolvedValueOnce({
@@ -323,14 +334,14 @@ describe('CloudStorageService auth readiness', () => {
       ],
     })
     await expect(
-      storage.downloadChatForBackup('chat', 'captured-etag'),
+      downloadChatForBackup(storage, 'chat', 'captured-etag'),
     ).rejects.toMatchObject({ code: 'invalid_previous_etag' })
 
     mockEnclavePull.mockResolvedValueOnce({
       items: [{ id: 'chat', ok: false, code: 'NOT_FOUND' }],
     })
     await expect(
-      storage.downloadChatForBackup('chat', 'captured-etag'),
+      downloadChatForBackup(storage, 'chat', 'captured-etag'),
     ).rejects.toMatchObject({
       category: 'snapshot_deleted',
       reason: 'record_deleted_after_snapshot',
@@ -352,7 +363,7 @@ describe('CloudStorageService auth readiness', () => {
     })
 
     await expect(
-      storage.downloadChatForBackup('chat', 'captured-etag'),
+      downloadChatForBackup(storage, 'chat', 'captured-etag'),
     ).resolves.toMatchObject({ id: 'chat', title: 'Rewrapped' })
 
     mockEnclavePull.mockResolvedValueOnce({
@@ -367,7 +378,7 @@ describe('CloudStorageService auth readiness', () => {
       ],
     })
     await expect(
-      storage.downloadChatForBackup('chat', 'captured-etag'),
+      downloadChatForBackup(storage, 'chat', 'captured-etag'),
     ).rejects.toMatchObject({ code: 'invalid_previous_etag' })
   })
 
@@ -377,7 +388,7 @@ describe('CloudStorageService auth readiness', () => {
       items: [{ id: 'chat', ok: false, code: 'UNKNOWN_KEY', etag: 'new-etag' }],
     })
     await expect(
-      storage.downloadChatForBackup('chat', 'captured-etag'),
+      downloadChatForBackup(storage, 'chat', 'captured-etag'),
     ).rejects.toMatchObject({
       category: 'snapshot_changed',
       reason: 'record_changed_after_snapshot',
@@ -394,9 +405,11 @@ describe('CloudStorageService auth readiness', () => {
         },
       ],
     })
-    const matchingKeyFailure = await storage
-      .downloadChatForBackup('chat', 'captured-etag')
-      .catch((error: unknown) => error)
+    const matchingKeyFailure = await downloadChatForBackup(
+      storage,
+      'chat',
+      'captured-etag',
+    ).catch((error: unknown) => error)
     expect(matchingKeyFailure).toBeInstanceOf(SyncEnclaveError)
     expect(matchingKeyFailure).toMatchObject({ code: 'UNKNOWN_KEY' })
 
@@ -404,14 +417,14 @@ describe('CloudStorageService auth readiness', () => {
       items: [{ id: 'chat', ok: false, code: 'UNKNOWN_KEY' }],
     })
     await expect(
-      storage.downloadChatForBackup('chat', 'captured-etag'),
+      downloadChatForBackup(storage, 'chat', 'captured-etag'),
     ).rejects.toMatchObject({ code: 'missing_etag' })
 
     mockEnclavePull.mockResolvedValueOnce({
       items: [{ id: 'chat', ok: false, code: 'NOT_FOUND', etag: 'new-etag' }],
     })
     await expect(
-      storage.downloadChatForBackup('chat', 'captured-etag'),
+      downloadChatForBackup(storage, 'chat', 'captured-etag'),
     ).rejects.toMatchObject({ category: 'snapshot_changed' })
   })
 

--- a/tests/services/cloud/cloud-storage.test.ts
+++ b/tests/services/cloud/cloud-storage.test.ts
@@ -4,6 +4,7 @@ import {
   CloudStorageService,
 } from '@/services/cloud/cloud-storage'
 import { SyncEnclaveError, SyncNetworkError } from '@/services/sync-enclave'
+import { EncryptedAttachmentValidationError } from '@/utils/binary-codec'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetAuthHeaders = vi.fn()
@@ -462,12 +463,64 @@ describe('CloudStorageService auth readiness', () => {
       >[0]),
     ).rejects.toMatchObject({
       category: 'item_invalid',
-      reason: 'attachment_payload_invalid',
+      reason: 'attachment_key_invalid',
       omittable: true,
       cause: expect.objectContaining({ name: 'InvalidCharacterError' }),
     })
 
     const key = btoa(String.fromCharCode(...new Uint8Array(32)))
+    const invalidLength = await storage
+      .loadChatImageForBackup({
+        id: 'invalid-key-length',
+        type: 'image',
+        fileName: 'legacy.png',
+        key: 'AA==',
+      } as unknown as Parameters<
+        CloudStorageService['loadChatImageForBackup']
+      >[0])
+      .catch((error: unknown) => error)
+    expect(invalidLength).toMatchObject({
+      category: 'item_invalid',
+      reason: 'attachment_key_invalid',
+      omittable: true,
+    })
+    expect(invalidLength.cause).toBeInstanceOf(
+      EncryptedAttachmentValidationError,
+    )
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => new Uint8Array(20).buffer,
+      }),
+    )
+    const truncated = await storage
+      .loadChatImageForBackup({
+        id: 'truncated-ciphertext',
+        type: 'image',
+        fileName: 'legacy.png',
+        key,
+      } as unknown as Parameters<
+        CloudStorageService['loadChatImageForBackup']
+      >[0])
+      .catch((error: unknown) => error)
+    expect(truncated).toMatchObject({
+      category: 'item_invalid',
+      reason: 'attachment_payload_invalid',
+      omittable: true,
+    })
+    expect(truncated.cause).toBeInstanceOf(EncryptedAttachmentValidationError)
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => encrypted,
+      }),
+    )
     await expect(
       storage.loadChatImageForBackup({
         id: 'corrupt-ciphertext',

--- a/tests/services/cloud/cloud-storage.test.ts
+++ b/tests/services/cloud/cloud-storage.test.ts
@@ -439,6 +439,95 @@ describe('CloudStorageService auth readiness', () => {
     ).rejects.toBe(runtimeFailure)
   })
 
+  it('omits only structured legacy attachment decode and decrypt failures', async () => {
+    const storage = new CloudStorageService()
+    const encrypted = new Uint8Array(32).buffer
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => encrypted,
+      }),
+    )
+
+    await expect(
+      storage.loadChatImageForBackup({
+        id: 'malformed-key',
+        type: 'image',
+        fileName: 'legacy.png',
+        key: 'not base64!',
+      } as unknown as Parameters<
+        CloudStorageService['loadChatImageForBackup']
+      >[0]),
+    ).rejects.toMatchObject({
+      category: 'item_invalid',
+      reason: 'attachment_payload_invalid',
+      omittable: true,
+      cause: expect.objectContaining({ name: 'InvalidCharacterError' }),
+    })
+
+    const key = btoa(String.fromCharCode(...new Uint8Array(32)))
+    await expect(
+      storage.loadChatImageForBackup({
+        id: 'corrupt-ciphertext',
+        type: 'image',
+        fileName: 'legacy.png',
+        key,
+      } as unknown as Parameters<
+        CloudStorageService['loadChatImageForBackup']
+      >[0]),
+    ).rejects.toMatchObject({
+      category: 'item_invalid',
+      reason: 'attachment_payload_invalid',
+      omittable: true,
+      cause: expect.objectContaining({ name: 'OperationError' }),
+    })
+  })
+
+  it('keeps legacy attachment transport, HTTP, and runtime failures fatal', async () => {
+    const storage = new CloudStorageService()
+    const attachment = {
+      id: 'legacy',
+      type: 'image',
+      fileName: 'legacy.png',
+      key: btoa(String.fromCharCode(...new Uint8Array(32))),
+    } as unknown as Parameters<CloudStorageService['loadChatImageForBackup']>[0]
+    const networkCause = new TypeError('Network unavailable')
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(networkCause))
+    await expect(
+      storage.loadChatImageForBackup(attachment),
+    ).rejects.toMatchObject({ code: 'NETWORK', cause: networkCause })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({ ok: false, status: 503 }),
+    )
+    await expect(
+      storage.loadChatImageForBackup(attachment),
+    ).rejects.toMatchObject({ status: 503 })
+
+    const runtimeFailure = new Error('Unexpected crypto runtime failure')
+    const decrypt = vi
+      .spyOn(crypto.subtle, 'decrypt')
+      .mockRejectedValueOnce(runtimeFailure)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => new Uint8Array(32).buffer,
+      }),
+    )
+    try {
+      await expect(storage.loadChatImageForBackup(attachment)).rejects.toBe(
+        runtimeFailure,
+      )
+    } finally {
+      decrypt.mockRestore()
+    }
+  })
+
   it('preserves an explicit project delete on a single conflict pull', async () => {
     mockEnclavePull.mockResolvedValue({
       items: [

--- a/tests/services/cloud/project-storage.documents.test.ts
+++ b/tests/services/cloud/project-storage.documents.test.ts
@@ -1,3 +1,4 @@
+import { CloudBackupReadError } from '@/services/cloud/backup-read-error'
 import { ProjectStorageService } from '@/services/cloud/project-storage'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -90,6 +91,37 @@ describe('ProjectStorageService documents', () => {
     expect(documents.get('doc-1')?.sizeBytes).toBe(
       new TextEncoder().encode(content).length,
     )
+  })
+
+  it('strictly distinguishes malformed document data from runtime failures', async () => {
+    const storage = new ProjectStorageService()
+    mocks.enclavePull.mockResolvedValue({
+      items: [{ id: 'project-1/doc-1', ok: true, etag: '1' }],
+    })
+    mocks.pullItemPlaintext.mockReturnValue(new TextEncoder().encode('{'))
+
+    const malformed = await storage
+      .getDocumentForBackup('project-1', 'doc-1')
+      .catch((error: unknown) => error)
+    expect(malformed).toBeInstanceOf(CloudBackupReadError)
+    expect(malformed).toMatchObject({
+      category: 'item_invalid',
+      reason: 'document_payload_invalid',
+      omittable: true,
+    })
+
+    const runtimeFailure = new Error('unexpected JSON runtime failure')
+    const parse = vi.spyOn(JSON, 'parse').mockImplementationOnce(() => {
+      throw runtimeFailure
+    })
+    mocks.pullItemPlaintext.mockReturnValue(new TextEncoder().encode('{}'))
+    try {
+      await expect(
+        storage.getDocumentForBackup('project-1', 'doc-1'),
+      ).rejects.toBe(runtimeFailure)
+    } finally {
+      parse.mockRestore()
+    }
   })
 
   it('deduplicates documents listed on multiple pages', async () => {

--- a/tests/services/cloud/project-storage.documents.test.ts
+++ b/tests/services/cloud/project-storage.documents.test.ts
@@ -1,4 +1,7 @@
-import { CloudBackupReadError } from '@/services/cloud/backup-read-error'
+import {
+  CloudBackupReadError,
+  unwrapBackupPullResult,
+} from '@/services/cloud/backup-read-error'
 import { ProjectStorageService } from '@/services/cloud/project-storage'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -40,6 +43,17 @@ vi.mock('@/services/sync-enclave/sync-api', async () => {
 vi.mock('@/utils/error-handling', () => ({
   logError: vi.fn(),
 }))
+
+async function getDocumentForBackup(
+  storage: ProjectStorageService,
+  projectId: string,
+  id: string,
+  expectedEtag: string,
+) {
+  return unwrapBackupPullResult(
+    (await storage.getDocumentsForBackup([{ projectId, id, expectedEtag }]))[0],
+  )
+}
 
 describe('ProjectStorageService documents', () => {
   beforeEach(() => {
@@ -106,9 +120,12 @@ describe('ProjectStorageService documents', () => {
     })
     mocks.pullItemPlaintext.mockReturnValue(new TextEncoder().encode('{'))
 
-    const malformed = await storage
-      .getDocumentForBackup('project-1', 'doc-1', '1')
-      .catch((error: unknown) => error)
+    const malformed = await getDocumentForBackup(
+      storage,
+      'project-1',
+      'doc-1',
+      '1',
+    ).catch((error: unknown) => error)
     expect(malformed).toBeInstanceOf(CloudBackupReadError)
     expect(malformed).toMatchObject({
       category: 'item_invalid',
@@ -123,7 +140,7 @@ describe('ProjectStorageService documents', () => {
     mocks.pullItemPlaintext.mockReturnValue(new TextEncoder().encode('{}'))
     try {
       await expect(
-        storage.getDocumentForBackup('project-1', 'doc-1', '1'),
+        getDocumentForBackup(storage, 'project-1', 'doc-1', '1'),
       ).rejects.toBe(runtimeFailure)
     } finally {
       parse.mockRestore()
@@ -143,7 +160,7 @@ describe('ProjectStorageService documents', () => {
       ],
     })
     await expect(
-      storage.getDocumentForBackup('project-1', 'doc-1', 'captured-etag'),
+      getDocumentForBackup(storage, 'project-1', 'doc-1', 'captured-etag'),
     ).rejects.toMatchObject({
       category: 'snapshot_changed',
       reason: 'record_changed_after_snapshot',
@@ -153,7 +170,7 @@ describe('ProjectStorageService documents', () => {
       items: [{ id: 'doc-1', ok: true, etag: 'captured-etag' }],
     })
     await expect(
-      storage.getDocumentForBackup('project-1', 'doc-1', 'captured-etag'),
+      getDocumentForBackup(storage, 'project-1', 'doc-1', 'captured-etag'),
     ).rejects.toMatchObject({ code: 'unexpected_item' })
   })
 
@@ -180,7 +197,7 @@ describe('ProjectStorageService documents', () => {
     )
 
     await expect(
-      storage.getDocumentForBackup('project-1', 'doc-1', 'captured-etag'),
+      getDocumentForBackup(storage, 'project-1', 'doc-1', 'captured-etag'),
     ).resolves.toMatchObject({
       id: 'doc-1',
       projectId: 'project-1',

--- a/tests/services/cloud/project-storage.documents.test.ts
+++ b/tests/services/cloud/project-storage.documents.test.ts
@@ -22,14 +22,20 @@ vi.mock('@/services/cloud/cek-encoding', () => ({
   requirePrimaryKeyB64: () => 'primary-key',
 }))
 
-vi.mock('@/services/sync-enclave/sync-api', () => ({
-  deleteRow: vi.fn(),
-  listStatus: mocks.enclaveListStatus,
-  pull: mocks.enclavePull,
-  push: mocks.enclavePush,
-  newIdempotencyKey: () => 'idempotency-key',
-  pullItemPlaintext: mocks.pullItemPlaintext,
-}))
+vi.mock('@/services/sync-enclave/sync-api', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/services/sync-enclave/sync-api')
+  >('@/services/sync-enclave/sync-api')
+  return {
+    ...actual,
+    deleteRow: vi.fn(),
+    listStatus: mocks.enclaveListStatus,
+    pull: mocks.enclavePull,
+    push: mocks.enclavePush,
+    newIdempotencyKey: () => 'idempotency-key',
+    pullItemPlaintext: mocks.pullItemPlaintext,
+  }
+})
 
 vi.mock('@/utils/error-handling', () => ({
   logError: vi.fn(),
@@ -101,7 +107,7 @@ describe('ProjectStorageService documents', () => {
     mocks.pullItemPlaintext.mockReturnValue(new TextEncoder().encode('{'))
 
     const malformed = await storage
-      .getDocumentForBackup('project-1', 'doc-1')
+      .getDocumentForBackup('project-1', 'doc-1', '1')
       .catch((error: unknown) => error)
     expect(malformed).toBeInstanceOf(CloudBackupReadError)
     expect(malformed).toMatchObject({
@@ -117,11 +123,69 @@ describe('ProjectStorageService documents', () => {
     mocks.pullItemPlaintext.mockReturnValue(new TextEncoder().encode('{}'))
     try {
       await expect(
-        storage.getDocumentForBackup('project-1', 'doc-1'),
+        storage.getDocumentForBackup('project-1', 'doc-1', '1'),
       ).rejects.toBe(runtimeFailure)
     } finally {
       parse.mockRestore()
     }
+  })
+
+  it('enforces captured document identity and opaque ETag for backup reads', async () => {
+    const storage = new ProjectStorageService()
+    mocks.enclavePull.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'project-1/doc-1',
+          ok: true,
+          etag: 'new-etag',
+          plaintext: 'ignored',
+        },
+      ],
+    })
+    await expect(
+      storage.getDocumentForBackup('project-1', 'doc-1', 'captured-etag'),
+    ).rejects.toMatchObject({
+      category: 'snapshot_changed',
+      reason: 'record_changed_after_snapshot',
+    })
+
+    mocks.enclavePull.mockResolvedValueOnce({
+      items: [{ id: 'doc-1', ok: true, etag: 'captured-etag' }],
+    })
+    await expect(
+      storage.getDocumentForBackup('project-1', 'doc-1', 'captured-etag'),
+    ).rejects.toMatchObject({ code: 'unexpected_item' })
+  })
+
+  it('accepts a document lazily rewrapped from the captured ETag', async () => {
+    const storage = new ProjectStorageService()
+    mocks.enclavePull.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'project-1/doc-1',
+          ok: true,
+          etag: 'rewrapped-etag',
+          previous_etag: 'captured-etag',
+        },
+      ],
+    })
+    mocks.pullItemPlaintext.mockReturnValue(
+      new TextEncoder().encode(
+        JSON.stringify({
+          filename: 'notes.txt',
+          contentType: 'text/plain',
+          content: 'rewrapped content',
+        }),
+      ),
+    )
+
+    await expect(
+      storage.getDocumentForBackup('project-1', 'doc-1', 'captured-etag'),
+    ).resolves.toMatchObject({
+      id: 'doc-1',
+      projectId: 'project-1',
+      content: 'rewrapped content',
+    })
   })
 
   it('deduplicates documents listed on multiple pages', async () => {

--- a/tests/services/native-backup/collect-cancellation.test.ts
+++ b/tests/services/native-backup/collect-cancellation.test.ts
@@ -1,8 +1,16 @@
+import type { BackupPullResult } from '@/services/cloud/backup-read-error'
 import type { NativeBackupCollectionDependencies } from '@/services/native-backup'
 import { collectNativeBackupV1 } from '@/services/native-backup'
 import type { StoredChat } from '@/services/storage/indexed-db'
 
 const timestamp = '2026-08-20T12:00:00.000Z'
+
+function batchOf<T>(
+  requests: readonly unknown[],
+  value: T,
+): BackupPullResult<T>[] {
+  return requests.map(() => ({ ok: true, value }))
+}
 
 function dependencies(
   overrides: Partial<NativeBackupCollectionDependencies> = {},
@@ -16,10 +24,10 @@ function dependencies(
       total_items: 0,
       items: [],
     }),
-    getCloudChat: async () => null,
+    getCloudChats: async (requests) => batchOf(requests, null),
     getCloudImage: async () => null,
-    getProject: async () => null,
-    getDocument: async () => null,
+    getProjects: async (requests) => batchOf(requests, null),
+    getDocuments: async (requests) => batchOf(requests, null),
     getLocalChats: async () => [],
     getLocalChat: async () => null,
     ...overrides,
@@ -69,7 +77,7 @@ describe('native backup collection cancellation', () => {
   it('stops immediately when the one-shot inventory request aborts', async () => {
     const controller = new AbortController()
     const reason = new DOMException('Canceled', 'AbortError')
-    const getCloudChat = vi.fn()
+    const getCloudChats = vi.fn()
     const getCloudInventory = vi.fn().mockImplementation(async () => {
       controller.abort(reason)
       return { captured_at: timestamp, total_items: 0, items: [] }
@@ -77,22 +85,26 @@ describe('native backup collection cancellation', () => {
 
     await expect(
       collectNativeBackupV1(
-        dependencies({ getCloudInventory, getCloudChat }),
+        dependencies({ getCloudInventory, getCloudChats }),
         controller.signal,
       ),
     ).rejects.toBe(reason)
     expect(getCloudInventory).toHaveBeenCalledTimes(1)
-    expect(getCloudChat).not.toHaveBeenCalled()
+    expect(getCloudChats).not.toHaveBeenCalled()
   })
 
-  it('does not read later projects after a project read aborts', async () => {
+  it('does not process later project batches after a batch read aborts', async () => {
     const controller = new AbortController()
     const reason = new DOMException('Canceled', 'AbortError')
-    const getProject = vi.fn().mockImplementation(async () => {
-      controller.abort(reason)
-      return null
-    })
-    const projects = Array.from({ length: 8 }, (_, index) => ({
+    const getProjects = vi
+      .fn()
+      .mockImplementation(async (requests: readonly unknown[]) => {
+        controller.abort(reason)
+        return batchOf(requests, null)
+      })
+    // More projects than one pull batch so a second batch would be
+    // fetched if the abort were ignored.
+    const projects = Array.from({ length: 30 }, (_, index) => ({
       id: `project-${index}`,
       scope: 'project' as const,
       etag: 'etag',
@@ -108,13 +120,15 @@ describe('native backup collection cancellation', () => {
             total_items: projects.length,
             items: projects,
           }),
-          getProject,
+          getProjects,
         }),
         controller.signal,
       ),
     ).rejects.toBe(reason)
-    expect(getProject).toHaveBeenCalledTimes(1)
-    expect(getProject).toHaveBeenCalledWith('project-0', 'etag')
+    expect(getProjects).toHaveBeenCalledTimes(1)
+    expect(
+      getProjects.mock.calls[0][0].map(({ id }: { id: string }) => id),
+    ).toEqual(projects.slice(0, 20).map(({ id }) => id))
   })
 
   it('stops image reads and never returns partial input after abort', async () => {
@@ -125,7 +139,11 @@ describe('native backup collection cancellation', () => {
       controller.abort(reason)
       return new Uint8Array([1])
     })
-    const getCloudChat = vi.fn().mockResolvedValue(chat)
+    const getCloudChats = vi
+      .fn()
+      .mockImplementation(async (requests: readonly unknown[]) =>
+        batchOf(requests, chat),
+      )
 
     await expect(
       collectNativeBackupV1(
@@ -143,13 +161,13 @@ describe('native backup collection cancellation', () => {
               },
             ],
           }),
-          getCloudChat,
+          getCloudChats,
           getCloudImage,
         }),
         controller.signal,
       ),
     ).rejects.toBe(reason)
     expect(getCloudImage).toHaveBeenCalledTimes(1)
-    expect(getCloudChat).toHaveBeenCalledTimes(1)
+    expect(getCloudChats).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/services/native-backup/collect-cancellation.test.ts
+++ b/tests/services/native-backup/collect-cancellation.test.ts
@@ -11,12 +11,14 @@ function dependencies(
     isAuthenticated: async () => true,
     activeUserId: () => 'user',
     requireUnlockedCek: () => {},
-    listChats: async () => ({ items: [] }),
+    getCloudInventory: async () => ({
+      captured_at: timestamp,
+      total_items: 0,
+      items: [],
+    }),
     getCloudChat: async () => null,
     getCloudImage: async () => null,
-    listProjects: async () => ({ items: [] }),
     getProject: async () => null,
-    listDocuments: async () => [],
     getDocument: async () => null,
     getLocalChats: async () => [],
     getLocalChat: async () => null,
@@ -64,53 +66,55 @@ describe('native backup collection cancellation', () => {
     expect(isAuthenticated).not.toHaveBeenCalled()
   })
 
-  it('stops pagination immediately after an awaited page aborts', async () => {
+  it('stops immediately when the one-shot inventory request aborts', async () => {
     const controller = new AbortController()
     const reason = new DOMException('Canceled', 'AbortError')
     const getCloudChat = vi.fn()
-    const listChats = vi.fn().mockImplementation(async () => {
+    const getCloudInventory = vi.fn().mockImplementation(async () => {
       controller.abort(reason)
-      return { items: [], next: 'another-page' }
+      return { captured_at: timestamp, total_items: 0, items: [] }
     })
 
     await expect(
       collectNativeBackupV1(
-        dependencies({ listChats, getCloudChat }),
+        dependencies({ getCloudInventory, getCloudChat }),
         controller.signal,
       ),
     ).rejects.toBe(reason)
-    expect(listChats).toHaveBeenCalledTimes(1)
+    expect(getCloudInventory).toHaveBeenCalledTimes(1)
     expect(getCloudChat).not.toHaveBeenCalled()
   })
 
-  it('does not schedule more bounded document workers after abort', async () => {
+  it('does not read later projects after a project read aborts', async () => {
     const controller = new AbortController()
     const reason = new DOMException('Canceled', 'AbortError')
-    const getProject = vi.fn()
-    const listDocuments = vi.fn().mockImplementation(async () => {
+    const getProject = vi.fn().mockImplementation(async () => {
       controller.abort(reason)
-      return []
+      return null
     })
     const projects = Array.from({ length: 8 }, (_, index) => ({
       id: `project-${index}`,
-      syncVersion: 1,
-      createdAt: timestamp,
-      updatedAt: timestamp,
+      scope: 'project' as const,
+      etag: 'etag',
+      created_at: timestamp,
+      updated_at: timestamp,
     }))
 
     await expect(
       collectNativeBackupV1(
         dependencies({
-          listProjects: async () => ({ items: projects }),
-          listDocuments,
+          getCloudInventory: async () => ({
+            captured_at: timestamp,
+            total_items: projects.length,
+            items: projects,
+          }),
           getProject,
         }),
         controller.signal,
       ),
     ).rejects.toBe(reason)
-    expect(listDocuments).toHaveBeenCalledTimes(1)
-    expect(listDocuments).toHaveBeenCalledWith('project-0')
-    expect(getProject).not.toHaveBeenCalled()
+    expect(getProject).toHaveBeenCalledTimes(1)
+    expect(getProject).toHaveBeenCalledWith('project-0', 'etag')
   })
 
   it('stops image reads and never returns partial input after abort', async () => {
@@ -126,8 +130,18 @@ describe('native backup collection cancellation', () => {
     await expect(
       collectNativeBackupV1(
         dependencies({
-          listChats: async () => ({
-            items: [{ id: chat.id, syncVersion: 1 }],
+          getCloudInventory: async () => ({
+            captured_at: timestamp,
+            total_items: 1,
+            items: [
+              {
+                scope: 'chat',
+                id: chat.id,
+                etag: 'etag',
+                created_at: timestamp,
+                updated_at: timestamp,
+              },
+            ],
           }),
           getCloudChat,
           getCloudImage,

--- a/tests/services/native-backup/collect-cancellation.test.ts
+++ b/tests/services/native-backup/collect-cancellation.test.ts
@@ -1,6 +1,7 @@
 import type { BackupPullResult } from '@/services/cloud/backup-read-error'
 import type { NativeBackupCollectionDependencies } from '@/services/native-backup'
 import { collectNativeBackupV1 } from '@/services/native-backup'
+import { CLOUD_PULL_BATCH_SIZE } from '@/services/native-backup/collect'
 import type { StoredChat } from '@/services/storage/indexed-db'
 
 const timestamp = '2026-08-20T12:00:00.000Z'
@@ -104,13 +105,16 @@ describe('native backup collection cancellation', () => {
       })
     // More projects than one pull batch so a second batch would be
     // fetched if the abort were ignored.
-    const projects = Array.from({ length: 30 }, (_, index) => ({
-      id: `project-${index}`,
-      scope: 'project' as const,
-      etag: 'etag',
-      created_at: timestamp,
-      updated_at: timestamp,
-    }))
+    const projects = Array.from(
+      { length: CLOUD_PULL_BATCH_SIZE + 10 },
+      (_, index) => ({
+        id: `project-${index}`,
+        scope: 'project' as const,
+        etag: 'etag',
+        created_at: timestamp,
+        updated_at: timestamp,
+      }),
+    )
 
     await expect(
       collectNativeBackupV1(
@@ -128,7 +132,7 @@ describe('native backup collection cancellation', () => {
     expect(getProjects).toHaveBeenCalledTimes(1)
     expect(
       getProjects.mock.calls[0][0].map(({ id }: { id: string }) => id),
-    ).toEqual(projects.slice(0, 20).map(({ id }) => id))
+    ).toEqual(projects.slice(0, CLOUD_PULL_BATCH_SIZE).map(({ id }) => id))
   })
 
   it('stops image reads and never returns partial input after abort', async () => {

--- a/tests/services/native-backup/collect-limits.test.ts
+++ b/tests/services/native-backup/collect-limits.test.ts
@@ -11,6 +11,8 @@ vi.mock('@/services/native-backup/constants', async (importOriginal) => {
     NATIVE_BACKUP_LIMITS: {
       ...actual.NATIVE_BACKUP_LIMITS,
       messages: 1,
+      attachments: 1,
+      entries: 5,
       discoveredRecords: 2,
       omissions: 1,
     },
@@ -129,5 +131,51 @@ describe('native backup collection limits', () => {
       ),
     ).rejects.toThrow('omission limit exceeded')
     expect(getCloudChat).toHaveBeenCalledTimes(6)
+  })
+
+  it('recomputes partial chat limits after dropping an unavailable image', async () => {
+    const { collectNativeBackupV2 } =
+      await import('@/services/native-backup/collect')
+    const source: StoredChat = {
+      ...cloudChat,
+      messages: [
+        {
+          role: 'user',
+          content: 'images',
+          timestamp: new Date(timestamp),
+          attachments: [
+            {
+              id: 'available',
+              type: 'image',
+              fileName: 'available.png',
+              encryptionKey: 'key',
+            },
+            {
+              id: 'missing',
+              type: 'image',
+              fileName: 'missing.png',
+              encryptionKey: 'key',
+            },
+          ],
+        },
+      ],
+    }
+    const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
+
+    const result = await collectNativeBackupV2(
+      dependencies({
+        getCloudInventory: async () => ({
+          captured_at: timestamp,
+          total_items: 1,
+          items: [item('chat')],
+        }),
+        getCloudChat: async () => source,
+        getCloudImage: async ({ id }) => (id === 'available' ? png : null),
+      }),
+    )
+
+    expect(result.cloudChats[0].messages[0].attachments).toHaveLength(1)
+    expect(result.images).toHaveLength(1)
+    expect(result.omissions).toHaveLength(1)
   })
 })

--- a/tests/services/native-backup/collect-limits.test.ts
+++ b/tests/services/native-backup/collect-limits.test.ts
@@ -1,10 +1,28 @@
-import { CloudBackupReadError } from '@/services/cloud/backup-read-error'
+import {
+  CloudBackupReadError,
+  type BackupPullResult,
+} from '@/services/cloud/backup-read-error'
 import {
   NativeBackupCollectionError,
   type NativeBackupCollectionDependencies,
 } from '@/services/native-backup/collect'
 import type { StoredChat } from '@/services/storage/indexed-db'
 import type { BackupInventoryItem } from '@/services/sync-enclave/sync-api'
+
+function batchReads<T>(fn: (id: string, expectedEtag: string) => Promise<T>) {
+  return (requests: ReadonlyArray<{ id: string; expectedEtag: string }>) =>
+    Promise.all(
+      requests.map(
+        async ({ id, expectedEtag }): Promise<BackupPullResult<T>> => {
+          try {
+            return { ok: true, value: await fn(id, expectedEtag) }
+          } catch (error) {
+            return { ok: false, error }
+          }
+        },
+      ),
+    )
+}
 
 vi.mock('@/services/native-backup/constants', async (importOriginal) => {
   const actual =
@@ -58,10 +76,11 @@ function dependencies(
       total_items: 0,
       items: [],
     }),
-    getCloudChat: async () => null,
+    getCloudChats: batchReads(async () => null),
     getCloudImage: async () => null,
-    getProject: async () => null,
-    getDocument: async () => null,
+    getProjects: batchReads(async () => null),
+    getDocuments: async (requests: readonly unknown[]) =>
+      requests.map(() => ({ ok: true as const, value: null })),
     getLocalChats: async () => [],
     getLocalChat: async () => null,
     ...overrides,
@@ -82,7 +101,7 @@ describe('native backup collection limits', () => {
             total_items: 1,
             items: [item('chat')],
           }),
-          getCloudChat: async () => cloudChat,
+          getCloudChats: batchReads(async () => cloudChat),
           getCloudImage,
         }),
       ),
@@ -103,7 +122,7 @@ describe('native backup collection limits', () => {
             total_items: 3,
             items: [item('chat-1'), item('chat-2'), item('chat-3')],
           }),
-          getCloudChat,
+          getCloudChats: batchReads(getCloudChat),
         }),
       ),
     ).rejects.toThrow('discovered record limit exceeded')
@@ -129,7 +148,7 @@ describe('native backup collection limits', () => {
             total_items: 2,
             items: [item('chat-1'), item('chat-2')],
           }),
-          getCloudChat,
+          getCloudChats: batchReads(getCloudChat),
         }),
       ),
     ).rejects.toThrow('omission limit exceeded')
@@ -172,7 +191,7 @@ describe('native backup collection limits', () => {
           total_items: 1,
           items: [item('chat')],
         }),
-        getCloudChat: async () => source,
+        getCloudChats: batchReads(async () => source),
         getCloudImage: async ({ id }) => (id === 'available' ? png : null),
       }),
     )
@@ -231,7 +250,7 @@ describe('native backup collection limits', () => {
           total_items: 1,
           items: [item('chat')],
         }),
-        getCloudChat: async () => source,
+        getCloudChats: batchReads(async () => source),
         getCloudImage,
       }),
     )

--- a/tests/services/native-backup/collect-limits.test.ts
+++ b/tests/services/native-backup/collect-limits.test.ts
@@ -1,6 +1,7 @@
 import { CloudBackupReadError } from '@/services/cloud/backup-read-error'
 import type { NativeBackupCollectionDependencies } from '@/services/native-backup/collect'
 import type { StoredChat } from '@/services/storage/indexed-db'
+import type { BackupInventoryItem } from '@/services/sync-enclave/sync-api'
 
 vi.mock('@/services/native-backup/constants', async (importOriginal) => {
   const actual =
@@ -17,23 +18,11 @@ vi.mock('@/services/native-backup/constants', async (importOriginal) => {
 })
 
 const timestamp = '2026-08-20T12:00:00.000Z'
-const localChat: StoredChat = {
-  id: 'local',
-  title: 'Local',
+const cloudChat: StoredChat = {
+  id: 'chat',
+  title: 'Chat',
   messages: [
-    {
-      role: 'user',
-      content: 'one',
-      timestamp: new Date(timestamp),
-      attachments: [
-        {
-          id: 'image',
-          type: 'image',
-          fileName: 'image.png',
-          encryptionKey: 'key',
-        },
-      ],
-    },
+    { role: 'user', content: 'one', timestamp: new Date(timestamp) },
     { role: 'assistant', content: 'two', timestamp: new Date(timestamp) },
   ],
   createdAt: timestamp,
@@ -42,61 +31,77 @@ const localChat: StoredChat = {
   syncVersion: 1,
 }
 
+function item(id: string): BackupInventoryItem {
+  return {
+    scope: 'chat',
+    id,
+    etag: 'opaque-etag',
+    created_at: timestamp,
+    updated_at: timestamp,
+  }
+}
+
+function dependencies(
+  overrides: Partial<NativeBackupCollectionDependencies> = {},
+): NativeBackupCollectionDependencies {
+  return {
+    isAuthenticated: async () => true,
+    activeUserId: () => 'user',
+    requireUnlockedCek: () => {},
+    getCloudInventory: async () => ({
+      captured_at: timestamp,
+      total_items: 0,
+      items: [],
+    }),
+    getCloudChat: async () => null,
+    getCloudImage: async () => null,
+    getProject: async () => null,
+    getDocument: async () => null,
+    getLocalChats: async () => [],
+    getLocalChat: async () => null,
+    ...overrides,
+  }
+}
+
 describe('native backup collection limits', () => {
   it('guards message counts before reading attachments', async () => {
-    const { collectNativeBackupV1 } =
+    const { collectNativeBackupV2 } =
       await import('@/services/native-backup/collect')
-    const getCloudImage = vi.fn().mockResolvedValue(new Uint8Array([1]))
-    const dependencies: NativeBackupCollectionDependencies = {
-      isAuthenticated: async () => true,
-      activeUserId: () => 'user',
-      requireUnlockedCek: () => {},
-      listChats: async () => ({
-        items: [{ id: localChat.id, syncVersion: 1 }],
-      }),
-      getCloudChat: async () => localChat,
-      getCloudImage,
-      listProjects: async () => ({ items: [] }),
-      getProject: async () => null,
-      listDocuments: async () => [],
-      getDocument: async () => null,
-      getLocalChats: async () => [],
-      getLocalChat: async () => null,
-    }
+    const getCloudImage = vi.fn()
 
-    await expect(collectNativeBackupV1(dependencies)).rejects.toThrow(
-      'message limit exceeded',
-    )
+    await expect(
+      collectNativeBackupV2(
+        dependencies({
+          getCloudInventory: async () => ({
+            captured_at: timestamp,
+            total_items: 1,
+            items: [item('chat')],
+          }),
+          getCloudChat: async () => cloudChat,
+          getCloudImage,
+        }),
+      ),
+    ).rejects.toThrow('message limit exceeded')
     expect(getCloudImage).not.toHaveBeenCalled()
   })
 
-  it('bounds discovered records before reading record contents', async () => {
+  it('bounds captured inventory before reading record contents', async () => {
     const { collectNativeBackupV2 } =
       await import('@/services/native-backup/collect')
     const getCloudChat = vi.fn()
-    const dependencies: NativeBackupCollectionDependencies = {
-      isAuthenticated: async () => true,
-      activeUserId: () => 'user',
-      requireUnlockedCek: () => {},
-      listChats: async () => ({
-        items: [1, 2, 3].map((index) => ({
-          id: `chat-${index}`,
-          syncVersion: 1,
-        })),
-      }),
-      getCloudChat,
-      getCloudImage: async () => null,
-      listProjects: async () => ({ items: [] }),
-      getProject: async () => null,
-      listDocuments: async () => [],
-      getDocument: async () => null,
-      getLocalChats: async () => [],
-      getLocalChat: async () => null,
-    }
 
-    await expect(collectNativeBackupV2(dependencies)).rejects.toThrow(
-      'discovered record limit exceeded',
-    )
+    await expect(
+      collectNativeBackupV2(
+        dependencies({
+          getCloudInventory: async () => ({
+            captured_at: timestamp,
+            total_items: 3,
+            items: [item('chat-1'), item('chat-2'), item('chat-3')],
+          }),
+          getCloudChat,
+        }),
+      ),
+    ).rejects.toThrow('discovered record limit exceeded')
     expect(getCloudChat).not.toHaveBeenCalled()
   })
 
@@ -110,29 +115,19 @@ describe('native backup collection limits', () => {
         true,
       )
     })
-    const dependencies: NativeBackupCollectionDependencies = {
-      isAuthenticated: async () => true,
-      activeUserId: () => 'user',
-      requireUnlockedCek: () => {},
-      listChats: async () => ({
-        items: [
-          { id: 'chat-1', syncVersion: 1 },
-          { id: 'chat-2', syncVersion: 1 },
-        ],
-      }),
-      getCloudChat,
-      getCloudImage: async () => null,
-      listProjects: async () => ({ items: [] }),
-      getProject: async () => null,
-      listDocuments: async () => [],
-      getDocument: async () => null,
-      getLocalChats: async () => [],
-      getLocalChat: async () => null,
-    }
 
-    await expect(collectNativeBackupV2(dependencies)).rejects.toThrow(
-      'omission limit exceeded',
-    )
+    await expect(
+      collectNativeBackupV2(
+        dependencies({
+          getCloudInventory: async () => ({
+            captured_at: timestamp,
+            total_items: 2,
+            items: [item('chat-1'), item('chat-2')],
+          }),
+          getCloudChat,
+        }),
+      ),
+    ).rejects.toThrow('omission limit exceeded')
     expect(getCloudChat).toHaveBeenCalledTimes(6)
   })
 })

--- a/tests/services/native-backup/collect-limits.test.ts
+++ b/tests/services/native-backup/collect-limits.test.ts
@@ -1,3 +1,4 @@
+import { CloudBackupReadError } from '@/services/cloud/backup-read-error'
 import type { NativeBackupCollectionDependencies } from '@/services/native-backup/collect'
 import type { StoredChat } from '@/services/storage/indexed-db'
 
@@ -9,6 +10,8 @@ vi.mock('@/services/native-backup/constants', async (importOriginal) => {
     NATIVE_BACKUP_LIMITS: {
       ...actual.NATIVE_BACKUP_LIMITS,
       messages: 1,
+      discoveredRecords: 2,
+      omissions: 1,
     },
   }
 })
@@ -65,5 +68,71 @@ describe('native backup collection limits', () => {
       'message limit exceeded',
     )
     expect(getCloudImage).not.toHaveBeenCalled()
+  })
+
+  it('bounds discovered records before reading record contents', async () => {
+    const { collectNativeBackupV2 } =
+      await import('@/services/native-backup/collect')
+    const getCloudChat = vi.fn()
+    const dependencies: NativeBackupCollectionDependencies = {
+      isAuthenticated: async () => true,
+      activeUserId: () => 'user',
+      requireUnlockedCek: () => {},
+      listChats: async () => ({
+        items: [1, 2, 3].map((index) => ({
+          id: `chat-${index}`,
+          syncVersion: 1,
+        })),
+      }),
+      getCloudChat,
+      getCloudImage: async () => null,
+      listProjects: async () => ({ items: [] }),
+      getProject: async () => null,
+      listDocuments: async () => [],
+      getDocument: async () => null,
+      getLocalChats: async () => [],
+      getLocalChat: async () => null,
+    }
+
+    await expect(collectNativeBackupV2(dependencies)).rejects.toThrow(
+      'discovered record limit exceeded',
+    )
+    expect(getCloudChat).not.toHaveBeenCalled()
+  })
+
+  it('bounds structured omissions incrementally', async () => {
+    const { collectNativeBackupV2 } =
+      await import('@/services/native-backup/collect')
+    const getCloudChat = vi.fn(async () => {
+      throw new CloudBackupReadError(
+        'item_invalid',
+        'chat_payload_invalid',
+        true,
+      )
+    })
+    const dependencies: NativeBackupCollectionDependencies = {
+      isAuthenticated: async () => true,
+      activeUserId: () => 'user',
+      requireUnlockedCek: () => {},
+      listChats: async () => ({
+        items: [
+          { id: 'chat-1', syncVersion: 1 },
+          { id: 'chat-2', syncVersion: 1 },
+        ],
+      }),
+      getCloudChat,
+      getCloudImage: async () => null,
+      listProjects: async () => ({ items: [] }),
+      getProject: async () => null,
+      listDocuments: async () => [],
+      getDocument: async () => null,
+      getLocalChats: async () => [],
+      getLocalChat: async () => null,
+    }
+
+    await expect(collectNativeBackupV2(dependencies)).rejects.toThrow(
+      'omission limit exceeded',
+    )
+    expect(getCloudChat).toHaveBeenCalledTimes(6)
   })
 })

--- a/tests/services/native-backup/collect-limits.test.ts
+++ b/tests/services/native-backup/collect-limits.test.ts
@@ -220,9 +220,8 @@ describe('native backup collection limits', () => {
       'image budget exceeded',
     )
     const getCloudImage = vi.fn(({ id }: { id: string }) => {
-      if (id === 'image-0') return earlier
       if (id === 'image-1') return later
-      return Promise.resolve(png)
+      return earlier
     })
 
     const collection = collectNativeBackupV2(

--- a/tests/services/native-backup/collect-limits.test.ts
+++ b/tests/services/native-backup/collect-limits.test.ts
@@ -1,5 +1,8 @@
 import { CloudBackupReadError } from '@/services/cloud/backup-read-error'
-import type { NativeBackupCollectionDependencies } from '@/services/native-backup/collect'
+import {
+  NativeBackupCollectionError,
+  type NativeBackupCollectionDependencies,
+} from '@/services/native-backup/collect'
 import type { StoredChat } from '@/services/storage/indexed-db'
 import type { BackupInventoryItem } from '@/services/sync-enclave/sync-api'
 
@@ -177,5 +180,69 @@ describe('native backup collection limits', () => {
     expect(result.cloudChats[0].messages[0].attachments).toHaveLength(1)
     expect(result.images).toHaveLength(1)
     expect(result.omissions).toHaveLength(1)
+  })
+
+  it('stops scheduling later downloads after an incremental limit failure', async () => {
+    const { collectNativeBackupV2 } =
+      await import('@/services/native-backup/collect')
+    const attachmentIds = Array.from(
+      { length: 8 },
+      (_, index) => `image-${index}`,
+    )
+    const source: StoredChat = {
+      ...cloudChat,
+      messages: [
+        {
+          role: 'user',
+          content: 'images',
+          timestamp: new Date(timestamp),
+          attachments: attachmentIds.map((id) => ({
+            id,
+            type: 'image' as const,
+            fileName: `${id}.png`,
+            encryptionKey: 'key',
+          })),
+        },
+      ],
+    }
+    const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
+    let releaseEarlier!: (bytes: Uint8Array) => void
+    const earlier = new Promise<Uint8Array>((resolve) => {
+      releaseEarlier = resolve
+    })
+    let rejectLater!: (error: Error) => void
+    const later = new Promise<Uint8Array>((_resolve, reject) => {
+      rejectLater = reject
+    })
+    const failure = new NativeBackupCollectionError(
+      'limits',
+      'collection',
+      'image budget exceeded',
+    )
+    const getCloudImage = vi.fn(({ id }: { id: string }) => {
+      if (id === 'image-0') return earlier
+      if (id === 'image-1') return later
+      return Promise.resolve(png)
+    })
+
+    const collection = collectNativeBackupV2(
+      dependencies({
+        getCloudInventory: async () => ({
+          captured_at: timestamp,
+          total_items: 1,
+          items: [item('chat')],
+        }),
+        getCloudChat: async () => source,
+        getCloudImage,
+      }),
+    )
+    await vi.waitFor(() => expect(getCloudImage).toHaveBeenCalledTimes(4))
+    rejectLater(failure)
+    releaseEarlier(png)
+
+    await expect(collection).rejects.toBe(failure)
+    expect(getCloudImage.mock.calls.map(([{ id }]) => id)).toEqual(
+      attachmentIds.slice(0, 4),
+    )
   })
 })

--- a/tests/services/native-backup/collect.test.ts
+++ b/tests/services/native-backup/collect.test.ts
@@ -2,22 +2,20 @@ import type { Attachment } from '@/components/chat/types'
 import { AuthTokenUnavailableError } from '@/services/auth'
 import { CloudBackupReadError } from '@/services/cloud/cloud-storage'
 import {
-  NATIVE_BACKUP_LIMITS,
-  NativeBackupCollectionError,
-  collectNativeBackupV1,
   collectNativeBackupV2,
-  formatNativeBackupV1,
   formatNativeBackupV2,
   type NativeBackupCollectionDependencies,
 } from '@/services/native-backup'
 import type { StoredChat } from '@/services/storage/indexed-db'
-import { SyncEnclaveError } from '@/services/sync-enclave'
+import type {
+  BackupInventoryItem,
+  BackupInventoryResponse,
+} from '@/services/sync-enclave/sync-api'
+import { SyncNetworkError } from '@/services/sync-enclave/sync-enclave-client'
 import type { Project, ProjectDocument } from '@/types/project'
 
 const timestamp = '2026-08-20T12:00:00.000Z'
 const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
-const pngBase64 = (suffix?: number) =>
-  btoa(String.fromCharCode(...png, ...(suffix === undefined ? [] : [suffix])))
 
 function chat(overrides: Partial<StoredChat> = {}): StoredChat {
   return {
@@ -39,15 +37,7 @@ function project(overrides: Partial<Project> = {}): Project {
     description: '',
     systemInstructions: 'Be concise',
     color: 'blue',
-    memory: [
-      {
-        id: 'fact',
-        fact: 'Likes tea',
-        category: 'preference',
-        confidence: 1,
-        date: timestamp,
-      },
-    ],
+    memory: [],
     createdAt: timestamp,
     updatedAt: timestamp,
     syncVersion: 1,
@@ -70,6 +60,26 @@ function document(overrides: Partial<ProjectDocument> = {}): ProjectDocument {
   }
 }
 
+function item(
+  scope: BackupInventoryItem['scope'],
+  id: string,
+  etag: string,
+  projectId?: string,
+): BackupInventoryItem {
+  return {
+    scope,
+    id,
+    etag,
+    ...(projectId ? { project_id: projectId } : {}),
+    created_at: timestamp,
+    updated_at: timestamp,
+  }
+}
+
+function inventory(items: BackupInventoryItem[] = []): BackupInventoryResponse {
+  return { captured_at: timestamp, total_items: items.length, items }
+}
+
 function dependencies(
   overrides: Partial<NativeBackupCollectionDependencies> = {},
 ): NativeBackupCollectionDependencies {
@@ -77,12 +87,10 @@ function dependencies(
     isAuthenticated: async () => true,
     activeUserId: () => 'user',
     requireUnlockedCek: () => {},
-    listChats: async () => ({ items: [] }),
+    getCloudInventory: async () => inventory(),
     getCloudChat: async () => null,
     getCloudImage: async () => null,
-    listProjects: async () => ({ items: [] }),
     getProject: async () => null,
-    listDocuments: async () => [],
     getDocument: async () => null,
     getLocalChats: async () => [],
     getLocalChat: async () => null,
@@ -91,614 +99,113 @@ function dependencies(
 }
 
 describe('native backup collection', () => {
-  it('paginates all cloud chats and projects', async () => {
-    const firstChat = chat({ id: 'chat-1' })
-    const secondChat = chat({ id: 'chat-2' })
-    const firstProject = project({ id: 'project-1' })
-    const secondProject = project({ id: 'project-2' })
-    const listChats = vi
+  it('uses one captured inventory and passes opaque ETags to grouped reads', async () => {
+    const getCloudInventory = vi
       .fn()
-      .mockResolvedValueOnce({
-        items: [{ id: firstChat.id, syncVersion: 1 }],
-        next: 'chat-page-2',
-      })
-      .mockResolvedValueOnce({
-        items: [{ id: secondChat.id, syncVersion: 1 }],
-      })
-      .mockResolvedValue({
-        items: [
-          { id: firstChat.id, syncVersion: 1 },
-          { id: secondChat.id, syncVersion: 1 },
-        ],
-      })
-    const listProjects = vi
+      .mockResolvedValue(
+        inventory([
+          item('chat', 'chat', 'chat-etag', 'project'),
+          item('project', 'project', 'project-etag'),
+          item('project_document', 'document', 'document-etag', 'project'),
+        ]),
+      )
+    const getCloudChat = vi
       .fn()
-      .mockResolvedValueOnce({
-        items: [
-          {
-            id: firstProject.id,
-            syncVersion: 1,
-            createdAt: timestamp,
-            updatedAt: timestamp,
-          },
-        ],
-        next: 'project-page-2',
-      })
-      .mockResolvedValueOnce({
-        items: [
-          {
-            id: secondProject.id,
-            syncVersion: 1,
-            createdAt: timestamp,
-            updatedAt: timestamp,
-          },
-        ],
-      })
-      .mockResolvedValue({
-        items: [firstProject, secondProject].map(
-          ({ id, syncVersion, createdAt, updatedAt }) => ({
-            id,
-            syncVersion,
-            createdAt,
-            updatedAt,
-          }),
-        ),
-      })
+      .mockResolvedValue(chat({ projectId: 'project' }))
+    const getProject = vi.fn().mockResolvedValue(project())
+    const getDocument = vi.fn().mockResolvedValue(document())
 
-    const result = await collectNativeBackupV1(
+    const result = await collectNativeBackupV2(
       dependencies({
-        listChats,
-        listProjects,
-        getCloudChat: async (id) =>
-          id === firstChat.id ? firstChat : secondChat,
-        getProject: async (id) =>
-          id === firstProject.id ? firstProject : secondProject,
+        getCloudInventory,
+        getCloudChat,
+        getProject,
+        getDocument,
       }),
     )
 
-    expect(listChats).toHaveBeenNthCalledWith(2, 'chat-page-2')
-    expect(listProjects).toHaveBeenNthCalledWith(2, 'project-page-2')
-    expect(result.cloudChats.map(({ id }) => id)).toEqual(['chat-1', 'chat-2'])
-    expect(result.projects.map(({ id }) => id)).toEqual([
-      'project-1',
-      'project-2',
-    ])
-  })
-
-  it('includes only signed-in-owner local-only chats', async () => {
-    const included = chat({
-      id: 'included',
-      isLocalOnly: true,
-      syncUserId: 'user',
-    })
-    const cloudCache = chat({ id: 'cloud-cache', syncUserId: 'user' })
-    const anonymous = chat({ id: 'anonymous', isLocalOnly: true })
-    const otherOwner = chat({
-      id: 'other-owner',
-      isLocalOnly: true,
-      syncUserId: 'other',
-    })
-    const temporary = chat({
-      id: 'temporary',
-      isLocalOnly: true,
-      syncUserId: 'user',
-      isTemporary: true,
-    })
-    const blank = chat({
-      id: 'blank',
-      isLocalOnly: true,
-      syncUserId: 'user',
-      isBlankChat: true,
-    })
-    const values = [
-      included,
-      cloudCache,
-      anonymous,
-      otherOwner,
-      temporary,
-      blank,
-    ]
-
-    const result = await collectNativeBackupV1(
-      dependencies({
-        getLocalChats: async () => values,
-        getLocalChat: async (id) => values.find((value) => value.id === id)!,
-      }),
+    expect(getCloudInventory).toHaveBeenCalledOnce()
+    expect(getCloudChat).toHaveBeenCalledWith('chat', 'chat-etag')
+    expect(getProject).toHaveBeenCalledWith('project', 'project-etag')
+    expect(getDocument).toHaveBeenCalledWith(
+      'project',
+      'document',
+      'document-etag',
     )
-
-    expect(result.localChats.map(({ id }) => id)).toEqual(['included'])
-  })
-
-  it('retrieves document content and cloud and local images with relationships', async () => {
-    const imageAttachment: Attachment = {
-      id: 'cloud-image',
-      type: 'image',
-      fileName: 'cloud.png',
-      mimeType: 'image/png',
-      encryptionKey: 'key',
-    }
-    const cloudChat = chat({
-      id: 'cloud-chat',
-      projectId: 'project',
-      messages: [
-        {
-          role: 'user',
-          content: 'cloud',
-          timestamp: new Date(timestamp),
-          attachments: [imageAttachment],
-        },
-      ],
-    })
-    const localChat = chat({
-      id: 'local-chat',
-      isLocalOnly: true,
-      syncUserId: 'user',
-      messages: [
-        {
-          role: 'user',
-          content: 'local',
-          timestamp: new Date(timestamp),
-          imageData: [{ base64: pngBase64(), mimeType: 'image/png' }],
-        },
-      ],
-    })
-    const doc = document()
-
-    const result = await collectNativeBackupV1(
-      dependencies({
-        listChats: async () => ({
-          items: [{ id: cloudChat.id, syncVersion: 1 }],
-        }),
-        getCloudChat: async () => cloudChat,
-        getCloudImage: async () => png,
-        listProjects: async () => ({
-          items: [
-            {
-              id: 'project',
-              syncVersion: 1,
-              createdAt: timestamp,
-              updatedAt: timestamp,
-            },
-          ],
-        }),
-        getProject: async () => project(),
-        listDocuments: async () => [
-          {
-            id: doc.id,
-            projectId: doc.projectId,
-            syncVersion: 1,
-            createdAt: timestamp,
-            updatedAt: timestamp,
-          },
-        ],
-        getDocument: async () => doc,
-        getLocalChats: async () => [localChat],
-        getLocalChat: async () => localChat,
-      }),
-    )
-
-    expect(result.projectDocuments[0].extractedText).toBe('text')
     expect(result.projects[0]).toMatchObject({
-      color: 'blue',
-      memory: project().memory,
+      id: 'project',
+      createdAt: timestamp,
+      updatedAt: timestamp,
     })
-    expect(result.images.map(({ bytes }) => [...bytes])).toEqual([
-      [...png],
-      [...png],
-    ])
-    expect(result.relationships).toEqual({
-      projectChats: [{ projectId: 'project', chatId: 'cloud-chat' }],
+    expect(result.relationships).toMatchObject({
+      projectChats: [{ projectId: 'project', chatId: 'chat' }],
       projectDocuments: [{ projectId: 'project', documentId: 'document' }],
-      chatImages: [
-        {
-          chatId: 'cloud-chat',
-          imageId: '["attachment","cloud-chat",0,0,"cloud-image"]',
-        },
-        {
-          chatId: 'local-chat',
-          imageId: 'legacy:local-chat:0:0',
-        },
-      ],
     })
     expect(() => formatNativeBackupV2(result)).not.toThrow()
   })
 
-  it('keeps documents with the same id in different projects', async () => {
-    const projects = [
-      project({ id: 'project-1' }),
-      project({ id: 'project-2' }),
-    ]
-    const documents = projects.map(({ id: projectId }) =>
-      document({ id: 'shared-document', projectId }),
-    )
-
-    const result = await collectNativeBackupV1(
-      dependencies({
-        listProjects: async () => ({
-          items: projects.map(({ id, syncVersion, createdAt, updatedAt }) => ({
-            id,
-            syncVersion,
-            createdAt,
-            updatedAt,
-          })),
-        }),
-        getProject: async (id) => projects.find((value) => value.id === id)!,
-        listDocuments: async (projectId) =>
-          documents
-            .filter((value) => value.projectId === projectId)
-            .map(({ id, projectId, syncVersion, createdAt, updatedAt }) => ({
-              id,
-              projectId,
-              syncVersion,
-              createdAt,
-              updatedAt,
-            })),
-        getDocument: async (projectId, id) =>
-          documents.find(
-            (value) => value.projectId === projectId && value.id === id,
-          )!,
-      }),
-    )
-
-    expect(result.projectDocuments).toHaveLength(2)
-  })
-
-  it('retries one changed record and fails a persistently changing record', async () => {
-    const stable = chat({ syncVersion: 2 })
-    const getStable = vi.fn().mockResolvedValue(stable)
-    const listStable = vi
-      .fn()
-      .mockResolvedValueOnce({ items: [{ id: stable.id, syncVersion: 1 }] })
-      .mockResolvedValue({ items: [{ id: stable.id, syncVersion: 2 }] })
-    await collectNativeBackupV1(
-      dependencies({
-        listChats: listStable,
-        getCloudChat: getStable,
-      }),
-    )
-    expect(getStable).toHaveBeenCalledTimes(5)
-
-    let version = 1
-    await expect(
-      collectNativeBackupV1(
-        dependencies({
-          listChats: async () => ({ items: [{ id: 'chat', syncVersion: 1 }] }),
-          getCloudChat: async () => chat({ syncVersion: version++ }),
-        }),
-      ),
-    ).rejects.toThrow('cloud chat chat: version changed during collection')
-  })
-
-  it('revalidates local ownership and eligibility after a changed read', async () => {
-    const eligible = chat({ isLocalOnly: true, syncUserId: 'user' })
-    const ineligible = chat({
-      isLocalOnly: true,
-      syncUserId: 'other-user',
-    })
-    const getLocalChat = vi
-      .fn()
-      .mockResolvedValueOnce(eligible)
-      .mockResolvedValue(ineligible)
-
-    const result = await collectNativeBackupV1(
-      dependencies({
-        getLocalChats: async () => [eligible],
-        getLocalChat,
-      }),
-    )
-
-    expect(result.localChats).toEqual([])
-    expect(getLocalChat).toHaveBeenCalledTimes(3)
-  })
-
-  it('detects local image changes during collection', async () => {
-    const local = (base64: string) =>
-      chat({
-        isLocalOnly: true,
-        syncUserId: 'user',
-        messages: [
-          {
-            role: 'user',
-            content: 'image',
-            timestamp: new Date(timestamp),
-            attachments: [
-              {
-                id: 'image',
-                type: 'image',
-                fileName: 'image.png',
-                mimeType: 'image/png',
-                base64,
-              },
-            ],
-          },
-        ],
-      })
-    const getLocalChat = vi
-      .fn()
-      .mockResolvedValueOnce(local(pngBase64(1)))
-      .mockResolvedValueOnce(local(pngBase64(2)))
-      .mockResolvedValueOnce(local(pngBase64(3)))
-      .mockResolvedValueOnce(local(pngBase64(4)))
-
-    await expect(
-      collectNativeBackupV1(
-        dependencies({
-          getLocalChats: async () => [local(pngBase64(1))],
-          getLocalChat,
-        }),
-      ),
-    ).rejects.toThrow('local chat chat: version changed during collection')
-  })
-
-  it('adds record context to malformed local chat errors', async () => {
-    const malformed = chat({
+  it('reuses the captured cloud inventory while local inventory converges', async () => {
+    const local = chat({
+      id: 'local',
       isLocalOnly: true,
       syncUserId: 'user',
-      createdAt: null as unknown as string,
     })
-
-    await expect(
-      collectNativeBackupV1(
-        dependencies({
-          getLocalChats: async () => [malformed],
-          getLocalChat: async () => malformed,
-        }),
-      ),
-    ).rejects.toThrow(
-      'local chat chat: record is invalid: Invalid backup timestamp',
-    )
-  })
-
-  it('refreshes authoritative timestamps when a listed version changes', async () => {
-    const oldTimestamp = '2026-08-19T12:00:00.000Z'
-    const listProjects = vi
+    const getCloudInventory = vi.fn().mockResolvedValue(inventory())
+    const getLocalChats = vi
       .fn()
-      .mockResolvedValueOnce({
-        items: [
-          {
-            id: 'project',
-            syncVersion: 1,
-            createdAt: oldTimestamp,
-            updatedAt: oldTimestamp,
-          },
-        ],
-      })
-      .mockResolvedValue({
-        items: [
-          {
-            id: 'project',
-            syncVersion: 2,
-            createdAt: timestamp,
-            updatedAt: timestamp,
-          },
-        ],
-      })
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([local])
+      .mockResolvedValue([local])
+    const getLocalChat = vi.fn().mockResolvedValue(local)
 
-    const result = await collectNativeBackupV1(
-      dependencies({
-        listProjects,
-        getProject: async () => project({ syncVersion: 2 }),
-      }),
+    const result = await collectNativeBackupV2(
+      dependencies({ getCloudInventory, getLocalChats, getLocalChat }),
     )
 
-    expect(result.projects[0]).toMatchObject({
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    })
-    expect(listProjects).toHaveBeenCalledTimes(5)
+    expect(getCloudInventory).toHaveBeenCalledOnce()
+    expect(result.localChats.map(({ id }) => id)).toEqual(['local'])
   })
 
-  it('deduplicates mutable paginated rows at their latest versions', async () => {
-    const listChats = vi
-      .fn()
-      .mockResolvedValueOnce({
-        items: [{ id: 'chat', syncVersion: 1 }],
-        next: 'next',
+  it.each([
+    ['snapshot_deleted', 'deleted', 'record_deleted_after_snapshot'],
+    ['snapshot_changed', 'unstable', 'record_changed_after_snapshot'],
+  ] as const)(
+    'omits a cloud item reported as %s after capture',
+    async (readCategory, omissionCategory, reason) => {
+      const getCloudChat = vi.fn(async () => {
+        throw new CloudBackupReadError(readCategory, reason, true)
       })
-      .mockResolvedValueOnce({ items: [{ id: 'chat', syncVersion: 2 }] })
-      .mockResolvedValue({ items: [{ id: 'chat', syncVersion: 2 }] })
-    const listProjects = vi
-      .fn()
-      .mockResolvedValueOnce({
-        items: [
-          {
-            id: 'project',
-            syncVersion: 1,
-            createdAt: timestamp,
-            updatedAt: timestamp,
-          },
-        ],
-        next: 'next',
-      })
-      .mockResolvedValueOnce({
-        items: [
-          {
-            id: 'project',
-            syncVersion: 2,
-            createdAt: timestamp,
-            updatedAt: timestamp,
-          },
-        ],
-      })
-      .mockResolvedValue({
-        items: [
-          {
-            id: 'project',
-            syncVersion: 2,
-            createdAt: timestamp,
-            updatedAt: timestamp,
-          },
-        ],
-      })
-    const getCloudChat = vi.fn().mockResolvedValue(chat({ syncVersion: 2 }))
-    const getProject = vi.fn().mockResolvedValue(project({ syncVersion: 2 }))
-    const listDocuments = vi.fn().mockResolvedValue([])
 
-    const result = await collectNativeBackupV1(
-      dependencies({
-        listChats,
-        listProjects,
-        getCloudChat,
-        getProject,
-        listDocuments,
-      }),
-    )
-
-    expect(result.cloudChats).toHaveLength(1)
-    expect(result.projects).toHaveLength(1)
-    expect(getCloudChat).toHaveBeenCalledTimes(2)
-    expect(getProject).toHaveBeenCalledTimes(1)
-    expect(listDocuments).toHaveBeenCalledTimes(2)
-  })
-
-  it('fails the whole collection with missing record and image details', async () => {
-    await expect(
-      collectNativeBackupV1(
+      const result = await collectNativeBackupV2(
         dependencies({
-          listProjects: async () => ({
-            items: [
-              {
-                id: 'missing-project',
-                syncVersion: 1,
-                createdAt: timestamp,
-                updatedAt: timestamp,
-              },
-            ],
-          }),
+          getCloudInventory: async () =>
+            inventory([item('chat', 'chat', 'opaque-etag')]),
+          getCloudChat,
         }),
-      ),
-    ).rejects.toMatchObject({
-      kind: 'project',
-      recordId: 'missing-project',
-    } satisfies Partial<NativeBackupCollectionError>)
-
-    const missingImage = chat({
-      messages: [
-        {
-          role: 'user',
-          content: '',
-          timestamp: new Date(timestamp),
-          attachments: [
-            { id: 'missing', type: 'image', fileName: 'missing.png' },
-          ],
-        },
-      ],
-    })
-    await expect(
-      collectNativeBackupV1(
-        dependencies({
-          listChats: async () => ({
-            items: [{ id: missingImage.id, syncVersion: 1 }],
-          }),
-          getCloudChat: async () => missingImage,
-        }),
-      ),
-    ).rejects.toThrow(
-      'image ["attachment","chat",0,0,"missing"]: image bytes are missing',
-    )
-  })
-
-  it('preserves authentication failures while reading cloud records', async () => {
-    const error = new AuthTokenUnavailableError('signed out')
-
-    await expect(
-      collectNativeBackupV1(
-        dependencies({
-          listChats: async () => ({
-            items: [{ id: 'chat', syncVersion: 1 }],
-          }),
-          getCloudChat: async () => {
-            throw error
-          },
-        }),
-      ),
-    ).rejects.toBe(error)
-  })
-
-  it('preflights per-image limits', async () => {
-    const oversized = chat({
-      messages: [
-        {
-          role: 'user',
-          content: '',
-          timestamp: new Date(timestamp),
-          attachments: [
-            {
-              id: 'large',
-              type: 'image',
-              fileName: 'large.png',
-              encryptionKey: 'key',
-            },
-          ],
-        },
-      ],
-    })
-
-    await expect(
-      collectNativeBackupV1(
-        dependencies({
-          listChats: async () => ({
-            items: [{ id: oversized.id, syncVersion: 1 }],
-          }),
-          getCloudChat: async () => oversized,
-          getCloudImage: async () => {
-            const bytes = new Uint8Array(NATIVE_BACKUP_LIMITS.imageBytes + 1)
-            bytes.set(png)
-            return bytes
-          },
-        }),
-      ),
-    ).rejects.toThrow('image size limit exceeded')
-  })
-
-  it('omits a persistently unreadable cloud chat in a partial V2 collection', async () => {
-    const getCloudChat = vi.fn(async () => {
-      throw new CloudBackupReadError(
-        'item_invalid',
-        'chat_payload_invalid',
-        true,
       )
-    })
-    const result = await collectNativeBackupV2(
-      dependencies({
-        listChats: async () => ({ items: [{ id: 'broken', syncVersion: 1 }] }),
-        getCloudChat,
-      }),
-    )
 
-    expect(result.cloudChats).toEqual([])
-    expect(result.omissions).toEqual([
-      expect.objectContaining({
+      expect(getCloudChat).toHaveBeenCalledOnce()
+      expect(result.cloudChats).toEqual([])
+      expect(result.omissions).toContainEqual({
         kind: 'cloud_chat',
-        source_id: 'broken',
-        category: 'invalid',
-        reason: 'chat_payload_invalid',
-      }),
-    ])
-    expect(result.warnings).toEqual([
-      expect.objectContaining({ code: 'source_items_omitted', count: 1 }),
-    ])
-    expect(getCloudChat).toHaveBeenCalledTimes(3)
-  })
+        source_id: 'chat',
+        category: omissionCategory,
+        reason,
+      })
+    },
+  )
 
-  it('omits dependent documents and detaches chats from an omitted project', async () => {
-    const sourceChat = chat({ projectId: 'project' })
+  it('omits dependent documents and repairs relationships for an omitted project', async () => {
+    const cloudChat = chat({ projectId: 'project' })
     const result = await collectNativeBackupV2(
       dependencies({
-        listChats: async () => ({
-          items: [{ id: sourceChat.id, syncVersion: 1 }],
-        }),
-        getCloudChat: async () => sourceChat,
-        listProjects: async () => ({
-          items: [
-            {
-              id: 'project',
-              syncVersion: 1,
-              createdAt: timestamp,
-              updatedAt: timestamp,
-            },
-          ],
-        }),
+        getCloudInventory: async () =>
+          inventory([
+            item('chat', 'chat', 'chat-etag', 'project'),
+            item('project', 'project', 'project-etag'),
+            item('project_document', 'document', 'doc-etag', 'project'),
+          ]),
+        getCloudChat: async () => cloudChat,
         getProject: async () => {
           throw new CloudBackupReadError(
             'item_invalid',
@@ -706,377 +213,110 @@ describe('native backup collection', () => {
             true,
           )
         },
-        listDocuments: async () => [
-          {
-            id: 'document',
-            projectId: 'project',
-            syncVersion: 1,
-            createdAt: timestamp,
-            updatedAt: timestamp,
-          },
-        ],
       }),
     )
 
     expect(result.projects).toEqual([])
     expect(result.projectDocuments).toEqual([])
     expect(result.cloudChats[0].projectId).toBeUndefined()
-    expect(result.relationships.projectChats).toEqual([])
-    expect(result.relationships.projectDocuments).toEqual([])
-    expect(result.omissions.map(({ kind }) => kind)).toEqual([
-      'project',
-      'project_document',
-      'relationship',
-    ])
-    expect(result.warnings).toContainEqual(
-      expect.objectContaining({
-        code: 'chats_detached_from_omitted_projects',
-        count: 1,
-      }),
-    )
-  })
-
-  it('omits an unreadable attachment and removes its dangling reference', async () => {
-    const source = chat({
-      messages: [
-        {
-          role: 'user',
-          content: 'image',
-          timestamp: new Date(timestamp),
-          attachments: [
-            {
-              id: 'broken-image',
-              type: 'image',
-              fileName: 'broken.png',
-              encryptionKey: 'key',
-            },
-          ],
-        },
-      ],
-    })
-    const result = await collectNativeBackupV2(
-      dependencies({
-        listChats: async () => ({ items: [{ id: source.id, syncVersion: 1 }] }),
-        getCloudChat: async () => source,
-        getCloudImage: async () => {
-          throw new CloudBackupReadError(
-            'item_unavailable',
-            'attachment_not_found',
-            true,
-          )
-        },
-      }),
-    )
-
-    expect(result.cloudChats[0].messages[0].attachments).toEqual([])
-    expect(result.images).toEqual([])
-    expect(result.relationships.chatImages).toEqual([])
-    expect(result.omissions[0]).toMatchObject({
-      kind: 'attachment',
-      parent_source_id: source.id,
-      reason: 'attachment_not_found',
-    })
-    expect(() => formatNativeBackupV1(result)).not.toThrow()
-  })
-
-  it('omits an attachment with a missing item key and keeps exporting', async () => {
-    const source = chat({
-      messages: [
-        {
-          role: 'user',
-          content: 'image',
-          timestamp: new Date(timestamp),
-          attachments: [
-            { id: 'missing-key', type: 'image', fileName: 'missing.png' },
-          ],
-        },
-      ],
-    })
-    const result = await collectNativeBackupV2(
-      dependencies({
-        listChats: async () => ({ items: [{ id: source.id, syncVersion: 1 }] }),
-        getCloudChat: async () => source,
-        getCloudImage: async () => {
-          throw new CloudBackupReadError(
-            'item_invalid',
-            'attachment_key_unavailable',
-            true,
-          )
-        },
-      }),
-    )
-
-    expect(result.cloudChats).toHaveLength(1)
-    expect(result.cloudChats[0].messages[0].attachments).toEqual([])
-    expect(result.omissions).toContainEqual(
-      expect.objectContaining({
-        kind: 'attachment',
-        reason: 'attachment_key_unavailable',
-      }),
-    )
-    expect(() => formatNativeBackupV1(result)).not.toThrow()
-  })
-
-  it('removes omitted image references using descending original indexes', async () => {
-    const source = chat({
-      messages: [
-        {
-          role: 'user',
-          content: 'images',
-          timestamp: new Date(timestamp),
-          attachments: [
-            {
-              id: 'missing-first',
-              type: 'image',
-              fileName: 'first.png',
-              encryptionKey: 'key',
-            },
-            {
-              id: 'kept-middle',
-              type: 'image',
-              fileName: 'middle.png',
-              encryptionKey: 'key',
-            },
-            {
-              id: 'missing-last',
-              type: 'image',
-              fileName: 'last.png',
-              encryptionKey: 'key',
-            },
-            {
-              id: 'document',
-              type: 'document',
-              fileName: 'scan.pdf',
-              pages: [
-                { page: 0, text: '', is_scanned: true, image: '%%%' },
-                { page: 1, text: '', is_scanned: true, image: '%%%' },
-              ],
-            },
-          ],
-          imageData: [
-            { base64: '%%%', mimeType: 'image/png' },
-            { base64: pngBase64(), mimeType: 'image/png' },
-            { base64: '%%%', mimeType: 'image/png' },
-          ],
-        },
-      ],
-    })
-    const result = await collectNativeBackupV2(
-      dependencies({
-        listChats: async () => ({ items: [{ id: source.id, syncVersion: 1 }] }),
-        getCloudChat: async () => source,
-        getCloudImage: async (attachment) =>
-          attachment.id === 'kept-middle' ? png : null,
-      }),
-    )
-
-    const message = result.cloudChats[0].messages[0]
-    expect(message.attachments?.map(({ id }) => id)).toEqual([
-      'kept-middle',
-      'document',
-    ])
-    const documentAttachment = message.attachments?.[1]
-    expect(documentAttachment?.type).toBe('document')
-    if (documentAttachment?.type === 'document')
-      expect(documentAttachment.pages).toEqual([
-        { page: 0, text: '', is_scanned: true },
-        { page: 1, text: '', is_scanned: true },
-      ])
-    expect(message.imageData).toHaveLength(1)
-    expect(result.images).toHaveLength(2)
-    expect(() => formatNativeBackupV1(result)).not.toThrow()
-  })
-
-  it('keeps unknown runtime failures fatal', async () => {
-    const runtimeFailure = new Error('unexpected runtime failure')
-    const source = chat()
-    Object.defineProperty(source, 'messages', {
-      get() {
-        throw runtimeFailure
-      },
-    })
-
-    await expect(
-      collectNativeBackupV2(
-        dependencies({
-          listChats: async () => ({
-            items: [{ id: source.id, syncVersion: 1 }],
-          }),
-          getCloudChat: async () => source,
+    expect(result.omissions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'project', source_id: 'project' }),
+        expect.objectContaining({
+          kind: 'project_document',
+          source_id: 'document',
+          reason: 'parent_project_omitted',
         }),
-      ),
-    ).rejects.toBe(runtimeFailure)
-  })
-
-  it('retries the whole cloud pass when inventory versions change', async () => {
-    const listChats = vi
-      .fn()
-      .mockResolvedValueOnce({ items: [{ id: 'chat', syncVersion: 1 }] })
-      .mockResolvedValueOnce({ items: [{ id: 'chat', syncVersion: 2 }] })
-      .mockResolvedValue({ items: [{ id: 'chat', syncVersion: 2 }] })
-    const getCloudChat = vi
-      .fn()
-      .mockResolvedValueOnce(chat({ title: 'V1', syncVersion: 1 }))
-      .mockResolvedValueOnce(chat({ title: 'V1', syncVersion: 1 }))
-      .mockResolvedValue(chat({ title: 'V2', syncVersion: 2 }))
-
-    const result = await collectNativeBackupV2(
-      dependencies({ listChats, getCloudChat }),
+        expect.objectContaining({ kind: 'relationship', source_id: 'chat' }),
+      ]),
     )
-
-    expect(result.cloudChats[0].title).toBe('V2')
-    expect(listChats).toHaveBeenCalledTimes(4)
-    expect(getCloudChat).toHaveBeenCalledTimes(4)
   })
 
-  it('fails when the whole cloud inventory never converges', async () => {
-    let version = 0
-    const listChats = vi.fn(async () => ({
-      items: [{ id: 'chat', syncVersion: ++version }],
-    }))
-    const getCloudChat = vi.fn(async () => chat({ syncVersion: version }))
-
-    await expect(
-      collectNativeBackupV2(dependencies({ listChats, getCloudChat })),
-    ).rejects.toMatchObject({ kind: 'inventory', omittable: false })
-    expect(listChats).toHaveBeenCalledTimes(6)
-  })
-
-  it('retries local collection when an eligible chat is added', async () => {
-    const added = chat({
-      id: 'added',
-      title: 'Added',
+  it('keeps owner local chats and omits unavailable attachments', async () => {
+    const attachment: Attachment = {
+      id: 'image',
+      type: 'image',
+      fileName: 'image.png',
+      encryptionKey: 'key',
+    }
+    const source = chat({
+      id: 'local',
       isLocalOnly: true,
       syncUserId: 'user',
+      messages: [
+        {
+          role: 'user',
+          content: 'image',
+          timestamp: new Date(timestamp),
+          attachments: [attachment],
+        },
+      ],
     })
-    const getLocalChats = vi
-      .fn()
-      .mockResolvedValueOnce([])
-      .mockResolvedValue([added])
-
     const result = await collectNativeBackupV2(
       dependencies({
-        getLocalChats,
-        getLocalChat: async () => added,
+        getLocalChats: async () => [source],
+        getLocalChat: async () => source,
       }),
-    )
-
-    expect(result.localChats.map(({ id }) => id)).toEqual(['added'])
-    expect(result.omissions).toEqual([])
-    expect(getLocalChats).toHaveBeenCalledTimes(4)
-  })
-
-  it('retries local collection when an eligible chat is removed', async () => {
-    const removed = chat({
-      id: 'removed',
-      isLocalOnly: true,
-      syncUserId: 'user',
-    })
-    const getLocalChats = vi
-      .fn()
-      .mockResolvedValueOnce([removed])
-      .mockResolvedValue([])
-
-    const result = await collectNativeBackupV2(
-      dependencies({
-        getLocalChats,
-        getLocalChat: async () => removed,
-      }),
-    )
-
-    expect(result.localChats).toEqual([])
-    expect(result.omissions).toEqual([])
-    expect(getLocalChats).toHaveBeenCalledTimes(4)
-  })
-
-  it('retries local collection when eligible chat content changes', async () => {
-    const first = chat({
-      id: 'changed',
-      title: 'First',
-      isLocalOnly: true,
-      syncUserId: 'user',
-    })
-    const second = { ...first, title: 'Second' }
-    const getLocalChats = vi
-      .fn()
-      .mockResolvedValueOnce([first])
-      .mockResolvedValue([second])
-    const getLocalChat = vi
-      .fn()
-      .mockResolvedValueOnce(first)
-      .mockResolvedValueOnce(first)
-      .mockResolvedValue(second)
-
-    const result = await collectNativeBackupV2(
-      dependencies({ getLocalChats, getLocalChat }),
-    )
-
-    expect(result.localChats[0].title).toBe('Second')
-    expect(result.omissions).toEqual([])
-  })
-
-  it('marks a coherent local snapshot partial after bounded inventory instability', async () => {
-    let inventoryRead = 0
-    let current = chat({
-      id: 'unstable',
-      isLocalOnly: true,
-      syncUserId: 'user',
-    })
-    const getLocalChats = vi.fn(async () => {
-      inventoryRead++
-      current = chat({
-        id: 'unstable',
-        title: `Version ${inventoryRead}`,
-        isLocalOnly: true,
-        syncUserId: 'user',
-      })
-      return [current]
-    })
-    const getLocalChat = vi.fn(async () => current)
-
-    const result = await collectNativeBackupV2(
-      dependencies({ getLocalChats, getLocalChat }),
     )
 
     expect(result.localChats).toHaveLength(1)
-    expect(result.omissions).toContainEqual({
-      kind: 'local_inventory',
-      source_id: 'eligible_local_chats',
-      category: 'unstable',
-      reason: 'inventory_did_not_converge',
+    expect(result.localChats[0].messages[0].attachments).toEqual([])
+    expect(result.omissions[0]).toMatchObject({
+      kind: 'attachment',
+      parent_source_id: 'local',
     })
-    expect(result.warnings).toContainEqual({
-      code: 'local_inventory_unstable',
-      category: 'source_coverage',
-      count: 1,
-    })
-    expect(getLocalChats).toHaveBeenCalledTimes(6)
-    expect(() => formatNativeBackupV2(result)).not.toThrow()
   })
 
-  it('does not omit systemic key, network, or protocol failures', async () => {
-    const failures = [
-      new CloudBackupReadError(
-        'key_unavailable',
-        'attachment_key_unavailable',
-        false,
-      ),
-      new SyncEnclaveError('offline', undefined, 'NETWORK'),
-      new Error('invalid protocol response'),
-    ]
-    for (const failure of failures) {
+  it('includes available embedded local images in the browser archive input', async () => {
+    const source = chat({
+      id: 'local',
+      isLocalOnly: true,
+      syncUserId: 'user',
+      messages: [
+        {
+          role: 'user',
+          content: 'image',
+          timestamp: new Date(timestamp),
+          attachments: [
+            {
+              id: 'image',
+              type: 'image',
+              fileName: 'image.png',
+              base64: btoa(String.fromCharCode(...png)),
+            },
+          ],
+        },
+      ],
+    })
+    const result = await collectNativeBackupV2(
+      dependencies({
+        getLocalChats: async () => [source],
+        getLocalChat: async () => source,
+      }),
+    )
+
+    expect(result.images).toHaveLength(1)
+    expect(result.images[0].bytes).toEqual(png)
+  })
+
+  it.each([
+    new AuthTokenUnavailableError('signed out'),
+    new SyncNetworkError(),
+    new CloudBackupReadError('key_unavailable', 'cloud_key_unavailable', false),
+  ])(
+    'keeps authentication, network, and key failures fatal',
+    async (failure) => {
       await expect(
         collectNativeBackupV2(
           dependencies({
-            listChats: async () => ({
-              items: [{ id: 'chat', syncVersion: 1 }],
-            }),
+            getCloudInventory: async () =>
+              inventory([item('chat', 'chat', 'etag')]),
             getCloudChat: async () => {
               throw failure
             },
           }),
         ),
       ).rejects.toBe(failure)
-    }
-  })
+    },
+  )
 })

--- a/tests/services/native-backup/collect.test.ts
+++ b/tests/services/native-backup/collect.test.ts
@@ -8,6 +8,7 @@ import {
   formatNativeBackupV2,
   type NativeBackupCollectionDependencies,
 } from '@/services/native-backup'
+import { CLOUD_PULL_BATCH_SIZE } from '@/services/native-backup/collect'
 import type { StoredChat } from '@/services/storage/indexed-db'
 import type {
   BackupInventoryItem,
@@ -181,8 +182,9 @@ describe('native backup collection', () => {
   })
 
   it('pulls inventory records in batches and isolates per-record failures', async () => {
-    const items = Array.from({ length: 25 }, (_, index) =>
-      item('chat', `chat-${index}`, `etag-${index}`),
+    const items = Array.from(
+      { length: CLOUD_PULL_BATCH_SIZE + 5 },
+      (_, index) => item('chat', `chat-${index}`, `etag-${index}`),
     )
     const getCloudChats = vi.fn(
       async (requests: ReadonlyArray<{ id: string; expectedEtag: string }>) =>
@@ -208,13 +210,13 @@ describe('native backup collection', () => {
     )
 
     expect(getCloudChats).toHaveBeenCalledTimes(2)
-    expect(getCloudChats.mock.calls[0][0]).toHaveLength(20)
+    expect(getCloudChats.mock.calls[0][0]).toHaveLength(CLOUD_PULL_BATCH_SIZE)
     expect(getCloudChats.mock.calls[1][0]).toHaveLength(5)
     expect(getCloudChats.mock.calls[0][0][0]).toEqual({
       id: 'chat-0',
       expectedEtag: 'etag-0',
     })
-    expect(result.cloudChats).toHaveLength(24)
+    expect(result.cloudChats).toHaveLength(items.length - 1)
     expect(result.omissions).toEqual([
       {
         kind: 'cloud_chat',

--- a/tests/services/native-backup/collect.test.ts
+++ b/tests/services/native-backup/collect.test.ts
@@ -326,10 +326,10 @@ describe('native backup collection', () => {
     })
     let active = 0
     let maxActive = 0
-    const getCloudImage = vi.fn(async () => {
+    const getCloudImage = vi.fn(async ({ id }: { id: string }) => {
       active++
       maxActive = Math.max(maxActive, active)
-      await downloadGate
+      if (id === 'image-0') await downloadGate
       active--
       return png
     })
@@ -343,9 +343,8 @@ describe('native backup collection', () => {
       }),
     )
     await vi.waitFor(() =>
-      expect(getCloudImage.mock.calls.length).toBeGreaterThan(1),
+      expect(getCloudImage).toHaveBeenCalledTimes(attachmentIds.length),
     )
-    expect(getCloudImage.mock.calls.length).toBeLessThan(attachmentIds.length)
     releaseDownloads()
 
     const result = await collection

--- a/tests/services/native-backup/collect.test.ts
+++ b/tests/services/native-backup/collect.test.ts
@@ -1,13 +1,17 @@
 import type { Attachment } from '@/components/chat/types'
 import { AuthTokenUnavailableError } from '@/services/auth'
+import { CloudBackupReadError } from '@/services/cloud/cloud-storage'
 import {
   NATIVE_BACKUP_LIMITS,
   NativeBackupCollectionError,
   collectNativeBackupV1,
+  collectNativeBackupV2,
   formatNativeBackupV1,
+  formatNativeBackupV2,
   type NativeBackupCollectionDependencies,
 } from '@/services/native-backup'
 import type { StoredChat } from '@/services/storage/indexed-db'
+import { SyncEnclaveError } from '@/services/sync-enclave'
 import type { Project, ProjectDocument } from '@/types/project'
 
 const timestamp = '2026-08-20T12:00:00.000Z'
@@ -101,6 +105,12 @@ describe('native backup collection', () => {
       .mockResolvedValueOnce({
         items: [{ id: secondChat.id, syncVersion: 1 }],
       })
+      .mockResolvedValue({
+        items: [
+          { id: firstChat.id, syncVersion: 1 },
+          { id: secondChat.id, syncVersion: 1 },
+        ],
+      })
     const listProjects = vi
       .fn()
       .mockResolvedValueOnce({
@@ -123,6 +133,16 @@ describe('native backup collection', () => {
             updatedAt: timestamp,
           },
         ],
+      })
+      .mockResolvedValue({
+        items: [firstProject, secondProject].map(
+          ({ id, syncVersion, createdAt, updatedAt }) => ({
+            id,
+            syncVersion,
+            createdAt,
+            updatedAt,
+          }),
+        ),
       })
 
     const result = await collectNativeBackupV1(
@@ -280,7 +300,7 @@ describe('native backup collection', () => {
         },
       ],
     })
-    expect(() => formatNativeBackupV1(result)).not.toThrow()
+    expect(() => formatNativeBackupV2(result)).not.toThrow()
   })
 
   it('keeps documents with the same id in different projects', async () => {
@@ -336,7 +356,7 @@ describe('native backup collection', () => {
         getCloudChat: getStable,
       }),
     )
-    expect(getStable).toHaveBeenCalledTimes(3)
+    expect(getStable).toHaveBeenCalledTimes(5)
 
     let version = 1
     await expect(
@@ -465,7 +485,7 @@ describe('native backup collection', () => {
       createdAt: timestamp,
       updatedAt: timestamp,
     })
-    expect(listProjects).toHaveBeenCalledTimes(2)
+    expect(listProjects).toHaveBeenCalledTimes(5)
   })
 
   it('deduplicates mutable paginated rows at their latest versions', async () => {
@@ -476,6 +496,7 @@ describe('native backup collection', () => {
         next: 'next',
       })
       .mockResolvedValueOnce({ items: [{ id: 'chat', syncVersion: 2 }] })
+      .mockResolvedValue({ items: [{ id: 'chat', syncVersion: 2 }] })
     const listProjects = vi
       .fn()
       .mockResolvedValueOnce({
@@ -490,6 +511,16 @@ describe('native backup collection', () => {
         next: 'next',
       })
       .mockResolvedValueOnce({
+        items: [
+          {
+            id: 'project',
+            syncVersion: 2,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          },
+        ],
+      })
+      .mockResolvedValue({
         items: [
           {
             id: 'project',
@@ -517,7 +548,7 @@ describe('native backup collection', () => {
     expect(result.projects).toHaveLength(1)
     expect(getCloudChat).toHaveBeenCalledTimes(2)
     expect(getProject).toHaveBeenCalledTimes(1)
-    expect(listDocuments).toHaveBeenCalledTimes(1)
+    expect(listDocuments).toHaveBeenCalledTimes(2)
   })
 
   it('fails the whole collection with missing record and image details', async () => {
@@ -618,5 +649,434 @@ describe('native backup collection', () => {
         }),
       ),
     ).rejects.toThrow('image size limit exceeded')
+  })
+
+  it('omits a persistently unreadable cloud chat in a partial V2 collection', async () => {
+    const getCloudChat = vi.fn(async () => {
+      throw new CloudBackupReadError(
+        'item_invalid',
+        'chat_payload_invalid',
+        true,
+      )
+    })
+    const result = await collectNativeBackupV2(
+      dependencies({
+        listChats: async () => ({ items: [{ id: 'broken', syncVersion: 1 }] }),
+        getCloudChat,
+      }),
+    )
+
+    expect(result.cloudChats).toEqual([])
+    expect(result.omissions).toEqual([
+      expect.objectContaining({
+        kind: 'cloud_chat',
+        source_id: 'broken',
+        category: 'invalid',
+        reason: 'chat_payload_invalid',
+      }),
+    ])
+    expect(result.warnings).toEqual([
+      expect.objectContaining({ code: 'source_items_omitted', count: 1 }),
+    ])
+    expect(getCloudChat).toHaveBeenCalledTimes(3)
+  })
+
+  it('omits dependent documents and detaches chats from an omitted project', async () => {
+    const sourceChat = chat({ projectId: 'project' })
+    const result = await collectNativeBackupV2(
+      dependencies({
+        listChats: async () => ({
+          items: [{ id: sourceChat.id, syncVersion: 1 }],
+        }),
+        getCloudChat: async () => sourceChat,
+        listProjects: async () => ({
+          items: [
+            {
+              id: 'project',
+              syncVersion: 1,
+              createdAt: timestamp,
+              updatedAt: timestamp,
+            },
+          ],
+        }),
+        getProject: async () => {
+          throw new CloudBackupReadError(
+            'item_invalid',
+            'project_payload_invalid',
+            true,
+          )
+        },
+        listDocuments: async () => [
+          {
+            id: 'document',
+            projectId: 'project',
+            syncVersion: 1,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          },
+        ],
+      }),
+    )
+
+    expect(result.projects).toEqual([])
+    expect(result.projectDocuments).toEqual([])
+    expect(result.cloudChats[0].projectId).toBeUndefined()
+    expect(result.relationships.projectChats).toEqual([])
+    expect(result.relationships.projectDocuments).toEqual([])
+    expect(result.omissions.map(({ kind }) => kind)).toEqual([
+      'project',
+      'project_document',
+      'relationship',
+    ])
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({
+        code: 'chats_detached_from_omitted_projects',
+        count: 1,
+      }),
+    )
+  })
+
+  it('omits an unreadable attachment and removes its dangling reference', async () => {
+    const source = chat({
+      messages: [
+        {
+          role: 'user',
+          content: 'image',
+          timestamp: new Date(timestamp),
+          attachments: [
+            {
+              id: 'broken-image',
+              type: 'image',
+              fileName: 'broken.png',
+              encryptionKey: 'key',
+            },
+          ],
+        },
+      ],
+    })
+    const result = await collectNativeBackupV2(
+      dependencies({
+        listChats: async () => ({ items: [{ id: source.id, syncVersion: 1 }] }),
+        getCloudChat: async () => source,
+        getCloudImage: async () => {
+          throw new CloudBackupReadError(
+            'item_unavailable',
+            'attachment_not_found',
+            true,
+          )
+        },
+      }),
+    )
+
+    expect(result.cloudChats[0].messages[0].attachments).toEqual([])
+    expect(result.images).toEqual([])
+    expect(result.relationships.chatImages).toEqual([])
+    expect(result.omissions[0]).toMatchObject({
+      kind: 'attachment',
+      parent_source_id: source.id,
+      reason: 'attachment_not_found',
+    })
+    expect(() => formatNativeBackupV1(result)).not.toThrow()
+  })
+
+  it('omits an attachment with a missing item key and keeps exporting', async () => {
+    const source = chat({
+      messages: [
+        {
+          role: 'user',
+          content: 'image',
+          timestamp: new Date(timestamp),
+          attachments: [
+            { id: 'missing-key', type: 'image', fileName: 'missing.png' },
+          ],
+        },
+      ],
+    })
+    const result = await collectNativeBackupV2(
+      dependencies({
+        listChats: async () => ({ items: [{ id: source.id, syncVersion: 1 }] }),
+        getCloudChat: async () => source,
+        getCloudImage: async () => {
+          throw new CloudBackupReadError(
+            'item_invalid',
+            'attachment_key_unavailable',
+            true,
+          )
+        },
+      }),
+    )
+
+    expect(result.cloudChats).toHaveLength(1)
+    expect(result.cloudChats[0].messages[0].attachments).toEqual([])
+    expect(result.omissions).toContainEqual(
+      expect.objectContaining({
+        kind: 'attachment',
+        reason: 'attachment_key_unavailable',
+      }),
+    )
+    expect(() => formatNativeBackupV1(result)).not.toThrow()
+  })
+
+  it('removes omitted image references using descending original indexes', async () => {
+    const source = chat({
+      messages: [
+        {
+          role: 'user',
+          content: 'images',
+          timestamp: new Date(timestamp),
+          attachments: [
+            {
+              id: 'missing-first',
+              type: 'image',
+              fileName: 'first.png',
+              encryptionKey: 'key',
+            },
+            {
+              id: 'kept-middle',
+              type: 'image',
+              fileName: 'middle.png',
+              encryptionKey: 'key',
+            },
+            {
+              id: 'missing-last',
+              type: 'image',
+              fileName: 'last.png',
+              encryptionKey: 'key',
+            },
+            {
+              id: 'document',
+              type: 'document',
+              fileName: 'scan.pdf',
+              pages: [
+                { page: 0, text: '', is_scanned: true, image: '%%%' },
+                { page: 1, text: '', is_scanned: true, image: '%%%' },
+              ],
+            },
+          ],
+          imageData: [
+            { base64: '%%%', mimeType: 'image/png' },
+            { base64: pngBase64(), mimeType: 'image/png' },
+            { base64: '%%%', mimeType: 'image/png' },
+          ],
+        },
+      ],
+    })
+    const result = await collectNativeBackupV2(
+      dependencies({
+        listChats: async () => ({ items: [{ id: source.id, syncVersion: 1 }] }),
+        getCloudChat: async () => source,
+        getCloudImage: async (attachment) =>
+          attachment.id === 'kept-middle' ? png : null,
+      }),
+    )
+
+    const message = result.cloudChats[0].messages[0]
+    expect(message.attachments?.map(({ id }) => id)).toEqual([
+      'kept-middle',
+      'document',
+    ])
+    const documentAttachment = message.attachments?.[1]
+    expect(documentAttachment?.type).toBe('document')
+    if (documentAttachment?.type === 'document')
+      expect(documentAttachment.pages).toEqual([
+        { page: 0, text: '', is_scanned: true },
+        { page: 1, text: '', is_scanned: true },
+      ])
+    expect(message.imageData).toHaveLength(1)
+    expect(result.images).toHaveLength(2)
+    expect(() => formatNativeBackupV1(result)).not.toThrow()
+  })
+
+  it('keeps unknown runtime failures fatal', async () => {
+    const runtimeFailure = new Error('unexpected runtime failure')
+    const source = chat()
+    Object.defineProperty(source, 'messages', {
+      get() {
+        throw runtimeFailure
+      },
+    })
+
+    await expect(
+      collectNativeBackupV2(
+        dependencies({
+          listChats: async () => ({
+            items: [{ id: source.id, syncVersion: 1 }],
+          }),
+          getCloudChat: async () => source,
+        }),
+      ),
+    ).rejects.toBe(runtimeFailure)
+  })
+
+  it('retries the whole cloud pass when inventory versions change', async () => {
+    const listChats = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [{ id: 'chat', syncVersion: 1 }] })
+      .mockResolvedValueOnce({ items: [{ id: 'chat', syncVersion: 2 }] })
+      .mockResolvedValue({ items: [{ id: 'chat', syncVersion: 2 }] })
+    const getCloudChat = vi
+      .fn()
+      .mockResolvedValueOnce(chat({ title: 'V1', syncVersion: 1 }))
+      .mockResolvedValueOnce(chat({ title: 'V1', syncVersion: 1 }))
+      .mockResolvedValue(chat({ title: 'V2', syncVersion: 2 }))
+
+    const result = await collectNativeBackupV2(
+      dependencies({ listChats, getCloudChat }),
+    )
+
+    expect(result.cloudChats[0].title).toBe('V2')
+    expect(listChats).toHaveBeenCalledTimes(4)
+    expect(getCloudChat).toHaveBeenCalledTimes(4)
+  })
+
+  it('fails when the whole cloud inventory never converges', async () => {
+    let version = 0
+    const listChats = vi.fn(async () => ({
+      items: [{ id: 'chat', syncVersion: ++version }],
+    }))
+    const getCloudChat = vi.fn(async () => chat({ syncVersion: version }))
+
+    await expect(
+      collectNativeBackupV2(dependencies({ listChats, getCloudChat })),
+    ).rejects.toMatchObject({ kind: 'inventory', omittable: false })
+    expect(listChats).toHaveBeenCalledTimes(6)
+  })
+
+  it('retries local collection when an eligible chat is added', async () => {
+    const added = chat({
+      id: 'added',
+      title: 'Added',
+      isLocalOnly: true,
+      syncUserId: 'user',
+    })
+    const getLocalChats = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([added])
+
+    const result = await collectNativeBackupV2(
+      dependencies({
+        getLocalChats,
+        getLocalChat: async () => added,
+      }),
+    )
+
+    expect(result.localChats.map(({ id }) => id)).toEqual(['added'])
+    expect(result.omissions).toEqual([])
+    expect(getLocalChats).toHaveBeenCalledTimes(4)
+  })
+
+  it('retries local collection when an eligible chat is removed', async () => {
+    const removed = chat({
+      id: 'removed',
+      isLocalOnly: true,
+      syncUserId: 'user',
+    })
+    const getLocalChats = vi
+      .fn()
+      .mockResolvedValueOnce([removed])
+      .mockResolvedValue([])
+
+    const result = await collectNativeBackupV2(
+      dependencies({
+        getLocalChats,
+        getLocalChat: async () => removed,
+      }),
+    )
+
+    expect(result.localChats).toEqual([])
+    expect(result.omissions).toEqual([])
+    expect(getLocalChats).toHaveBeenCalledTimes(4)
+  })
+
+  it('retries local collection when eligible chat content changes', async () => {
+    const first = chat({
+      id: 'changed',
+      title: 'First',
+      isLocalOnly: true,
+      syncUserId: 'user',
+    })
+    const second = { ...first, title: 'Second' }
+    const getLocalChats = vi
+      .fn()
+      .mockResolvedValueOnce([first])
+      .mockResolvedValue([second])
+    const getLocalChat = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(first)
+      .mockResolvedValue(second)
+
+    const result = await collectNativeBackupV2(
+      dependencies({ getLocalChats, getLocalChat }),
+    )
+
+    expect(result.localChats[0].title).toBe('Second')
+    expect(result.omissions).toEqual([])
+  })
+
+  it('marks a coherent local snapshot partial after bounded inventory instability', async () => {
+    let inventoryRead = 0
+    let current = chat({
+      id: 'unstable',
+      isLocalOnly: true,
+      syncUserId: 'user',
+    })
+    const getLocalChats = vi.fn(async () => {
+      inventoryRead++
+      current = chat({
+        id: 'unstable',
+        title: `Version ${inventoryRead}`,
+        isLocalOnly: true,
+        syncUserId: 'user',
+      })
+      return [current]
+    })
+    const getLocalChat = vi.fn(async () => current)
+
+    const result = await collectNativeBackupV2(
+      dependencies({ getLocalChats, getLocalChat }),
+    )
+
+    expect(result.localChats).toHaveLength(1)
+    expect(result.omissions).toContainEqual({
+      kind: 'local_inventory',
+      source_id: 'eligible_local_chats',
+      category: 'unstable',
+      reason: 'inventory_did_not_converge',
+    })
+    expect(result.warnings).toContainEqual({
+      code: 'local_inventory_unstable',
+      category: 'source_coverage',
+      count: 1,
+    })
+    expect(getLocalChats).toHaveBeenCalledTimes(6)
+    expect(() => formatNativeBackupV2(result)).not.toThrow()
+  })
+
+  it('does not omit systemic key, network, or protocol failures', async () => {
+    const failures = [
+      new CloudBackupReadError(
+        'key_unavailable',
+        'attachment_key_unavailable',
+        false,
+      ),
+      new SyncEnclaveError('offline', undefined, 'NETWORK'),
+      new Error('invalid protocol response'),
+    ]
+    for (const failure of failures) {
+      await expect(
+        collectNativeBackupV2(
+          dependencies({
+            listChats: async () => ({
+              items: [{ id: 'chat', syncVersion: 1 }],
+            }),
+            getCloudChat: async () => {
+              throw failure
+            },
+          }),
+        ),
+      ).rejects.toBe(failure)
+    }
   })
 })

--- a/tests/services/native-backup/collect.test.ts
+++ b/tests/services/native-backup/collect.test.ts
@@ -2,6 +2,7 @@ import type { Attachment } from '@/components/chat/types'
 import { AuthTokenUnavailableError } from '@/services/auth'
 import { CloudBackupReadError } from '@/services/cloud/cloud-storage'
 import {
+  NativeBackupCollectionError,
   collectNativeBackupV2,
   formatNativeBackupV2,
   type NativeBackupCollectionDependencies,
@@ -297,6 +298,105 @@ describe('native backup collection', () => {
 
     expect(result.images).toHaveLength(1)
     expect(result.images[0].bytes).toEqual(png)
+  })
+
+  it('downloads attachments concurrently within a bounded ordered pool', async () => {
+    const attachmentIds = Array.from(
+      { length: 8 },
+      (_, index) => `image-${index}`,
+    )
+    const source = chat({
+      messages: [
+        {
+          role: 'user',
+          content: 'images',
+          timestamp: new Date(timestamp),
+          attachments: attachmentIds.map((id) => ({
+            id,
+            type: 'image' as const,
+            fileName: `${id}.png`,
+            encryptionKey: 'key',
+          })),
+        },
+      ],
+    })
+    let releaseDownloads!: () => void
+    const downloadGate = new Promise<void>((resolve) => {
+      releaseDownloads = resolve
+    })
+    let active = 0
+    let maxActive = 0
+    const getCloudImage = vi.fn(async () => {
+      active++
+      maxActive = Math.max(maxActive, active)
+      await downloadGate
+      active--
+      return png
+    })
+
+    const collection = collectNativeBackupV2(
+      dependencies({
+        getCloudInventory: async () =>
+          inventory([item('chat', 'chat', 'etag')]),
+        getCloudChat: async () => source,
+        getCloudImage,
+      }),
+    )
+    await vi.waitFor(() =>
+      expect(getCloudImage.mock.calls.length).toBeGreaterThan(1),
+    )
+    expect(getCloudImage.mock.calls.length).toBeLessThan(attachmentIds.length)
+    releaseDownloads()
+
+    const result = await collection
+    expect(maxActive).toBeGreaterThan(1)
+    expect(maxActive).toBeLessThan(attachmentIds.length)
+    expect(
+      result.relationships.chatImages.map(
+        ({ imageId }) => JSON.parse(imageId)[4],
+      ),
+    ).toEqual(attachmentIds)
+  })
+
+  it('keeps an explicitly omittable systemic attachment failure fatal', async () => {
+    const source = chat({
+      messages: [
+        {
+          role: 'user',
+          content: 'image',
+          timestamp: new Date(timestamp),
+          attachments: [
+            {
+              id: 'image',
+              type: 'image',
+              fileName: 'image.png',
+              encryptionKey: 'key',
+            },
+          ],
+        },
+      ],
+    })
+    const failure = new NativeBackupCollectionError(
+      'image',
+      'image',
+      'system unavailable',
+      'systemic',
+      'system_unavailable',
+      true,
+    )
+
+    await expect(
+      collectNativeBackupV2(
+        dependencies({
+          getCloudInventory: async () =>
+            inventory([item('chat', 'chat', 'etag')]),
+          getCloudChat: async () => source,
+          getCloudImage: async () => {
+            throw failure
+          },
+        }),
+      ),
+    ).rejects.toBe(failure)
   })
 
   it.each([

--- a/tests/services/native-backup/collect.test.ts
+++ b/tests/services/native-backup/collect.test.ts
@@ -1,5 +1,6 @@
 import type { Attachment } from '@/components/chat/types'
 import { AuthTokenUnavailableError } from '@/services/auth'
+import type { BackupPullResult } from '@/services/cloud/backup-read-error'
 import { CloudBackupReadError } from '@/services/cloud/cloud-storage'
 import {
   NativeBackupCollectionError,
@@ -14,6 +15,40 @@ import type {
 } from '@/services/sync-enclave/sync-api'
 import { SyncNetworkError } from '@/services/sync-enclave/sync-enclave-client'
 import type { Project, ProjectDocument } from '@/types/project'
+
+async function settle<T>(read: () => Promise<T>): Promise<BackupPullResult<T>> {
+  try {
+    return { ok: true, value: await read() }
+  } catch (error) {
+    return { ok: false, error }
+  }
+}
+
+function batchReads<T>(fn: (id: string, expectedEtag: string) => Promise<T>) {
+  return (requests: ReadonlyArray<{ id: string; expectedEtag: string }>) =>
+    Promise.all(
+      requests.map(({ id, expectedEtag }) =>
+        settle(() => fn(id, expectedEtag)),
+      ),
+    )
+}
+
+function batchDocumentReads<T>(
+  fn: (projectId: string, id: string, expectedEtag: string) => Promise<T>,
+) {
+  return (
+    requests: ReadonlyArray<{
+      projectId: string
+      id: string
+      expectedEtag: string
+    }>,
+  ) =>
+    Promise.all(
+      requests.map(({ projectId, id, expectedEtag }) =>
+        settle(() => fn(projectId, id, expectedEtag)),
+      ),
+    )
+}
 
 const timestamp = '2026-08-20T12:00:00.000Z'
 const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
@@ -89,10 +124,10 @@ function dependencies(
     activeUserId: () => 'user',
     requireUnlockedCek: () => {},
     getCloudInventory: async () => inventory(),
-    getCloudChat: async () => null,
+    getCloudChats: batchReads(async () => null),
     getCloudImage: async () => null,
-    getProject: async () => null,
-    getDocument: async () => null,
+    getProjects: batchReads(async () => null),
+    getDocuments: batchDocumentReads(async () => null),
     getLocalChats: async () => [],
     getLocalChat: async () => null,
     ...overrides,
@@ -119,9 +154,9 @@ describe('native backup collection', () => {
     const result = await collectNativeBackupV2(
       dependencies({
         getCloudInventory,
-        getCloudChat,
-        getProject,
-        getDocument,
+        getCloudChats: batchReads(getCloudChat),
+        getProjects: batchReads(getProject),
+        getDocuments: batchDocumentReads(getDocument),
       }),
     )
 
@@ -143,6 +178,51 @@ describe('native backup collection', () => {
       projectDocuments: [{ projectId: 'project', documentId: 'document' }],
     })
     expect(() => formatNativeBackupV2(result)).not.toThrow()
+  })
+
+  it('pulls inventory records in batches and isolates per-record failures', async () => {
+    const items = Array.from({ length: 25 }, (_, index) =>
+      item('chat', `chat-${index}`, `etag-${index}`),
+    )
+    const getCloudChats = vi.fn(
+      async (requests: ReadonlyArray<{ id: string; expectedEtag: string }>) =>
+        requests.map(({ id }) =>
+          id === 'chat-3'
+            ? {
+                ok: false as const,
+                error: new CloudBackupReadError(
+                  'snapshot_deleted',
+                  'record_deleted_after_snapshot',
+                  true,
+                ),
+              }
+            : { ok: true as const, value: chat({ id }) },
+        ),
+    )
+
+    const result = await collectNativeBackupV2(
+      dependencies({
+        getCloudInventory: async () => inventory(items),
+        getCloudChats,
+      }),
+    )
+
+    expect(getCloudChats).toHaveBeenCalledTimes(2)
+    expect(getCloudChats.mock.calls[0][0]).toHaveLength(20)
+    expect(getCloudChats.mock.calls[1][0]).toHaveLength(5)
+    expect(getCloudChats.mock.calls[0][0][0]).toEqual({
+      id: 'chat-0',
+      expectedEtag: 'etag-0',
+    })
+    expect(result.cloudChats).toHaveLength(24)
+    expect(result.omissions).toEqual([
+      {
+        kind: 'cloud_chat',
+        source_id: 'chat-3',
+        category: 'deleted',
+        reason: 'record_deleted_after_snapshot',
+      },
+    ])
   })
 
   it('reuses the captured cloud inventory while local inventory converges', async () => {
@@ -181,7 +261,7 @@ describe('native backup collection', () => {
         dependencies({
           getCloudInventory: async () =>
             inventory([item('chat', 'chat', 'opaque-etag')]),
-          getCloudChat,
+          getCloudChats: batchReads(getCloudChat),
         }),
       )
 
@@ -206,14 +286,14 @@ describe('native backup collection', () => {
             item('project', 'project', 'project-etag'),
             item('project_document', 'document', 'doc-etag', 'project'),
           ]),
-        getCloudChat: async () => cloudChat,
-        getProject: async () => {
+        getCloudChats: batchReads(async () => cloudChat),
+        getProjects: batchReads(async () => {
           throw new CloudBackupReadError(
             'item_invalid',
             'project_payload_invalid',
             true,
           )
-        },
+        }),
       }),
     )
 
@@ -338,7 +418,7 @@ describe('native backup collection', () => {
       dependencies({
         getCloudInventory: async () =>
           inventory([item('chat', 'chat', 'etag')]),
-        getCloudChat: async () => source,
+        getCloudChats: batchReads(async () => source),
         getCloudImage,
       }),
     )
@@ -389,7 +469,7 @@ describe('native backup collection', () => {
         dependencies({
           getCloudInventory: async () =>
             inventory([item('chat', 'chat', 'etag')]),
-          getCloudChat: async () => source,
+          getCloudChats: batchReads(async () => source),
           getCloudImage: async () => {
             throw failure
           },
@@ -410,9 +490,9 @@ describe('native backup collection', () => {
           dependencies({
             getCloudInventory: async () =>
               inventory([item('chat', 'chat', 'etag')]),
-            getCloudChat: async () => {
+            getCloudChats: batchReads(async () => {
               throw failure
-            },
+            }),
           }),
         ),
       ).rejects.toBe(failure)

--- a/tests/services/native-backup/export-cancellation.integration.test.ts
+++ b/tests/services/native-backup/export-cancellation.integration.test.ts
@@ -8,16 +8,16 @@ import {
 } from '@/services/native-backup/write'
 import { expect, it, vi } from 'vitest'
 
-const collectNativeBackupV1 = vi.hoisted(() => vi.fn())
+const collectNativeBackupV2 = vi.hoisted(() => vi.fn())
 
 vi.mock('@/services/native-backup/collect', async (importOriginal) => ({
   ...(await importOriginal()),
-  collectNativeBackupV1,
+  collectNativeBackupV2,
 }))
 
 it('propagates cancellation into the default collector', async () => {
   const controller = new AbortController()
-  collectNativeBackupV1.mockImplementation(
+  collectNativeBackupV2.mockImplementation(
     (_dependencies: unknown, signal: AbortSignal) =>
       new Promise((_resolve, reject) =>
         signal.addEventListener('abort', () => reject(signal.reason), {
@@ -27,11 +27,11 @@ it('propagates cancellation into the default collector', async () => {
   )
 
   const result = runNativeBackupExport(controller.signal, vi.fn())
-  await vi.waitFor(() => expect(collectNativeBackupV1).toHaveBeenCalled())
+  await vi.waitFor(() => expect(collectNativeBackupV2).toHaveBeenCalled())
   controller.abort()
 
   await expect(result).rejects.toMatchObject({ name: 'AbortError' })
-  expect(collectNativeBackupV1).toHaveBeenCalledWith(
+  expect(collectNativeBackupV2).toHaveBeenCalledWith(
     undefined,
     controller.signal,
   )
@@ -62,7 +62,7 @@ it('reports success when cancellation occurs during file close', async () => {
   }
   const download = vi.fn()
   const dependencies = {
-    collect: async () => ({}),
+    collect: async () => ({ omissions: [], warnings: [] }),
     format: () => ({
       manifestBytes: new TextEncoder().encode(
         '{"created_at":"2026-08-20T12:00:00.000Z"}',
@@ -76,7 +76,13 @@ it('reports success when cancellation occurs during file close', async () => {
 
   await expect(
     runNativeBackupExport(controller.signal, vi.fn(), dependencies),
-  ).resolves.toBeUndefined()
+  ).resolves.toEqual({
+    complete: true,
+    omitted: 0,
+    adjustedRelationships: 0,
+    localInventoryUnstable: false,
+    warnings: 0,
+  })
   expect(controller.signal.aborted).toBe(true)
   expect(download).toHaveBeenCalledWith({
     kind: 'file',

--- a/tests/services/native-backup/export.test.ts
+++ b/tests/services/native-backup/export.test.ts
@@ -19,7 +19,7 @@ describe('native backup export orchestration', () => {
       }),
       collect: vi.fn(async () => {
         order.push('collect')
-        return { value: true }
+        return { omissions: [], warnings: [] }
       }),
       format: vi.fn(() => {
         order.push('format')

--- a/tests/services/native-backup/export.test.ts
+++ b/tests/services/native-backup/export.test.ts
@@ -64,6 +64,55 @@ describe('native backup export orchestration', () => {
     expect(dependencies.download).not.toHaveBeenCalled()
   })
 
+  it('reports partial counts from canonical collection warnings', async () => {
+    const dependencies = {
+      prepare: vi.fn(async () => undefined),
+      collect: vi.fn(async () => ({
+        omissions: [{ kind: 'relationship' }],
+        warnings: [
+          {
+            code: 'source_items_omitted',
+            category: 'source_coverage',
+            count: 3,
+          },
+          {
+            code: 'chats_detached_from_omitted_projects',
+            category: 'relationship_adjustment',
+            count: 2,
+          },
+          {
+            code: 'local_inventory_unstable',
+            category: 'source_coverage',
+            count: 1,
+          },
+        ],
+      })),
+      format: vi.fn(() => ({ manifestBytes: new Uint8Array(), files: [] })),
+      write: vi.fn(
+        async () =>
+          ({
+            kind: 'file',
+            filename: 'backup.zip',
+          }) as const,
+      ),
+      download: vi.fn(),
+    } as unknown as NativeBackupExportDependencies
+
+    await expect(
+      runNativeBackupExport(
+        new AbortController().signal,
+        vi.fn(),
+        dependencies,
+      ),
+    ).resolves.toEqual({
+      complete: false,
+      omitted: 3,
+      adjustedRelationships: 2,
+      localInventoryUnstable: true,
+      warnings: 3,
+    })
+  })
+
   it('returns actionable errors for expected failures', () => {
     expect(
       nativeBackupExportError(

--- a/tests/services/native-backup/format.test.ts
+++ b/tests/services/native-backup/format.test.ts
@@ -2,7 +2,9 @@ import {
   NATIVE_BACKUP_LIMITS,
   assertNativeBackupSizeLimits,
   assertValidNativeBackupV1,
+  assertValidNativeBackupV2,
   formatNativeBackupV1,
+  formatNativeBackupV2,
   type NativeBackupFormatInput,
   type NativeBackupManifestV1,
 } from '@/services/native-backup'
@@ -345,5 +347,242 @@ describe('native backup v1 manifest', () => {
         ),
       ).toThrow()
     }
+  })
+})
+
+describe('native backup v2 manifest', () => {
+  it('truthfully records complete and partial source coverage', () => {
+    const complete = formatNativeBackupV2({
+      ...input(),
+      omissions: [],
+      warnings: [],
+    })
+    expect(
+      assertValidNativeBackupV2(complete.manifestBytes, complete.files),
+    ).toMatchObject({ version: 2, complete: true, omissions: [], warnings: [] })
+
+    const partial = formatNativeBackupV2({
+      ...input(),
+      omissions: [
+        {
+          kind: 'cloud_chat',
+          source_id: 'unreadable-chat',
+          category: 'invalid',
+          reason: 'chat_payload_invalid',
+        },
+      ],
+      warnings: [
+        {
+          code: 'source_items_omitted',
+          category: 'source_coverage',
+          count: 1,
+        },
+      ],
+    })
+    expect(
+      assertValidNativeBackupV2(partial.manifestBytes, partial.files),
+    ).toMatchObject({ version: 2, complete: false })
+  })
+
+  it('rejects contradictory partial metadata', () => {
+    const formatted = formatNativeBackupV2({
+      ...input(),
+      omissions: [],
+      warnings: [],
+    })
+    const manifest = JSON.parse(
+      new TextDecoder().decode(formatted.manifestBytes),
+    )
+    manifest.complete = false
+
+    expect(() =>
+      assertValidNativeBackupV2(
+        new TextEncoder().encode(JSON.stringify(manifest)),
+        formatted.files,
+      ),
+    ).toThrow('completeness')
+  })
+
+  it('rejects duplicate omissions and warnings not exactly derived from them', () => {
+    const omission = {
+      kind: 'cloud_chat' as const,
+      source_id: 'chat',
+      category: 'invalid' as const,
+      reason: 'chat_payload_invalid',
+    }
+    expect(() =>
+      formatNativeBackupV2({
+        ...input(),
+        omissions: [omission, { ...omission, reason: 'different_reason' }],
+        warnings: [
+          {
+            code: 'source_items_omitted',
+            category: 'source_coverage',
+            count: 2,
+          },
+        ],
+      }),
+    ).toThrow('duplicate or contradictory')
+
+    expect(() =>
+      formatNativeBackupV2({
+        ...input(),
+        omissions: [omission],
+        warnings: [
+          {
+            code: 'source_items_omitted',
+            category: 'source_coverage',
+            count: 2,
+          },
+        ],
+      }),
+    ).toThrow('warnings do not match')
+
+    expect(() =>
+      formatNativeBackupV2({
+        ...input(),
+        omissions: [omission],
+        warnings: [
+          {
+            code: 'source_items_omitted',
+            category: 'source_coverage',
+            count: 1,
+          },
+          {
+            code: 'source_items_omitted',
+            category: 'source_coverage',
+            count: 1,
+          },
+        ],
+      }),
+    ).toThrow('warnings do not match')
+  })
+
+  it('derives relationship adjustments separately from omitted entities', () => {
+    const value = input()
+    delete value.cloudChats[0].projectId
+    value.relationships.projectChats = []
+    const formatted = formatNativeBackupV2({
+      ...value,
+      omissions: [
+        {
+          kind: 'relationship',
+          source_id: 'c',
+          parent_source_id: 'missing-project',
+          category: 'unavailable',
+          reason: 'project_reference_unavailable',
+        },
+      ],
+      warnings: [
+        {
+          code: 'chats_detached_from_omitted_projects',
+          category: 'relationship_adjustment',
+          count: 1,
+        },
+      ],
+    })
+
+    expect(
+      assertValidNativeBackupV2(formatted.manifestBytes, formatted.files),
+    ).toMatchObject({
+      complete: false,
+      warnings: [
+        {
+          code: 'chats_detached_from_omitted_projects',
+          category: 'relationship_adjustment',
+          count: 1,
+        },
+      ],
+    })
+  })
+
+  it('rejects omissions contradicted by included entities or relationships', () => {
+    const entityOmission = {
+      kind: 'project' as const,
+      source_id: 'p',
+      category: 'invalid' as const,
+      reason: 'record_invalid',
+    }
+    expect(() =>
+      formatNativeBackupV2({
+        ...input(),
+        omissions: [entityOmission],
+        warnings: [
+          {
+            code: 'source_items_omitted',
+            category: 'source_coverage',
+            count: 1,
+          },
+        ],
+      }),
+    ).toThrow('project omission conflicts')
+
+    expect(() =>
+      formatNativeBackupV2({
+        ...input(),
+        omissions: [
+          {
+            kind: 'attachment',
+            source_id: 'i',
+            parent_source_id: 'c',
+            category: 'unavailable',
+            reason: 'attachment_not_found',
+          },
+        ],
+        warnings: [
+          {
+            code: 'source_items_omitted',
+            category: 'source_coverage',
+            count: 1,
+          },
+        ],
+      }),
+    ).toThrow('attachment omission conflicts')
+
+    expect(() =>
+      formatNativeBackupV2({
+        ...input(),
+        omissions: [
+          {
+            kind: 'relationship',
+            source_id: 'c',
+            parent_source_id: 'p',
+            category: 'unavailable',
+            reason: 'project_reference_unavailable',
+          },
+        ],
+        warnings: [
+          {
+            code: 'chats_detached_from_omitted_projects',
+            category: 'relationship_adjustment',
+            count: 1,
+          },
+        ],
+      }),
+    ).toThrow('relationship adjustment conflicts')
+
+    const formatted = formatNativeBackupV2({
+      ...input(),
+      omissions: [],
+      warnings: [],
+    })
+    const manifest = JSON.parse(
+      new TextDecoder().decode(formatted.manifestBytes),
+    )
+    manifest.complete = false
+    manifest.omissions = [entityOmission]
+    manifest.warnings = [
+      {
+        code: 'source_items_omitted',
+        category: 'source_coverage',
+        count: 1,
+      },
+    ]
+    expect(() =>
+      assertValidNativeBackupV2(
+        new TextEncoder().encode(JSON.stringify(manifest)),
+        formatted.files,
+      ),
+    ).toThrow('project omission conflicts')
   })
 })

--- a/tests/services/native-backup/format.test.ts
+++ b/tests/services/native-backup/format.test.ts
@@ -496,6 +496,36 @@ describe('native backup v2 manifest', () => {
     })
   })
 
+  it('treats a null project ID as detached for relationship adjustments', () => {
+    const value = input()
+    value.cloudChats[0].projectId = null
+    value.relationships.projectChats = []
+
+    const formatted = formatNativeBackupV2({
+      ...value,
+      omissions: [
+        {
+          kind: 'relationship',
+          source_id: 'c',
+          parent_source_id: 'missing-project',
+          category: 'unavailable',
+          reason: 'project_reference_unavailable',
+        },
+      ],
+      warnings: [
+        {
+          code: 'chats_detached_from_omitted_projects',
+          category: 'relationship_adjustment',
+          count: 1,
+        },
+      ],
+    })
+
+    expect(() =>
+      assertValidNativeBackupV2(formatted.manifestBytes, formatted.files),
+    ).not.toThrow()
+  })
+
   it('rejects omissions contradicted by included entities or relationships', () => {
     const entityOmission = {
       kind: 'project' as const,

--- a/tests/services/native-backup/orchestrate.test.ts
+++ b/tests/services/native-backup/orchestrate.test.ts
@@ -205,6 +205,46 @@ describe('restoreNativeBackup', () => {
     expect(result.report.cloud_chats.warnings[0]).not.toContain('omitted')
   })
 
+  it('attributes relationship adjustments for local source chat IDs locally', async () => {
+    const value = validated(false)
+    value.local.chats[0].projectId = undefined
+    value.backup = {
+      ...value.backup,
+      version: 2,
+      complete: false,
+      omissions: [
+        {
+          kind: 'relationship',
+          source_id: localChat.id,
+          parent_source_id: 'private-project-id',
+          category: 'unavailable',
+          reason: 'project_reference_unavailable',
+        },
+      ],
+      warnings: [
+        {
+          code: 'chats_detached_from_omitted_projects',
+          category: 'relationship_adjustment',
+          count: 1,
+        },
+      ],
+    } as ValidatedNativeRestore['backup']
+    dependencies.validate.mockResolvedValue(value)
+
+    const result = await restoreNativeBackup(
+      sourceFile,
+      'owner-a',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+
+    expect(result.report.local_chats.warnings).toEqual([
+      'Source archive adjusted 1 relationship to keep restored data valid.',
+    ])
+    expect(result.report.cloud_chats.warnings).toEqual([])
+  })
+
   it('does not count a skipped storage write as imported', async () => {
     dependencies.validate.mockResolvedValue(validated(false))
     saveChat.mockResolvedValue(null)

--- a/tests/services/native-backup/orchestrate.test.ts
+++ b/tests/services/native-backup/orchestrate.test.ts
@@ -127,6 +127,84 @@ describe('restoreNativeBackup', () => {
     expect(saveChat.mock.calls[1][0].id).not.toBe(id)
   })
 
+  it('surfaces partial source coverage through the restore report', async () => {
+    const value = validated(false)
+    value.backup = {
+      ...value.backup,
+      version: 2,
+      complete: false,
+      omissions: [
+        {
+          kind: 'cloud_chat',
+          source_id: 'private-source-id',
+          category: 'invalid',
+          reason: 'chat_payload_invalid',
+        },
+      ],
+      warnings: [
+        {
+          code: 'source_items_omitted',
+          category: 'source_coverage',
+          count: 1,
+        },
+      ],
+    } as ValidatedNativeRestore['backup']
+    dependencies.validate.mockResolvedValue(value)
+
+    const result = await restoreNativeBackup(
+      sourceFile,
+      'owner-a',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+
+    expect(result.state).toBe('partial')
+    expect(result.report.cloud_chats.warnings).toEqual([
+      'Source archive omitted 1 cloud chat.',
+    ])
+    expect(JSON.stringify(result.report)).not.toContain('private-source-id')
+  })
+
+  it('reports relationship adjustments separately from omitted cloud chats', async () => {
+    const value = validated(false)
+    value.backup = {
+      ...value.backup,
+      version: 2,
+      complete: false,
+      omissions: [
+        {
+          kind: 'relationship',
+          source_id: 'private-chat-id',
+          parent_source_id: 'private-project-id',
+          category: 'unavailable',
+          reason: 'project_reference_unavailable',
+        },
+      ],
+      warnings: [
+        {
+          code: 'chats_detached_from_omitted_projects',
+          category: 'relationship_adjustment',
+          count: 1,
+        },
+      ],
+    } as ValidatedNativeRestore['backup']
+    dependencies.validate.mockResolvedValue(value)
+
+    const result = await restoreNativeBackup(
+      sourceFile,
+      'owner-a',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+
+    expect(result.report.cloud_chats.warnings).toEqual([
+      'Source archive adjusted 1 relationship to keep restored data valid.',
+    ])
+    expect(result.report.cloud_chats.warnings[0]).not.toContain('omitted')
+  })
+
   it('does not count a skipped storage write as imported', async () => {
     dependencies.validate.mockResolvedValue(validated(false))
     saveChat.mockResolvedValue(null)

--- a/tests/services/native-backup/restore.test.ts
+++ b/tests/services/native-backup/restore.test.ts
@@ -2,6 +2,7 @@ import {
   NATIVE_BACKUP_LIMITS,
   forEachNativeBackupLocalImage,
   formatNativeBackupV1,
+  formatNativeBackupV2,
   validateAndPackageNativeBackup,
   type NativeBackupFileEntry,
   type NativeBackupFormatInput,
@@ -200,6 +201,34 @@ describe('native backup restore validation and cloud packaging', () => {
     expect(JSON.stringify(semantic)).not.toMatch(
       /encryptionKey|codeExecutionAccessToken|syncUserId|local-1/,
     )
+  })
+
+  it('accepts a partial V2 archive while preserving its source warnings', async () => {
+    const formatted = formatNativeBackupV2({
+      ...backupInput(),
+      omissions: [
+        {
+          kind: 'attachment',
+          source_id: 'missing-source-image',
+          parent_source_id: 'cloud-1',
+          category: 'unavailable',
+          reason: 'attachment_not_found',
+        },
+      ],
+      warnings: [
+        {
+          code: 'source_items_omitted',
+          category: 'source_coverage',
+          count: 1,
+        },
+      ],
+    })
+
+    const result = await validateAndPackageNativeBackup(
+      await zip(formatted.manifestBytes, formatted.files),
+    )
+
+    expect(result.backup).toMatchObject({ version: 2, complete: false })
   })
 
   it('rejects incomplete, tampered, unknown, and malformed archives', async () => {

--- a/tests/services/native-backup/restore.test.ts
+++ b/tests/services/native-backup/restore.test.ts
@@ -228,7 +228,26 @@ describe('native backup restore validation and cloud packaging', () => {
       await zip(formatted.manifestBytes, formatted.files),
     )
 
-    expect(result.backup).toMatchObject({ version: 2, complete: false })
+    expect(result.backup).toMatchObject({
+      version: 2,
+      complete: false,
+      omissions: [
+        {
+          kind: 'attachment',
+          source_id: 'missing-source-image',
+          parent_source_id: 'cloud-1',
+          category: 'unavailable',
+          reason: 'attachment_not_found',
+        },
+      ],
+      warnings: [
+        {
+          code: 'source_items_omitted',
+          category: 'source_coverage',
+          count: 1,
+        },
+      ],
+    })
   })
 
   it('rejects incomplete, tampered, unknown, and malformed archives', async () => {

--- a/tests/services/sync-enclave/sync-api.test.ts
+++ b/tests/services/sync-enclave/sync-api.test.ts
@@ -131,6 +131,169 @@ describe('sync-api (enclave JSON-RPC)', () => {
     })
   })
 
+  it('preserves lazy-rewrap metadata without applying backup rules to general pulls', async () => {
+    const api = await import('@/services/sync-enclave/sync-api')
+    mockFetch.mockResolvedValueOnce(
+      ok({
+        items: [
+          {
+            id: 'chat-1',
+            ok: true,
+            etag: 'rewrapped-etag',
+            previous_etag: 'previous-etag',
+            plaintext: '',
+          },
+        ],
+      }),
+    )
+
+    const response = await api.pull({
+      scope: 'chat',
+      ids: ['chat-1'],
+      keys: [{ key: 'key-1' }],
+    })
+
+    expect(response.items[0]).toMatchObject({
+      etag: 'rewrapped-etag',
+      previous_etag: 'previous-etag',
+    })
+  })
+
+  it('validates and returns a strict one-shot backup inventory', async () => {
+    const api = await import('@/services/sync-enclave/sync-api')
+    const response = {
+      captured_at: '2026-08-20T12:00:03.000Z',
+      total_items: 3,
+      items: [
+        {
+          scope: 'chat',
+          id: 'chat-1',
+          etag: 'opaque/chat-etag',
+          project_id: 'project-1',
+          created_at: '2026-08-20T12:00:00.000Z',
+          updated_at: '2026-08-20T12:00:01.000Z',
+        },
+        {
+          scope: 'project',
+          id: 'project-1',
+          etag: 'opaque-project-etag',
+          created_at: '2026-08-20T12:00:00.000Z',
+          updated_at: '2026-08-20T12:00:01.000Z',
+        },
+        {
+          scope: 'project_document',
+          id: 'document-1',
+          etag: 'opaque-document-etag',
+          project_id: 'project-1',
+          created_at: '2026-08-20T12:00:00.000Z',
+          updated_at: '2026-08-20T12:00:02.000Z',
+        },
+      ],
+    }
+    mockFetch.mockResolvedValueOnce(ok(response))
+
+    await expect(api.backupInventory()).resolves.toEqual(response)
+    expect(lastRequest()[0]).toBe('/v1/sync/backup-inventory')
+    expect(lastBody()).toEqual({})
+  })
+
+  it.each([
+    ['invalid_total', { total_items: 2 }],
+    ['invalid_timestamp', { captured_at: 'not-a-timestamp' }],
+    ['malformed_response', { unexpected: true }],
+  ] as const)(
+    'rejects backup inventory root contract violations as %s',
+    async (code, replacement) => {
+      const api = await import('@/services/sync-enclave/sync-api')
+      mockFetch.mockResolvedValueOnce(
+        ok({
+          captured_at: '2026-08-20T12:00:00.000Z',
+          total_items: 0,
+          items: [],
+          ...replacement,
+        }),
+      )
+
+      await expect(api.backupInventory()).rejects.toMatchObject({ code })
+    },
+  )
+
+  it.each([
+    ['unsupported_scope', { scope: 'profile' }],
+    ['missing_id', { id: '' }],
+    ['missing_etag', { etag: '' }],
+    ['invalid_timestamp', { updated_at: 'yesterday' }],
+    ['invalid_relationship', { scope: 'project_document' }],
+    ['invalid_relationship', { scope: 'project', project_id: 'project-1' }],
+    ['invalid_relationship', { project_id: 'missing-project' }],
+  ] as const)(
+    'rejects backup inventory item contract violations as %s',
+    async (code, replacement) => {
+      const api = await import('@/services/sync-enclave/sync-api')
+      const candidate: Record<string, unknown> = {
+        scope: 'chat',
+        id: 'chat-1',
+        etag: 'opaque-etag',
+        created_at: '2026-08-20T12:00:00.000Z',
+        updated_at: '2026-08-20T12:00:00.000Z',
+        ...replacement,
+      }
+      if ('scope' in replacement && replacement.scope === 'project_document') {
+        delete candidate.project_id
+      }
+      mockFetch.mockResolvedValueOnce(
+        ok({
+          captured_at: '2026-08-20T12:00:00.000Z',
+          total_items: 1,
+          items: [candidate],
+        }),
+      )
+
+      await expect(api.backupInventory()).rejects.toMatchObject({
+        code,
+        itemIndex: 0,
+      })
+    },
+  )
+
+  it.each([
+    [
+      'duplicate_item',
+      [
+        { scope: 'chat', id: 'chat-1' },
+        { scope: 'chat', id: 'chat-1' },
+      ],
+    ],
+    [
+      'invalid_order',
+      [
+        { scope: 'project', id: 'project-1' },
+        { scope: 'chat', id: 'chat-1' },
+      ],
+    ],
+  ] as const)(
+    'rejects inventory sequence violations as %s',
+    async (code, identities) => {
+      const api = await import('@/services/sync-enclave/sync-api')
+      const items = identities.map(({ scope, id }) => ({
+        scope,
+        id,
+        etag: 'opaque-etag',
+        created_at: '2026-08-20T12:00:00.000Z',
+        updated_at: '2026-08-20T12:00:00.000Z',
+      }))
+      mockFetch.mockResolvedValueOnce(
+        ok({
+          captured_at: '2026-08-20T12:00:00.000Z',
+          total_items: items.length,
+          items,
+        }),
+      )
+
+      await expect(api.backupInventory()).rejects.toMatchObject({ code })
+    },
+  )
+
   it('listStatus posts /v1/sync/list-status with scope and project filter', async () => {
     const api = await import('@/services/sync-enclave/sync-api')
     mockFetch.mockResolvedValueOnce(ok({ updates: [], deletes: [] }))


### PR DESCRIPTION
## Summary
- add a truthful V2 backup manifest for omitted source items and relationship adjustments
- collect cloud records from one stable attested inventory and validate opaque ETags on pull
- export coherent partial archives for persistently unreadable records and surface warnings during export and restore

## Privacy
- keeps ZIP generation and local-only chats in the browser
- receives metadata only from the new inventory endpoint; plaintext continues through existing attested pull paths

## Testing
- `npx vitest run`
- `npx tsc --noEmit --incremental false`
- `npx eslint .`

## Dependencies
- requires https://github.com/tinfoilsh/controlplane/pull/614
- requires https://github.com/tinfoilsh/confidential-sync/pull/43