### PR TITLE
fix: explain passkey setup failures

### DIFF
--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -910,9 +910,10 @@ ${generatedKey.replace('key_', '')}
         enterSetupFailed()
       }
     } catch (error) {
-      if (error instanceof PrfNotSupportedError) {
-        setSetupError(error.message)
-        enterSetupFailed()
+      const failure = getPasskeySetupFailure(error)
+      if (failure) {
+        setSetupError(failure.description)
+        enterSetupFailed('manual', failure.title)
       } else {
         logError('Start fresh failed', error, {
           component: 'CloudSyncSetupModal',

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/components/ui/utils'
 import { SETTINGS_HAS_SEEN_CLOUD_SYNC_MODAL } from '@/constants/storage-keys'
 import { useToast } from '@/hooks/use-toast'
 import { encryptionService } from '@/services/encryption/encryption-service'
-import { PrfNotSupportedError } from '@/services/passkey'
+import { PasskeyTimeoutError, PrfNotSupportedError } from '@/services/passkey'
 import { setCloudSyncEnabled as persistCloudSyncEnabled } from '@/utils/cloud-sync-settings'
 import { logError, logInfo } from '@/utils/error-handling'
 import {
@@ -42,6 +42,28 @@ const BUTTON_COLUMN_CLASS_NAME =
 
 const ILLUSTRATION_ICON_CLASS_NAME =
   'mx-auto h-20 w-20 text-content-secondary opacity-70'
+
+const PASSKEY_SETUP_FAILED_DESCRIPTION =
+  'Could not create passkey backup. You can try again later.'
+
+function getPasskeySetupFailure(error: unknown): {
+  title: string
+  description: string
+} | null {
+  if (error instanceof PrfNotSupportedError) {
+    return {
+      title: 'Passkey Provider Not Supported',
+      description: error.message,
+    }
+  }
+  if (error instanceof PasskeyTimeoutError) {
+    return {
+      title: 'Passkey Setup Timed Out',
+      description: error.message,
+    }
+  }
+  return null
+}
 
 interface CloudSyncSetupModalBaseProps {
   isOpen: boolean
@@ -121,6 +143,7 @@ export function CloudSyncSetupModal({
   const [isDragging, setIsDragging] = useState(false)
   const [isStartingFresh, setIsStartingFresh] = useState(false)
   const [keyAlreadyActivated, setKeyAlreadyActivated] = useState(false)
+  const [setupErrorTitle, setSetupErrorTitle] = useState('Setup Failed')
   const [setupError, setSetupError] = useState('')
   const [setupFailedOrigin, setSetupFailedOrigin] = useState<
     'passkey' | 'manual'
@@ -152,7 +175,11 @@ export function CloudSyncSetupModal({
     )
   }, [passkeyRecoveryNeeded])
 
-  const enterSetupFailed = (origin: 'passkey' | 'manual' = 'manual') => {
+  const enterSetupFailed = (
+    origin: 'passkey' | 'manual' = 'manual',
+    title = 'Setup Failed',
+  ) => {
+    setSetupErrorTitle(title)
     setSetupFailedOrigin(origin)
     setCurrentStep('setup-failed')
   }
@@ -169,20 +196,22 @@ export function CloudSyncSetupModal({
         if (success) {
           setCurrentStep('restore-success')
         } else {
-          setSetupError(
-            'Could not create passkey backup. You can try again later.',
-          )
+          setSetupError(PASSKEY_SETUP_FAILED_DESCRIPTION)
           enterSetupFailed('passkey')
         }
       } catch (error) {
-        logError('Could not start passkey setup', error, {
-          component: 'CloudSyncSetupModal',
-          action: 'handleContinue',
-        })
-        setSetupError(
-          'Could not create passkey backup. You can try again later.',
-        )
-        enterSetupFailed('passkey')
+        const failure = getPasskeySetupFailure(error)
+        if (failure) {
+          setSetupError(failure.description)
+          enterSetupFailed('passkey', failure.title)
+        } else {
+          logError('Could not start passkey setup', error, {
+            component: 'CloudSyncSetupModal',
+            action: 'handleContinue',
+          })
+          setSetupError(PASSKEY_SETUP_FAILED_DESCRIPTION)
+          enterSetupFailed('passkey')
+        }
       }
       return
     }
@@ -804,7 +833,7 @@ ${generatedKey.replace('key_', '')}
           as="h2"
           className="text-balance text-center text-xl font-bold leading-7"
         >
-          Setup Failed
+          {setupErrorTitle}
         </ModalTitle>
 
         <p className="text-balance text-center text-sm text-content-secondary">

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -347,7 +347,7 @@ export function usePasskeyBackup({
   /**
    * Create a PRF passkey and encrypt the given key bundle to the backend.
    * Returns true if the passkey was created and keys stored, false if the user
-   * cancelled or PRF wasn't supported, throws on unexpected errors.
+   * cancelled, and throws when setup cannot proceed or fails unexpectedly.
    */
   const createAndStorePasskeyBackup = async (
     userInfo: { userId: string; userName: string; displayName: string },
@@ -1403,7 +1403,8 @@ export function usePasskeyBackup({
    * generate a key in memory, create a passkey to back it up, and persist the
    * key only after passkey creation succeeds. Invoked from the first-time
    * confirmation modal — we intentionally do not auto-trigger the native
-   * passkey dialog on page load.
+   * passkey dialog on page load. Expected provider and timeout errors are
+   * rethrown so the modal can explain how the user can recover.
    */
   const setupFirstTimePasskey = useCallback(async (): Promise<boolean> => {
     setupWarningDismissedFlag.clear()
@@ -1518,6 +1519,12 @@ export function usePasskeyBackup({
         })
       }
       markFailedAndClosePrompt()
+      if (
+        error instanceof PrfNotSupportedError ||
+        error instanceof PasskeyTimeoutError
+      ) {
+        throw error
+      }
       return false
     }
   }, [applyRecoveredKeyBundle, generateKeyWithPasskeyBackup])

--- a/tests/components/cloud-sync-setup-modal.test.tsx
+++ b/tests/components/cloud-sync-setup-modal.test.tsx
@@ -305,6 +305,28 @@ describe('CloudSyncSetupModal onboarding', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('explains passkey failures while starting fresh', async () => {
+    const error = new PasskeyTimeoutError()
+    render(
+      <CloudSyncSetupModal
+        {...baseProps}
+        passkeyRecoveryNeeded
+        onRecoverWithPasskey={vi.fn()}
+        onSetupNewKey={vi.fn().mockRejectedValue(error)}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start Fresh' }))
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Yes, start fresh' }),
+    )
+
+    expect(
+      await screen.findByRole('heading', { name: 'Passkey Setup Timed Out' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText(error.message)).toBeInTheDocument()
+  })
+
   it('does not restrict the native recovery-key file picker', async () => {
     render(<CloudSyncSetupModal {...baseProps} manualRecoveryNeeded />)
 

--- a/tests/components/cloud-sync-setup-modal.test.tsx
+++ b/tests/components/cloud-sync-setup-modal.test.tsx
@@ -1,5 +1,6 @@
 import { CloudSyncSetupModal } from '@/components/modals/cloud-sync-setup-modal'
 import { encryptionService } from '@/services/encryption/encryption-service'
+import { PasskeyTimeoutError, PrfNotSupportedError } from '@/services/passkey'
 import {
   isCloudSyncEnabled,
   setCloudSyncEnabled,
@@ -96,6 +97,46 @@ describe('CloudSyncSetupModal onboarding', () => {
     expect(
       await screen.findByRole('heading', { name: 'Setup Failed' }),
     ).toBeInTheDocument()
+  })
+
+  it('explains when the passkey provider does not support PRF', async () => {
+    const error = new PrfNotSupportedError()
+    render(
+      <CloudSyncSetupModal
+        {...baseProps}
+        prfSupported
+        onSetupWithPasskey={vi.fn().mockRejectedValue(error)}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Passkey Provider Not Supported',
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByText(error.message)).toBeInTheDocument()
+    expect(mocks.logError).not.toHaveBeenCalled()
+  })
+
+  it('explains when passkey setup times out', async () => {
+    const error = new PasskeyTimeoutError()
+    render(
+      <CloudSyncSetupModal
+        {...baseProps}
+        prfSupported
+        onSetupWithPasskey={vi.fn().mockRejectedValue(error)}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(
+      await screen.findByRole('heading', { name: 'Passkey Setup Timed Out' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText(error.message)).toBeInTheDocument()
+    expect(mocks.logError).not.toHaveBeenCalled()
   })
 
   it('shows the intro before manual key setup', async () => {

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -3,6 +3,7 @@ import {
   SETTINGS_MANUAL_RECOVERY_DISMISSED,
 } from '@/constants/storage-keys'
 import { usePasskeyBackup } from '@/hooks/use-passkey-backup'
+import { PrfNotSupportedError } from '@/services/passkey'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -185,6 +186,23 @@ describe('usePasskeyBackup', () => {
 
     expect(prompted).toBe(false)
     expect(result.current.manualRecoveryNeeded).toBe(false)
+    expect(result.current.passkeySetupFailed).toBe(true)
+    expect(result.current.passkeyRetryAvailable).toBe(true)
+  })
+
+  it('surfaces unsupported passkey providers during first-time setup', async () => {
+    const error = new PrfNotSupportedError('PRF is not supported')
+    mocks.generateKey.mockResolvedValue('key_generated')
+    mocks.getAlternativeKeyBytes.mockReturnValue(new Uint8Array(32))
+    mocks.createAndWrapTinfoilKey.mockRejectedValue(error)
+    const { result } = renderHook(() =>
+      usePasskeyBackup({ ...baseOptions, initialized: false }),
+    )
+
+    await act(async () => {
+      await expect(result.current.setupFirstTimePasskey()).rejects.toBe(error)
+    })
+
     expect(result.current.passkeySetupFailed).toBe(true)
     expect(result.current.passkeyRetryAvailable).toBe(true)
   })


### PR DESCRIPTION
## Summary
- preserve unsupported-provider and timeout errors from first-time passkey setup
- show actionable titles and descriptions instead of the generic setup failure
- cover PRF incompatibility, timeout, and error propagation behavior

## Testing
- `npm run test:unit -- --run`
- `npx tsc --noEmit`
- `npx eslint src/hooks/use-passkey-backup.ts src/components/modals/cloud-sync-setup-modal.tsx tests/components/cloud-sync-setup-modal.test.tsx tests/hooks/use-passkey-backup.test.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explains passkey setup failures so users see specific reasons instead of a generic message when setup fails.

- Rethrows `PrfNotSupportedError` and `PasskeyTimeoutError` from first-time passkey setup so the modal can distinguish them.
- Shows a dedicated title and error description for unsupported passkey providers and timeouts in both first-time setup and start fresh; other failures still log and fall back to the generic message.
- Adds unit tests covering both error paths and the error propagation behavior.

<sup>Written for commit 45e1a94b2805366f01a285f206942a143838eae6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

