### PR TITLE
chore: update passkey-kit to 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@radix-ui/react-toast": "^1.2.7",
         "@radix-ui/react-tooltip": "^1.2.0",
         "@tailwindcss/typography": "^0.5.16",
-        "@tinfoilsh/passkey-kit": "0.2.0",
+        "@tinfoilsh/passkey-kit": "0.2.1",
         "@tinfoilsh/tinfoil-icons": "^2.0.4",
         "@zip.js/zip.js": "^2.8.53",
         "autoprefixer": "^10.4.21",
@@ -3386,9 +3386,9 @@
       }
     },
     "node_modules/@tinfoilsh/passkey-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@tinfoilsh/passkey-kit/-/passkey-kit-0.2.0.tgz",
-      "integrity": "sha512-1H+TdQJToupuje0yPW9VLkyAPBZM/DwjRT4Fh3pyfanrd8iuTDTvVb5ONvdSS9tJjWoGG82WAK193JepbXbMUw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tinfoilsh/passkey-kit/-/passkey-kit-0.2.1.tgz",
+      "integrity": "sha512-AsW9TCGI4WuoKxkYCI3z70StIG2bfZj89AXVVEZDrdXsNZ63ZdKEuz5bdgXEmodV0qyypmmqUmc1QDZvspfEag==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-toast": "^1.2.7",
     "@radix-ui/react-tooltip": "^1.2.0",
     "@tailwindcss/typography": "^0.5.16",
-    "@tinfoilsh/passkey-kit": "0.2.0",
+    "@tinfoilsh/passkey-kit": "0.2.1",
     "@tinfoilsh/tinfoil-icons": "^2.0.4",
     "@zip.js/zip.js": "^2.8.53",
     "autoprefixer": "^10.4.21",


### PR DESCRIPTION
## Summary
- Bumps `@tinfoilsh/passkey-kit` from 0.2.0 to 0.2.1
- 0.2.1 makes recovery resilient: malformed candidates (wrong profile, non-canonical credential ID, bad field lengths) are skipped instead of aborting the whole ceremony, so one corrupt or legacy-format bundle can no longer block recovery via healthy bundles

## Tests
- All passkey test suites pass against 0.2.1 (9 files, 70 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@tinfoilsh/passkey-kit` to 0.2.1 so recovery no longer aborts when it encounters a malformed candidate.

- Malformed candidates (wrong profile, non-canonical credential ID, bad field lengths) are now skipped instead of failing the whole ceremony.

<sup>Written for commit d92f170217b419108d1b25cd047ce4ea3fe4b0ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

