### PR TITLE
chore: update passkey kit to 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@radix-ui/react-toast": "^1.2.7",
         "@radix-ui/react-tooltip": "^1.2.0",
         "@tailwindcss/typography": "^0.5.16",
-        "@tinfoilsh/passkey-kit": "0.2.1",
+        "@tinfoilsh/passkey-kit": "0.2.2",
         "@tinfoilsh/tinfoil-icons": "^2.0.4",
         "@zip.js/zip.js": "^2.8.53",
         "autoprefixer": "^10.4.21",
@@ -3386,9 +3386,9 @@
       }
     },
     "node_modules/@tinfoilsh/passkey-kit": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@tinfoilsh/passkey-kit/-/passkey-kit-0.2.1.tgz",
-      "integrity": "sha512-AsW9TCGI4WuoKxkYCI3z70StIG2bfZj89AXVVEZDrdXsNZ63ZdKEuz5bdgXEmodV0qyypmmqUmc1QDZvspfEag==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@tinfoilsh/passkey-kit/-/passkey-kit-0.2.2.tgz",
+      "integrity": "sha512-oEWZGmUNPVPfpfURpT8U1d8R5hg3Oi1fdWRyWNnvJWDQ3b3aA9ft9Qg/HSw+/pjQBhinflY687w4utmD7CLXjA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-toast": "^1.2.7",
     "@radix-ui/react-tooltip": "^1.2.0",
     "@tailwindcss/typography": "^0.5.16",
-    "@tinfoilsh/passkey-kit": "0.2.1",
+    "@tinfoilsh/passkey-kit": "0.2.2",
     "@tinfoilsh/tinfoil-icons": "^2.0.4",
     "@zip.js/zip.js": "^2.8.53",
     "autoprefixer": "^10.4.21",


### PR DESCRIPTION
## Summary
- Bump `@tinfoilsh/passkey-kit` from 0.2.1 to 0.2.2 (exact pin).

## Upstream changes in 0.2.2
- Standalone `wrapKey`/`unwrapKey` crypto functions are now exported (tinfoilsh/tinfoil-passkey-kit#11) — no adoption needed here, but available for future migration tooling.
- Swift `KeychainPasskeyKeyStorage` gained an optional legacy-cache decode hook (tinfoilsh/tinfoil-passkey-kit#12) — Swift-only, no effect on this app.

Both upstream changes are additive with no wire-format changes; no code changes required in this repo. All 2053 unit tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@tinfoilsh/passkey-kit` from 0.2.1 to 0.2.2 (exact pin).

- Upstream 0.2.2 adds standalone `wrapKey`/`unwrapKey` exports and a Swift-only legacy-cache decode hook; both are additive.
- No wire-format changes and no code adjustments needed in this repo; all 2053 unit tests pass.

<sup>Written for commit 71ad36729d992b3d529fa540d1f4e2882de33159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

