### PR TITLE
chore: update Clerk authentication dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apple/mapkit-loader": "^0.2.1",
         "@braintree/sanitize-url": "^7.1.1",
-        "@clerk/nextjs": "^7.3.4",
+        "@clerk/nextjs": "^7.8.3",
         "@headlessui/react": "^2.1.1",
         "@heroicons/react": "^2.1.4",
         "@noble/hashes": "^2.2.0",
@@ -520,12 +520,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@clerk/backend": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.11.6.tgz",
-      "integrity": "sha512-cHAmZnSbr/z4HzyP00d8C7W9SjRZpdmzrS3q9SSdt176q3kw7KK6T0MBtn684tCx5E9sQPdCUB3Hvcu71hlWOA==",
+      "version": "3.16.13",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.16.13.tgz",
+      "integrity": "sha512-L6+48rB8WVoxoiFDKv49KWxc58aGwuYnbuHBxNdqgTZO6PTyEH3KLpnqI/WaCqIxQW56MJE24EJREsU8WlWrWw==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.25.4",
+        "@clerk/shared": "^4.30.2",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -534,14 +534,14 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.5.19.tgz",
-      "integrity": "sha512-CDT6F751pN/783R3pQ75sbdZqRzCyWUwpEzIITx1ocJsNQeJDsOL3HLkFOTUsN3rZy8JxGxw27E3Ipbm2OUbJA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.8.3.tgz",
+      "integrity": "sha512-1ltta1RbpbM7/ahZ3rROBV7bFTbNE0C10Hw3CRPt+tGYuO7dMz6sq+0aMEwRS/3flpN8J3/pHxiUGfMfliLWaQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^3.11.6",
-        "@clerk/react": "^6.12.4",
-        "@clerk/shared": "^4.25.4",
+        "@clerk/backend": "^3.16.13",
+        "@clerk/react": "^6.14.8",
+        "@clerk/shared": "^4.30.2",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -555,12 +555,12 @@
       }
     },
     "node_modules/@clerk/react": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.12.4.tgz",
-      "integrity": "sha512-YL4iS3F5o8TOW67v2RUPAvsIbSLTqcfgMQ+1/PYZCTf7DeGbAYfUzmAca1FGsSsrDFYV2sSV1piyscqVv7qQxQ==",
+      "version": "6.14.8",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.14.8.tgz",
+      "integrity": "sha512-N7Ca3zze0PsVZ+TiMq6foYUMJMuCSzc8eqQombnqZVOhMxTB3KAn3jSHKBrN6fBZq4jGcqT1IcSsH/4xAMjjVQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.25.4",
+        "@clerk/shared": "^4.30.2",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -572,9 +572,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.25.4",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.4.tgz",
-      "integrity": "sha512-q2iAdjMOwDIPC+1HFgkF0yVL/fnRPSCjEkQ8dgSEVbAPJb/M8/CeKNfhSRKQcXFKiYYa4YrnYPH2F0J0YQaWiQ==",
+      "version": "4.30.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.30.2.tgz",
+      "integrity": "sha512-2U8jE2Gno2uRxg5b2fv5uY3zxzxAvmBzjiaOPAfoAVUgJ2Ys9kPu+6k2TaBNTkeF0ncQ/5erECIx6dPt0d8XyQ==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
@@ -3273,9 +3273,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
-      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "version": "5.102.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.102.8.tgz",
+      "integrity": "sha512-ZNjkJ33CqvPNec/6lZBnHqLc3EVGPZ9ySLhYahU9TcuRFdmwXewuj0c4hwSWcGHqEUwcSrKeZ+oGcvPBqXcQcg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -13332,9 +13332,9 @@
       }
     },
     "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@apple/mapkit-loader": "^0.2.1",
     "@braintree/sanitize-url": "^7.1.1",
-    "@clerk/nextjs": "^7.3.4",
+    "@clerk/nextjs": "^7.8.3",
     "@headlessui/react": "^2.1.1",
     "@heroicons/react": "^2.1.4",
     "@noble/hashes": "^2.2.0",


### PR DESCRIPTION
## Summary
- update the Clerk Next.js SDK to 7.8.3
- refresh Clerk's transitive authentication dependencies

## Testing
- `npm run test:unit -- --run tests/pages/signin.test.tsx`
- `npm run lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `@clerk/nextjs` to ^7.8.3 (from ^7.3.4) and refreshes its transitive auth dependencies (`@clerk/backend`, `@clerk/react`, `@clerk/shared`, `standardwebhooks`, `@tanstack/query-core`) to latest compatible versions. This is a maintenance update with no expected API or behavior changes.

<sup>Written for commit 6a389f84d9a0ca028311c122d84c636ec8aaae28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

