### PR TITLE
feat: option to make Enter insert a new line instead of sending

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -35,6 +35,7 @@ import {
 } from './components/context-usage-indicator'
 import { MacFileIcon } from './components/mac-file-icon'
 import { CONSTANTS } from './constants'
+import { useEnterToNewline } from './hooks/use-enter-to-newline'
 import type { PromptPreset } from './prompts/types'
 import type { ProcessedDocument } from './renderers/types'
 import type { LoadingState } from './types'
@@ -135,6 +136,7 @@ export function ChatInput({
   const documentsScrollRef = useRef<HTMLDivElement>(null)
   const { toast } = useToast()
   const { isProjectMode, activeProject } = useProject()
+  const enterToNewline = useEnterToNewline()
   const [textareaResetNonce, setTextareaResetNonce] = useState(0)
   const prevInputValueRef = useRef(input)
   const shouldRemountOnClearRef = useRef(false)
@@ -1079,12 +1081,16 @@ export function ChatInput({
                     }, 0)
                   }
                 }
-              } else if (e.key === 'Enter' && !e.shiftKey) {
+              } else if (
+                e.key === 'Enter' &&
+                !e.shiftKey &&
+                (!enterToNewline || e.metaKey || e.ctrlKey)
+              ) {
                 // On mobile, Enter should insert a newline, not submit
                 const isMobile = /iPhone|iPad|iPod|Android/i.test(
                   navigator.userAgent,
                 )
-                if (isMobile) {
+                if (isMobile && !e.metaKey && !e.ctrlKey) {
                   return
                 }
                 e.preventDefault()
@@ -1097,7 +1103,7 @@ export function ChatInput({
                   shouldRemountOnClearRef.current = true
                   handleSubmit(e)
                 }
-              } else if (e.key === 'Enter' && e.shiftKey) {
+              } else if (e.key === 'Enter') {
                 const textarea = e.currentTarget
                 const cursorPosition = textarea.selectionStart
                 const textBeforeCursor = input.slice(0, cursorPosition)

--- a/src/components/chat/hooks/use-enter-to-newline.ts
+++ b/src/components/chat/hooks/use-enter-to-newline.ts
@@ -3,11 +3,17 @@ import { SETTINGS_ENTER_TO_NEWLINE_ENABLED } from '@/constants/storage-keys'
 import { useSyncExternalStore } from 'react'
 
 const subscribe = (onStoreChange: () => void) => {
+  // A null key means localStorage.clear(), which also resets this setting.
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === null || event.key === SETTINGS_ENTER_TO_NEWLINE_ENABLED) {
+      onStoreChange()
+    }
+  }
   window.addEventListener(ENTER_TO_NEWLINE_CHANGED_EVENT, onStoreChange)
-  window.addEventListener('storage', onStoreChange)
+  window.addEventListener('storage', handleStorage)
   return () => {
     window.removeEventListener(ENTER_TO_NEWLINE_CHANGED_EVENT, onStoreChange)
-    window.removeEventListener('storage', onStoreChange)
+    window.removeEventListener('storage', handleStorage)
   }
 }
 

--- a/src/components/chat/hooks/use-enter-to-newline.ts
+++ b/src/components/chat/hooks/use-enter-to-newline.ts
@@ -1,0 +1,32 @@
+import { ENTER_TO_NEWLINE_CHANGED_EVENT } from '@/constants/settings-events'
+import { SETTINGS_ENTER_TO_NEWLINE_ENABLED } from '@/constants/storage-keys'
+import { useSyncExternalStore } from 'react'
+
+const subscribe = (onStoreChange: () => void) => {
+  window.addEventListener(ENTER_TO_NEWLINE_CHANGED_EVENT, onStoreChange)
+  window.addEventListener('storage', onStoreChange)
+  return () => {
+    window.removeEventListener(ENTER_TO_NEWLINE_CHANGED_EVENT, onStoreChange)
+    window.removeEventListener('storage', onStoreChange)
+  }
+}
+
+const getSnapshot = (): boolean => {
+  try {
+    return localStorage.getItem(SETTINGS_ENTER_TO_NEWLINE_ENABLED) === 'true'
+  } catch {
+    // Storage can be blocked (e.g. disabled cookies); keep the default.
+    return false
+  }
+}
+
+const getServerSnapshot = (): boolean => false
+
+/**
+ * Whether pressing Enter in a chat textarea should insert a newline instead
+ * of submitting. When enabled, submitting is done via Cmd/Ctrl+Enter or the
+ * send button. Reacts to same-tab settings changes and cross-tab storage
+ * events.
+ */
+export const useEnterToNewline = (): boolean =>
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -17,6 +17,7 @@ import { GoClockFill } from 'react-icons/go'
 import { RxCopy } from 'react-icons/rx'
 import { hasMessageAttachments } from '../../attachment-helpers'
 import { hasVisibleAssistantMessage } from '../../hooks/streaming/interrupted-message'
+import { useEnterToNewline } from '../../hooks/use-enter-to-newline'
 import { CodeExecProcess } from '../components/CodeExecProcess'
 import { DocumentList } from '../components/DocumentList'
 import { MessageActions } from '../components/MessageActions'
@@ -61,6 +62,7 @@ const DefaultMessageComponent = ({
   onRetryToolCall,
 }: MessageRenderProps) => {
   const isUser = message.role === 'user'
+  const enterToNewline = useEnterToNewline()
   const [isEditing, setIsEditing] = React.useState(false)
   const [editContent, setEditContent] = React.useState(message.content || '')
   const [copiedUser, setCopiedUser] = React.useState(false)
@@ -594,7 +596,11 @@ const DefaultMessageComponent = ({
                     value={editContent}
                     onChange={(e) => setEditContent(e.target.value)}
                     onKeyDown={(e) => {
-                      if (e.key === 'Enter' && !e.shiftKey) {
+                      if (
+                        e.key === 'Enter' &&
+                        !e.shiftKey &&
+                        (!enterToNewline || e.metaKey || e.ctrlKey)
+                      ) {
                         e.preventDefault()
                         handleSubmitEdit()
                       } else if (e.key === 'Escape') {

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -2,10 +2,14 @@ import { TextureGrid } from '@/components/texture-grid'
 import { cn } from '@/components/ui/utils'
 import { UserAvatar } from '@/components/user-avatar'
 import { API_BASE_URL } from '@/config'
-import { PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
+import {
+  ENTER_TO_NEWLINE_CHANGED_EVENT,
+  PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
+} from '@/constants/settings-events'
 import {
   SETTINGS_CHAT_FONT,
   SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED,
+  SETTINGS_ENTER_TO_NEWLINE_ENABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
   SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
@@ -476,6 +480,10 @@ export function SettingsModal({
   // Web Search PII check setting (defaults to on)
   const [piiCheckEnabled, setPiiCheckEnabled] = useState<boolean>(true)
 
+  // Enter inserts newline instead of sending (defaults to off)
+  const [enterToNewlineEnabled, setEnterToNewlineEnabled] =
+    useState<boolean>(false)
+
   const [pixelateSidebarChatTitles, setPixelateSidebarChatTitles] =
     useState<boolean>(true)
 
@@ -652,6 +660,12 @@ export function SettingsModal({
     // Load PII check setting (defaults to true if not set)
     const savedPiiCheck = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
     setPiiCheckEnabled(savedPiiCheck === null ? true : savedPiiCheck === 'true')
+
+    // Load Enter-inserts-newline setting (defaults to false if not set)
+    const savedEnterToNewline = localStorage.getItem(
+      SETTINGS_ENTER_TO_NEWLINE_ENABLED,
+    )
+    setEnterToNewlineEnabled(savedEnterToNewline === 'true')
 
     const savedPixelateSidebarChatTitles = localStorage.getItem(
       SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
@@ -2484,6 +2498,53 @@ ${encryptionKey.replace('key_', '')}
                             </option>
                           ))}
                         </select>
+                      </div>
+                    </div>
+                    {/* Enter inserts newline */}
+                    <div
+                      className={cn(
+                        'rounded-lg border border-border-subtle p-4',
+                        isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+                      )}
+                    >
+                      <div className="flex items-start justify-between">
+                        <div className="mr-3 flex-1">
+                          <div className="font-aeonik text-sm font-medium text-content-primary">
+                            Press Enter for new line
+                          </div>
+                          <div className="font-aeonik-fono text-xs text-content-muted">
+                            Enter inserts a new line instead of sending your
+                            message. Send with Cmd/Ctrl+Enter or the send
+                            button.
+                          </div>
+                        </div>
+                        <label className="relative inline-flex cursor-pointer items-center">
+                          <input
+                            type="checkbox"
+                            aria-label="Press Enter for new line"
+                            checked={enterToNewlineEnabled}
+                            onChange={(e) => {
+                              const newValue = e.target.checked
+                              setEnterToNewlineEnabled(newValue)
+                              if (isClient) {
+                                localStorage.setItem(
+                                  SETTINGS_ENTER_TO_NEWLINE_ENABLED,
+                                  newValue.toString(),
+                                )
+                                window.dispatchEvent(
+                                  new CustomEvent(
+                                    ENTER_TO_NEWLINE_CHANGED_EVENT,
+                                    {
+                                      detail: { enabled: newValue },
+                                    },
+                                  ),
+                                )
+                              }
+                            }}
+                            className="peer sr-only"
+                          />
+                          <div className="peer h-5 w-9 rounded-full border border-border-subtle bg-content-muted/40 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-content-muted/70 after:shadow-sm after:transition-all after:content-[''] peer-checked:bg-brand-accent-light peer-checked:after:translate-x-full peer-checked:after:bg-white peer-focus:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-border-strong" />
+                        </label>
                       </div>
                     </div>
                   </div>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -717,6 +717,11 @@ export function SettingsModal({
     ) => {
       setPixelateSidebarChatTitles(event.detail.enabled)
     }
+    const handleEnterToNewlineUpdate = (
+      event: CustomEvent<{ enabled: boolean }>,
+    ) => {
+      setEnterToNewlineEnabled(event.detail.enabled)
+    }
 
     // Listen for cloud sync setting changes (e.g., from modal or other sources)
     const handleCloudSyncUpdate = () => {
@@ -737,6 +742,10 @@ export function SettingsModal({
     window.addEventListener(
       PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
       handlePixelateSidebarChatTitlesUpdate as EventListener,
+    )
+    window.addEventListener(
+      ENTER_TO_NEWLINE_CHANGED_EVENT,
+      handleEnterToNewlineUpdate as EventListener,
     )
     window.addEventListener(
       CLOUD_SYNC_SETTING_CHANGED_EVENT,
@@ -761,6 +770,10 @@ export function SettingsModal({
       window.removeEventListener(
         PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
         handlePixelateSidebarChatTitlesUpdate as EventListener,
+      )
+      window.removeEventListener(
+        ENTER_TO_NEWLINE_CHANGED_EVENT,
+        handleEnterToNewlineUpdate as EventListener,
       )
       window.removeEventListener(
         CLOUD_SYNC_SETTING_CHANGED_EVENT,

--- a/src/constants/settings-events.ts
+++ b/src/constants/settings-events.ts
@@ -1,3 +1,4 @@
 export const PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT =
   'pixelateSidebarChatTitlesChanged'
 export const PINNED_CHAT_IDS_CHANGED_EVENT = 'pinnedChatIdsChanged'
+export const ENTER_TO_NEWLINE_CHANGED_EVENT = 'enterToNewlineChanged'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -48,6 +48,10 @@ export const SETTINGS_CODE_EXECUTION_ENABLED =
 export const SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED =
   'tinfoil-settings-pixelate-sidebar-chat-titles-enabled'
 export const SETTINGS_PII_CHECK_ENABLED = 'tinfoil-settings-pii-check-enabled'
+// When enabled, pressing Enter in the chat input inserts a newline instead
+// of submitting the message; submit via Cmd/Ctrl+Enter or the send button.
+export const SETTINGS_ENTER_TO_NEWLINE_ENABLED =
+  'tinfoil-settings-enter-to-newline-enabled'
 export const SETTINGS_GENUI_ENABLED = 'tinfoil-settings-genui-enabled'
 export const SETTINGS_THEME_MODE = 'tinfoil-settings-theme-mode'
 export const SETTINGS_THEME = 'tinfoil-settings-theme'

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -1,6 +1,7 @@
 import { CLOUD_SYNC } from '@/config'
 import { AUTH_ACTIVE_USER_CHANGED_EVENT } from '@/constants/auth-events'
 import {
+  ENTER_TO_NEWLINE_CHANGED_EVENT,
   PINNED_CHAT_IDS_CHANGED_EVENT,
   PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
 } from '@/constants/settings-events'
@@ -428,6 +429,7 @@ export function useProfileSync() {
       'codeExecutionEnabledChanged',
       PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
       'piiCheckEnabledChanged',
+      ENTER_TO_NEWLINE_CHANGED_EVENT,
       'genUIEnabledChanged',
       'chatFontChanged',
     ]

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -40,7 +40,11 @@ export const PROFILE_MERGE_FIELDS = [
 // Older clients omit this field, while the setting itself has no unset state.
 const PRESERVE_LOCAL_WHEN_REMOTE_OMITS = new Set<
   (typeof PROFILE_MERGE_FIELDS)[number]
->(['pixelateSidebarChatTitlesEnabled', 'pinnedChatIds'])
+>([
+  'pixelateSidebarChatTitlesEnabled',
+  'pinnedChatIds',
+  'enterToNewlineEnabled',
+])
 
 const TREAT_LOCAL_OMISSION_AS_UNEDITED = new Set<
   (typeof PROFILE_MERGE_FIELDS)[number]

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -32,6 +32,7 @@ export const PROFILE_MERGE_FIELDS = [
   'codeExecutionEnabled',
   'pixelateSidebarChatTitlesEnabled',
   'piiCheckEnabled',
+  'enterToNewlineEnabled',
   'genUIEnabled',
   'chatFont',
 ] as const

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -1,10 +1,12 @@
 import {
+  ENTER_TO_NEWLINE_CHANGED_EVENT,
   PINNED_CHAT_IDS_CHANGED_EVENT,
   PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
 } from '@/constants/settings-events'
 import {
   SETTINGS_CHAT_FONT,
   SETTINGS_CODE_EXECUTION_ENABLED,
+  SETTINGS_ENTER_TO_NEWLINE_ENABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
   SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
@@ -108,6 +110,7 @@ export function hasProfileChanged(
     profile1.pixelateSidebarChatTitlesEnabled !==
       profile2.pixelateSidebarChatTitlesEnabled ||
     profile1.piiCheckEnabled !== profile2.piiCheckEnabled ||
+    profile1.enterToNewlineEnabled !== profile2.enterToNewlineEnabled ||
     profile1.genUIEnabled !== profile2.genUIEnabled ||
     profile1.chatFont !== profile2.chatFont
   )
@@ -248,6 +251,13 @@ export function loadLocalSettings(): ProfileData {
     settings.piiCheckEnabled = piiCheckEnabled === 'true'
   }
 
+  const enterToNewlineEnabled = localStorage.getItem(
+    SETTINGS_ENTER_TO_NEWLINE_ENABLED,
+  )
+  if (enterToNewlineEnabled !== null) {
+    settings.enterToNewlineEnabled = enterToNewlineEnabled === 'true'
+  }
+
   const genUIEnabled = localStorage.getItem(SETTINGS_GENUI_ENABLED)
   if (genUIEnabled !== null) {
     settings.genUIEnabled = genUIEnabled === 'true'
@@ -287,6 +297,7 @@ export function resetSettingsToLocalDefaults(): ProfileData {
     codeExecutionEnabled: false,
     pixelateSidebarChatTitlesEnabled: true,
     piiCheckEnabled: true,
+    enterToNewlineEnabled: false,
     genUIEnabled: true,
     chatFont: 'system',
   }
@@ -517,6 +528,18 @@ export function applySettingsToLocal(settings: ProfileData): void {
     window.dispatchEvent(
       new CustomEvent('piiCheckEnabledChanged', {
         detail: { enabled: settings.piiCheckEnabled },
+      }),
+    )
+  }
+
+  if (settings.enterToNewlineEnabled !== undefined) {
+    localStorage.setItem(
+      SETTINGS_ENTER_TO_NEWLINE_ENABLED,
+      String(settings.enterToNewlineEnabled),
+    )
+    window.dispatchEvent(
+      new CustomEvent(ENTER_TO_NEWLINE_CHANGED_EVENT, {
+        detail: { enabled: settings.enterToNewlineEnabled },
       }),
     )
   }

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -84,6 +84,7 @@ export interface ProfileData {
   codeExecutionEnabled?: boolean
   pixelateSidebarChatTitlesEnabled?: boolean
   piiCheckEnabled?: boolean
+  enterToNewlineEnabled?: boolean
   genUIEnabled?: boolean
   chatFont?: 'system' | 'serif' | 'mono' | 'dyslexic'
 

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -151,6 +151,7 @@ export const ProfileDataSchema = z
     codeExecutionEnabled: z.boolean().optional(),
     pixelateSidebarChatTitlesEnabled: z.boolean().optional(),
     piiCheckEnabled: z.boolean().optional(),
+    enterToNewlineEnabled: z.boolean().optional(),
     genUIEnabled: z.boolean().optional(),
     chatFont: z.enum(['system', 'serif', 'mono', 'dyslexic']).optional(),
     version: z.number().optional(),

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -1,6 +1,7 @@
 import {
   SETTINGS_CHAT_FONT,
   SETTINGS_CODE_EXECUTION_ENABLED,
+  SETTINGS_ENTER_TO_NEWLINE_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
   SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_REASONING_EFFORT,
@@ -165,6 +166,7 @@ describe('profile-settings-serializer', () => {
     localStorage.setItem(SETTINGS_CODE_EXECUTION_ENABLED, 'true')
     localStorage.setItem(SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED, 'false')
     localStorage.setItem(SETTINGS_PII_CHECK_ENABLED, 'false')
+    localStorage.setItem(SETTINGS_ENTER_TO_NEWLINE_ENABLED, 'true')
     localStorage.setItem(SETTINGS_CHAT_FONT, 'mono')
 
     const loaded = loadLocalSettings()
@@ -179,6 +181,7 @@ describe('profile-settings-serializer', () => {
       codeExecutionEnabled: true,
       pixelateSidebarChatTitlesEnabled: false,
       piiCheckEnabled: false,
+      enterToNewlineEnabled: true,
       chatFont: 'mono',
     })
   })
@@ -232,6 +235,7 @@ describe('profile-settings-serializer', () => {
       codeExecutionEnabled: false,
       pixelateSidebarChatTitlesEnabled: true,
       piiCheckEnabled: true,
+      enterToNewlineEnabled: true,
       chatFont: 'serif',
     })
 
@@ -251,6 +255,7 @@ describe('profile-settings-serializer', () => {
       localStorage.getItem(SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED),
     ).toBe('true')
     expect(localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)).toBe('true')
+    expect(localStorage.getItem(SETTINGS_ENTER_TO_NEWLINE_ENABLED)).toBe('true')
     expect(localStorage.getItem(SETTINGS_CHAT_FONT)).toBe('serif')
   })
 


### PR DESCRIPTION
## Summary
- Adds a "Press Enter for new line" toggle in Settings → Chat → Conversation Settings (off by default). When enabled, Enter inserts a newline in the chat input instead of sending the message; sending is done via Cmd/Ctrl+Enter or the send button.
- Applies consistently to both the main chat input and the inline edit-message textarea. Shift+Enter list continuation behavior is preserved.
- The preference syncs across devices via the encrypted cloud profile, following the same pattern as existing toggles (localStorage + change events + profile serializer/merge/schema).

## Motivation
Users working on long, multi-line prompts often hit Enter intending a new line and accidentally send the message, forcing them to stop generation. This opt-in mode (similar to Venice's "enter does not submit") avoids that.

## Testing
- `npx tsc --noEmit` passes
- Full vitest suite passes (2053 tests), including updated profile settings serializer round-trip tests covering the new field

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in "Press Enter for new line" setting (off by default) in Settings → Chat → Conversation Settings so Enter inserts a newline instead of accidentally sending while composing long prompts.

**New Features**
- Applies to the main chat input and the inline edit-message textarea.
- When enabled, send with Cmd/Ctrl+Enter or the send button; Shift+Enter list continuation is preserved.
- Syncs across devices via the encrypted cloud profile, including merge handling for older clients and cross-tab updates.

<sup>Written for commit 17ff30071fad7df774cdf1608d7a8098a6be4718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

