### PR TITLE
fix: prevent Enter from sending mid-composition with IME keyboards

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -36,6 +36,7 @@ import {
 import { MacFileIcon } from './components/mac-file-icon'
 import { CONSTANTS } from './constants'
 import { useEnterToNewline } from './hooks/use-enter-to-newline'
+import { isImeComposition } from './keyboard-utils'
 import type { PromptPreset } from './prompts/types'
 import type { ProcessedDocument } from './renderers/types'
 import type { LoadingState } from './types'
@@ -959,6 +960,11 @@ export function ChatInput({
             }}
             onPaste={handlePaste}
             onKeyDown={(e) => {
+              // Enter during IME composition only confirms the conversion;
+              // it must not send the message or edit the list structure.
+              if (e.key === 'Enter' && isImeComposition(e)) {
+                return
+              }
               if (e.key === 'Tab') {
                 const textarea = e.currentTarget
                 const cursorPosition = textarea.selectionStart

--- a/src/components/chat/keyboard-utils.ts
+++ b/src/components/chat/keyboard-utils.ts
@@ -1,0 +1,15 @@
+import type { KeyboardEvent } from 'react'
+
+// Legacy keyCode reported while an IME is processing a key. Some Safari
+// builds fire the conversion-confirming Enter keydown after compositionend
+// with isComposing already false, but still report keyCode 229.
+const IME_PROCESS_KEY_CODE = 229
+
+/**
+ * True when a keydown originates from an IME composition (e.g. confirming a
+ * Japanese/Chinese/Korean conversion with Enter). Such events must not
+ * trigger actions like submitting a message.
+ */
+export function isImeComposition(e: KeyboardEvent<HTMLElement>): boolean {
+  return e.nativeEvent.isComposing || e.keyCode === IME_PROCESS_KEY_CODE
+}

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -18,6 +18,7 @@ import { RxCopy } from 'react-icons/rx'
 import { hasMessageAttachments } from '../../attachment-helpers'
 import { hasVisibleAssistantMessage } from '../../hooks/streaming/interrupted-message'
 import { useEnterToNewline } from '../../hooks/use-enter-to-newline'
+import { isImeComposition } from '../../keyboard-utils'
 import { CodeExecProcess } from '../components/CodeExecProcess'
 import { DocumentList } from '../components/DocumentList'
 import { MessageActions } from '../components/MessageActions'
@@ -596,6 +597,9 @@ const DefaultMessageComponent = ({
                     value={editContent}
                     onChange={(e) => setEditContent(e.target.value)}
                     onKeyDown={(e) => {
+                      if (e.key === 'Enter' && isImeComposition(e)) {
+                        return
+                      }
                       if (
                         e.key === 'Enter' &&
                         !e.shiftKey &&

--- a/tests/components/chat/chat-input-enter-key.test.tsx
+++ b/tests/components/chat/chat-input-enter-key.test.tsx
@@ -1,0 +1,78 @@
+import { ChatInput } from '@/components/chat/chat-input'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/project', () => ({
+  ProjectModeBanner: () => null,
+  useProject: () => ({
+    isProjectMode: false,
+    activeProject: null,
+    loadingProject: false,
+  }),
+}))
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}))
+
+vi.mock('@/components/chat/hooks/use-chat-font', () => ({
+  CHAT_FONT_CLASSES: { default: '' },
+  useChatFont: () => 'default',
+}))
+
+function renderChatInput(handleSubmit = vi.fn()) {
+  render(
+    <ChatInput
+      input="hello"
+      setInput={vi.fn()}
+      handleSubmit={handleSubmit}
+      loadingState="idle"
+      cancelGeneration={vi.fn()}
+      inputRef={createRef<HTMLTextAreaElement>()}
+      handleInputFocus={vi.fn()}
+      inputMinHeight="40px"
+      isDarkMode
+    />,
+  )
+  return { handleSubmit, textarea: screen.getByRole('textbox') }
+}
+
+describe('ChatInput Enter key handling', () => {
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('submits on plain Enter', () => {
+    const { handleSubmit, textarea } = renderChatInput()
+
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    expect(handleSubmit).toHaveBeenCalledOnce()
+  })
+
+  it('does not submit while an IME composition is active', () => {
+    const { handleSubmit, textarea } = renderChatInput()
+
+    fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true })
+
+    expect(handleSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not submit on the IME process keyCode 229', () => {
+    const { handleSubmit, textarea } = renderChatInput()
+
+    fireEvent.keyDown(textarea, { key: 'Enter', keyCode: 229 })
+
+    expect(handleSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not submit on Shift+Enter', () => {
+    const { handleSubmit, textarea } = renderChatInput()
+
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true })
+
+    expect(handleSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/chat/chat-input-enter-key.test.tsx
+++ b/tests/components/chat/chat-input-enter-key.test.tsx
@@ -16,11 +16,6 @@ vi.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: vi.fn() }),
 }))
 
-vi.mock('@/components/chat/hooks/use-chat-font', () => ({
-  CHAT_FONT_CLASSES: { default: '' },
-  useChatFont: () => 'default',
-}))
-
 function renderChatInput(handleSubmit = vi.fn()) {
   render(
     <ChatInput


### PR DESCRIPTION
## Summary
- When typing Japanese/Chinese/Korean with an IME, pressing Enter to confirm a character conversion fired the chat input's Enter handler and sent the half-composed message.
- Adds an IME guard (`isImeComposition`) checking `nativeEvent.isComposing`, plus `keyCode === 229` for Safari builds where the conversion-confirming Enter fires after `compositionend` with `isComposing` already false.
- Applied to both the main chat input and the inline edit-message textarea. This matches the behavior of Slack, ChatGPT, and Discord.

## Testing
- New tests verify Enter submits normally but not during composition (`isComposing`) or with the IME process keyCode; confirmed the composition tests fail without the fix.
- `npx tsc --noEmit` passes; full vitest suite passes (2057 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Enter from sending a message while an IME composition is active. Confirming a Japanese/Chinese/Korean conversion with Enter previously submitted the half-composed text; now it only confirms the conversion, matching Slack, ChatGPT, and Discord.

The new `isImeComposition` guard checks `nativeEvent.isComposing` and keyCode 229 to cover Safari builds where the conversion-confirming Enter fires after `compositionend`. It applies to both the main chat input and the inline edit-message textarea. Tests cover plain Enter, active composition, keyCode 229, and Shift+Enter.

<sup>Written for commit 499a4b75910f4a0d30f9b857da59f6a5a1f007ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

