### PR TITLE
fix: restore older cloud chats after toggling sync and when rows are unreadable

### DIFF
--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1,6 +1,5 @@
 import { PAGINATION } from '@/config'
 import {
-  SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED,
   UI_EXPAND_PROJECTS_ON_MOUNT,
   UI_SIDEBAR_ACTIVE_TAB,
   UI_SIDEBAR_CHAT_HISTORY_EXPANDED,
@@ -21,7 +20,7 @@ import {
   hasUserSetLocalOnlyPreference,
   isCloudSyncEnabled,
   isLocalOnlyModeEnabled,
-  setCloudSyncEnabled as setCloudSyncEnabledSetting,
+  recordCloudSyncPreference,
   setLocalOnlyModeEnabled as setLocalOnlyModeSetting,
 } from '@/utils/cloud-sync-settings'
 import { logInfo } from '@/utils/error-handling'
@@ -883,17 +882,11 @@ export function ChatSidebar({
 
       // If key exists, proceed with enabling
       setCloudSyncEnabled(true)
-      setCloudSyncEnabledSetting(true)
-
-      // Clear the explicit disable flag when re-enabling
-      localStorage.removeItem(SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED)
+      recordCloudSyncPreference(true)
     } else {
       // Disabling cloud sync
       setCloudSyncEnabled(false)
-      setCloudSyncEnabledSetting(false)
-
-      // Mark that user explicitly disabled cloud sync (to prevent auto-enable)
-      localStorage.setItem(SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED, 'true')
+      recordCloudSyncPreference(false)
 
       try {
         const deletedCount = await chatStorage.deleteAllNonLocalChats()
@@ -914,14 +907,6 @@ export function ChatSidebar({
           metadata: { error },
         })
       }
-    }
-
-    if (isClient) {
-      window.dispatchEvent(
-        new CustomEvent(CLOUD_SYNC_SETTING_CHANGED_EVENT, {
-          detail: { enabled },
-        }),
-      )
     }
   }
 

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -752,7 +752,7 @@ export function ChatSidebar({
 
     try {
       const result = await loadMorePage()
-      if (!result) return
+      if (!result || result.saved === 0) return
 
       setPendingChatsRender(true)
       try {

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -8,7 +8,6 @@ import {
 } from '@/constants/settings-events'
 import {
   SETTINGS_CHAT_FONT,
-  SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED,
   SETTINGS_ENTER_TO_NEWLINE_ENABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
@@ -72,7 +71,7 @@ import {
   CLOUD_SYNC_SETTING_CHANGED_EVENT,
   isCloudSyncEnabled,
   isLocalOnlyModeEnabled,
-  setCloudSyncEnabled,
+  recordCloudSyncPreference,
   setLocalOnlyModeEnabled,
 } from '@/utils/cloud-sync-settings'
 import { logError, logInfo, logWarning } from '@/utils/error-handling'
@@ -1111,17 +1110,11 @@ export function SettingsModal({
 
       // If key exists, proceed with enabling
       setCloudSyncEnabledState(true)
-      setCloudSyncEnabled(true)
-
-      // Clear the explicit disable flag when re-enabling
-      localStorage.removeItem(SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED)
+      recordCloudSyncPreference(true)
     } else {
       // Disabling cloud sync
       setCloudSyncEnabledState(false)
-      setCloudSyncEnabled(false)
-
-      // Mark that user explicitly disabled cloud sync (to prevent auto-enable)
-      localStorage.setItem(SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED, 'true')
+      recordCloudSyncPreference(false)
 
       try {
         const deletedCount = await chatStorage.deleteAllNonLocalChats()
@@ -1142,14 +1135,6 @@ export function SettingsModal({
           metadata: { error },
         })
       }
-    }
-
-    if (isClient) {
-      window.dispatchEvent(
-        new CustomEvent(CLOUD_SYNC_SETTING_CHANGED_EVENT, {
-          detail: { enabled },
-        }),
-      )
     }
   }
 

--- a/src/hooks/use-cloud-pagination.ts
+++ b/src/hooks/use-cloud-pagination.ts
@@ -1,5 +1,5 @@
 import { PAGINATION } from '@/config'
-import { cloudSync } from '@/services/cloud/cloud-sync'
+import { cloudSync, type ChatPageResult } from '@/services/cloud/cloud-sync'
 import {
   CLOUD_SYNC_SETTING_CHANGED_EVENT,
   isCloudSyncEnabled,
@@ -20,14 +20,7 @@ interface UseCloudPaginationReturn {
   hasAttempted: boolean
   isInitialized: boolean
   canRetryInitialization: boolean
-  loadMore: () => Promise<
-    | {
-        hasMore: boolean
-        nextToken?: string
-        saved: number
-      }
-    | undefined
-  >
+  loadMore: () => Promise<ChatPageResult | undefined>
 }
 
 export function useCloudPagination(

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -39,10 +39,15 @@ export interface IngestOptions {
   userId?: string
 }
 
+export interface IngestFailure {
+  chatId: string
+  error: unknown
+}
+
 export interface IngestResult {
   savedIds: string[]
   downloaded: number
-  errors: string[]
+  errors: IngestFailure[]
 }
 
 export async function ingestRemoteChats(
@@ -122,9 +127,7 @@ export async function ingestRemoteChats(
         result.downloaded++
       }
     } catch (error) {
-      result.errors.push(
-        `Failed to process chat ${remoteChat.id}: ${error instanceof Error ? error.message : String(error)}`,
-      )
+      result.errors.push({ chatId: remoteChat.id, error })
     }
   }
 

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -6,6 +6,7 @@
  * appears in every sync method.
  */
 
+import { logError } from '@/utils/error-handling'
 import { chatEvents, type ChatChangeReason } from '../storage/chat-events'
 import { indexedDBStorage, type ChatSyncMetadata } from '../storage/indexed-db'
 import {
@@ -127,6 +128,11 @@ export async function ingestRemoteChats(
         result.downloaded++
       }
     } catch (error) {
+      logError('Failed to ingest remote chat', error, {
+        component: 'ChatIngestion',
+        action: 'ingestRemoteChats',
+        metadata: { chatId: remoteChat.id },
+      })
       result.errors.push({ chatId: remoteChat.id, error })
     }
   }

--- a/src/services/cloud/chat-revision-sync.ts
+++ b/src/services/cloud/chat-revision-sync.ts
@@ -22,8 +22,8 @@ import {
   type RevisionEvent,
   type RevisionSnapshotItem,
 } from '@/services/sync-enclave/sync-api'
-import { ingestRemoteChats, type IngestFailure } from './chat-ingestion'
-import { cloudStorage, type PulledChatResult } from './cloud-storage'
+import { ingestRemoteChats, type RemoteChatEntry } from './chat-ingestion'
+import { cloudStorage } from './cloud-storage'
 import { isUploadableChat } from './sync-predicates'
 
 const REVISION_PAGE_LIMIT = 250
@@ -69,29 +69,51 @@ function etagToSyncVersion(etag: string | undefined): number {
   return version
 }
 
-/**
- * Revision sync must mirror the server exactly, so a row the enclave
- * could not return is fatal unless the row was deleted between the
- * event and the pull; a later delete event will reconcile that case.
- */
-function requirePulledContent(
-  results: PulledChatResult[],
-): Extract<PulledChatResult, { status: 'ok' }>[] {
-  const pulled: Extract<PulledChatResult, { status: 'ok' }>[] = []
-  for (const result of results) {
-    if (result.status === 'ok') {
-      pulled.push(result)
-    } else if (result.code !== PULL_ITEM_CODES.NotFound) {
-      throw new Error(result.code)
-    }
-  }
-  return pulled
-}
+type RemoteChatMetadata = Pick<
+  RevisionEvent,
+  'id' | 'etag' | 'project_id' | 'updated_at'
+>
 
-function ingestFailureError(failure: IngestFailure): Error {
-  return new Error(`Failed to process chat ${failure.chatId}`, {
-    cause: failure.error,
-  })
+/**
+ * Pull and store content for the given rows. Revision sync must mirror
+ * the server exactly, so a row the enclave could not return is fatal
+ * unless it was deleted between the listing and the pull; a later
+ * delete event reconciles that case.
+ */
+async function pullAndIngest(
+  rows: readonly RemoteChatMetadata[],
+  userId: string,
+  isCurrent: () => boolean,
+): Promise<number> {
+  if (rows.length === 0) return 0
+  const metadata = new Map(rows.map((row) => [row.id, row]))
+  const results = await cloudStorage.downloadChats([...metadata.keys()])
+  ensureCurrent(isCurrent)
+  const remoteChats: RemoteChatEntry[] = []
+  for (const result of results) {
+    if (result.status === 'unavailable') {
+      if (result.code === PULL_ITEM_CODES.NotFound) continue
+      throw new Error(
+        `Sync enclave could not return chat ${result.id}: ${result.code}`,
+      )
+    }
+    const row = metadata.get(result.id)!
+    remoteChats.push({
+      id: result.id,
+      content: result.content,
+      updatedAt: row.updated_at,
+      syncVersion: etagToSyncVersion(row.etag),
+      projectId: row.project_id,
+    })
+  }
+  const ingest = await ingestRemoteChats(remoteChats, { isCurrent, userId })
+  if (ingest.errors.length > 0) {
+    const [failure] = ingest.errors
+    throw new Error(`Failed to process chat ${failure.chatId}`, {
+      cause: failure.error,
+    })
+  }
+  return ingest.downloaded
 }
 
 function toRemoteState(
@@ -139,40 +161,18 @@ async function applyPulledUpserts(
   const latestById = new Map<string, RevisionEvent>()
   for (const event of events) latestById.set(event.id, event)
   const latest = [...latestById.values()]
-  const idsToPull: string[] = []
+  const toPull: RevisionEvent[] = []
   for (const event of latest) {
     if (pendingDeleteIds.has(event.id)) continue
     const local = await indexedDBStorage.getChat(event.id)
     ensureCurrent(isCurrent)
     if (local?.locallyModified) continue
     if (!local || String(local.syncVersion ?? 0) !== event.etag) {
-      idsToPull.push(event.id)
+      toPull.push(event)
     }
   }
 
-  let downloaded = 0
-  if (idsToPull.length > 0) {
-    const pulled = requirePulledContent(
-      await cloudStorage.downloadChats(idsToPull),
-    )
-    ensureCurrent(isCurrent)
-    const eventById = new Map(latest.map((event) => [event.id, event]))
-    const ingest = await ingestRemoteChats(
-      pulled.map((chat) => {
-        const event = eventById.get(chat.id)!
-        return {
-          id: chat.id,
-          content: chat.content,
-          updatedAt: event.updated_at,
-          syncVersion: etagToSyncVersion(event.etag),
-          projectId: event.project_id,
-        }
-      }),
-      { isCurrent, userId },
-    )
-    if (ingest.errors.length > 0) throw ingestFailureError(ingest.errors[0])
-    downloaded = ingest.downloaded
-  }
+  const downloaded = await pullAndIngest(toPull, userId, isCurrent)
   return {
     downloaded,
     states: latest.map((event) =>
@@ -231,28 +231,11 @@ async function bootstrapFromSnapshot(
       recentMissing.push(item)
     }
   }
-  const candidates = [...staleExisting, ...recentMissing]
-
-  let downloaded = 0
-  if (candidates.length > 0) {
-    const pulled = requirePulledContent(
-      await cloudStorage.downloadChats(candidates.map((item) => item.id)),
-    )
-    ensureCurrent(isCurrent)
-    const metadata = new Map(candidates.map((item) => [item.id, item]))
-    const ingest = await ingestRemoteChats(
-      pulled.map((chat) => ({
-        id: chat.id,
-        content: chat.content,
-        updatedAt: metadata.get(chat.id)!.updated_at,
-        syncVersion: etagToSyncVersion(metadata.get(chat.id)!.etag),
-        projectId: metadata.get(chat.id)!.project_id,
-      })),
-      { isCurrent, userId },
-    )
-    if (ingest.errors.length > 0) throw ingestFailureError(ingest.errors[0])
-    downloaded = ingest.downloaded
-  }
+  const downloaded = await pullAndIngest(
+    [...staleExisting, ...recentMissing],
+    userId,
+    isCurrent,
+  )
 
   ensureCurrent(isCurrent)
   const deletedIds = await indexedDBStorage.reconcileRevisionSnapshot(

--- a/src/services/cloud/chat-revision-sync.ts
+++ b/src/services/cloud/chat-revision-sync.ts
@@ -15,18 +15,18 @@ import {
   type StoredChat,
 } from '@/services/storage/indexed-db'
 import {
+  PULL_ITEM_CODES,
   revisionEvents,
   revisionSnapshot,
   revisionSummary,
   type RevisionEvent,
   type RevisionSnapshotItem,
 } from '@/services/sync-enclave/sync-api'
-import { ingestRemoteChats } from './chat-ingestion'
-import { cloudStorage } from './cloud-storage'
+import { ingestRemoteChats, type IngestFailure } from './chat-ingestion'
+import { cloudStorage, type PulledChatResult } from './cloud-storage'
 import { isUploadableChat } from './sync-predicates'
 
 const REVISION_PAGE_LIMIT = 250
-const CONTENT_BATCH_SIZE = 100
 export const BOOTSTRAP_RECENT_CONTENT_LIMIT = 50
 const DECIMAL_REVISION_PATTERN = /^\d+$/
 
@@ -67,6 +67,31 @@ function etagToSyncVersion(etag: string | undefined): number {
     throw new Error('Sync enclave returned an invalid chat ETag')
   }
   return version
+}
+
+/**
+ * Revision sync must mirror the server exactly, so a row the enclave
+ * could not return is fatal unless the row was deleted between the
+ * event and the pull; a later delete event will reconcile that case.
+ */
+function requirePulledContent(
+  results: PulledChatResult[],
+): Extract<PulledChatResult, { status: 'ok' }>[] {
+  const pulled: Extract<PulledChatResult, { status: 'ok' }>[] = []
+  for (const result of results) {
+    if (result.status === 'ok') {
+      pulled.push(result)
+    } else if (result.code !== PULL_ITEM_CODES.NotFound) {
+      throw new Error(result.code)
+    }
+  }
+  return pulled
+}
+
+function ingestFailureError(failure: IngestFailure): Error {
+  return new Error(`Failed to process chat ${failure.chatId}`, {
+    cause: failure.error,
+  })
 }
 
 function toRemoteState(
@@ -126,14 +151,9 @@ async function applyPulledUpserts(
   }
 
   let downloaded = 0
-  for (
-    let offset = 0;
-    offset < idsToPull.length;
-    offset += CONTENT_BATCH_SIZE
-  ) {
-    const pulled = await cloudStorage.downloadChats(
-      idsToPull.slice(offset, offset + CONTENT_BATCH_SIZE),
-      { tolerateNotFound: true },
+  if (idsToPull.length > 0) {
+    const pulled = requirePulledContent(
+      await cloudStorage.downloadChats(idsToPull),
     )
     ensureCurrent(isCurrent)
     const eventById = new Map(latest.map((event) => [event.id, event]))
@@ -141,7 +161,8 @@ async function applyPulledUpserts(
       pulled.map((chat) => {
         const event = eventById.get(chat.id)!
         return {
-          ...chat,
+          id: chat.id,
+          content: chat.content,
           updatedAt: event.updated_at,
           syncVersion: etagToSyncVersion(event.etag),
           projectId: event.project_id,
@@ -149,8 +170,8 @@ async function applyPulledUpserts(
       }),
       { isCurrent, userId },
     )
-    if (ingest.errors.length > 0) throw new Error(ingest.errors[0])
-    downloaded += ingest.downloaded
+    if (ingest.errors.length > 0) throw ingestFailureError(ingest.errors[0])
+    downloaded = ingest.downloaded
   }
   return {
     downloaded,
@@ -213,29 +234,24 @@ async function bootstrapFromSnapshot(
   const candidates = [...staleExisting, ...recentMissing]
 
   let downloaded = 0
-  for (
-    let offset = 0;
-    offset < candidates.length;
-    offset += CONTENT_BATCH_SIZE
-  ) {
-    const batch = candidates.slice(offset, offset + CONTENT_BATCH_SIZE)
-    const pulled = await cloudStorage.downloadChats(
-      batch.map((item) => item.id),
-      { tolerateNotFound: true },
+  if (candidates.length > 0) {
+    const pulled = requirePulledContent(
+      await cloudStorage.downloadChats(candidates.map((item) => item.id)),
     )
     ensureCurrent(isCurrent)
-    const metadata = new Map(batch.map((item) => [item.id, item]))
+    const metadata = new Map(candidates.map((item) => [item.id, item]))
     const ingest = await ingestRemoteChats(
       pulled.map((chat) => ({
-        ...chat,
+        id: chat.id,
+        content: chat.content,
         updatedAt: metadata.get(chat.id)!.updated_at,
         syncVersion: etagToSyncVersion(metadata.get(chat.id)!.etag),
         projectId: metadata.get(chat.id)!.project_id,
       })),
       { isCurrent, userId },
     )
-    if (ingest.errors.length > 0) throw new Error(ingest.errors[0])
-    downloaded += ingest.downloaded
+    if (ingest.errors.length > 0) throw ingestFailureError(ingest.errors[0])
+    downloaded = ingest.downloaded
   }
 
   ensureCurrent(isCurrent)

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -27,7 +27,10 @@ import {
   SyncEnclaveError,
   SyncNetworkError,
 } from '../sync-enclave/sync-enclave-client'
-import { RESTORE_DELETED_HEADERS } from '../sync-enclave/wire-contract'
+import {
+  PULL_ITEM_CODE_UNSPECIFIED,
+  RESTORE_DELETED_HEADERS,
+} from '../sync-enclave/wire-contract'
 import type { AccountOperationGuard } from './account-operation'
 import {
   CloudBackupReadError,
@@ -66,7 +69,8 @@ export interface ChatListResponse {
     id: string
     updatedAt: string
     syncVersion: number
-    projectId?: string
+    /** Authoritative server value; null means the chat is in no project. */
+    projectId: string | null
   }>
   nextContinuationToken?: string
   hasMore: boolean
@@ -163,7 +167,7 @@ function chatUpdateToMeta(update: {
     id: update.id,
     updatedAt: update.updated_at,
     syncVersion: etagToSyncVersion(update.etag) ?? 1,
-    projectId: update.project_id ?? undefined,
+    projectId: update.project_id ?? null,
   }
 }
 
@@ -185,7 +189,11 @@ function settlePulledChatBatch(
       throw new Error('Sync enclave returned an incomplete chat batch')
     }
     if (!item.ok) {
-      return { status: 'unavailable', id, code: item.code ?? 'UNKNOWN' }
+      return {
+        status: 'unavailable',
+        id,
+        code: item.code ?? PULL_ITEM_CODE_UNSPECIFIED,
+      }
     }
     const plaintext = pullItemPlaintext(item)
     if (!plaintext) {

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -17,6 +17,7 @@ import {
   listStatus as enclaveListStatus,
   pull as enclavePull,
   push as enclavePush,
+  MAX_PULL_IDS,
   newIdempotencyKey,
   pullItemPlaintext,
   revisionSnapshot,
@@ -65,12 +66,23 @@ export interface ChatListResponse {
     id: string
     updatedAt: string
     syncVersion: number
-    content?: string
     projectId?: string
   }>
   nextContinuationToken?: string
   hasMore: boolean
 }
+
+/**
+ * Per-row outcome of a batched pull. A row is `unavailable` when the
+ * enclave answered but could not hand back plaintext for it: deleted
+ * between list and pull (`NOT_FOUND`), sealed under a key this device
+ * does not hold (`UNKNOWN_KEY`), or a transient upstream failure
+ * (`NETWORK`). `code` is the enclave's structured item code so callers
+ * classify without matching on messages.
+ */
+export type PulledChatResult =
+  | { status: 'ok'; id: string; syncVersion: number; content: string }
+  | { status: 'unavailable'; id: string; code: string }
 
 export interface ProfileSyncStatus {
   exists: boolean
@@ -153,6 +165,39 @@ function chatUpdateToMeta(update: {
     syncVersion: etagToSyncVersion(update.etag) ?? 1,
     projectId: update.project_id ?? undefined,
   }
+}
+
+function settlePulledChatBatch(
+  requestedIds: readonly string[],
+  items: PullItem[],
+): PulledChatResult[] {
+  const requested = new Set(requestedIds)
+  const itemsById = new Map<string, PullItem>()
+  for (const item of items) {
+    if (!requested.has(item.id) || itemsById.has(item.id)) {
+      throw new Error('Sync enclave returned an unexpected chat batch item')
+    }
+    itemsById.set(item.id, item)
+  }
+  return requestedIds.map((id) => {
+    const item = itemsById.get(id)
+    if (!item) {
+      throw new Error('Sync enclave returned an incomplete chat batch')
+    }
+    if (!item.ok) {
+      return { status: 'unavailable', id, code: item.code ?? 'UNKNOWN' }
+    }
+    const plaintext = pullItemPlaintext(item)
+    if (!plaintext) {
+      throw new Error('Sync enclave returned empty chat content')
+    }
+    return {
+      status: 'ok',
+      id,
+      syncVersion: etagToSyncVersion(item.etag) ?? 1,
+      content: new TextDecoder().decode(plaintext),
+    }
+  })
 }
 
 // hasNextCursor guards against truthy-but-meaningless cursor values
@@ -573,43 +618,27 @@ export class CloudStorageService {
     }
   }
 
-  async downloadChats(
-    chatIds: string[],
-    options: { tolerateNotFound?: boolean } = {},
-  ): Promise<ChatListResponse['conversations']> {
+  /**
+   * Pull chat plaintext for every requested id. Requests are split into
+   * enclave-sized batches and results come back in request order, one
+   * per id. Transport and protocol failures (network error, response
+   * missing or duplicating an id, empty plaintext) reject the whole
+   * call; per-row enclave outcomes are settled into the result so one
+   * unreadable chat cannot hide its batch peers from the caller.
+   */
+  async downloadChats(chatIds: readonly string[]): Promise<PulledChatResult[]> {
     if (chatIds.length === 0) return []
     const keys = pullKey()
     if (keys.length === 0) {
       throw new Error('Cloud sync key is unavailable')
     }
-    const response = await enclavePull({ scope: 'chat', ids: chatIds, keys })
-    const conversations: ChatListResponse['conversations'] = []
-    const requestedIds = new Set(chatIds)
-    const returnedIds = new Set<string>()
-    for (const item of response.items) {
-      if (!requestedIds.has(item.id) || returnedIds.has(item.id)) {
-        throw new Error('Sync enclave returned an unexpected chat batch item')
-      }
-      returnedIds.add(item.id)
-      if (!item.ok) {
-        if (options.tolerateNotFound && item.code === 'NOT_FOUND') continue
-        throw new Error(item.code ?? 'Failed to batch-pull chat content')
-      }
-      const plaintext = pullItemPlaintext(item)
-      if (!plaintext) {
-        throw new Error('Sync enclave returned empty chat content')
-      }
-      conversations.push({
-        id: item.id,
-        updatedAt: '',
-        syncVersion: etagToSyncVersion(item.etag) ?? 1,
-        content: new TextDecoder().decode(plaintext),
-      })
+    const results: PulledChatResult[] = []
+    for (let start = 0; start < chatIds.length; start += MAX_PULL_IDS) {
+      const batch = chatIds.slice(start, start + MAX_PULL_IDS)
+      const response = await enclavePull({ scope: 'chat', ids: batch, keys })
+      results.push(...settlePulledChatBatch(batch, response.items))
     }
-    if (returnedIds.size !== requestedIds.size) {
-      throw new Error('Sync enclave returned an incomplete chat batch')
-    }
-    return conversations
+    return results
   }
 
   /**
@@ -790,7 +819,6 @@ export class CloudStorageService {
   async listChats(options?: {
     limit?: number
     continuationToken?: string
-    includeContent?: boolean
   }): Promise<ChatListResponse> {
     await this.ensureAuthReady()
     const limit = Math.min(options?.limit ?? ENCLAVE_CHAT_LIST_LIMIT, 500)
@@ -800,71 +828,10 @@ export class CloudStorageService {
       limit,
       direction: 'desc',
     })
-    const conversations = status.updates.map(chatUpdateToMeta)
-
-    if (options?.includeContent && conversations.length > 0) {
-      await this.attachInlineContent(conversations)
-    }
-
     return {
-      conversations,
+      conversations: status.updates.map(chatUpdateToMeta),
       nextContinuationToken: status.next_cursor,
       hasMore: hasNextCursor(status.next_cursor),
-    }
-  }
-
-  private async attachInlineContent(
-    conversations: ChatListResponse['conversations'],
-  ): Promise<void> {
-    const keys = pullKey()
-    if (keys.length === 0) return
-    const pulled = await enclavePull({
-      scope: 'chat',
-      ids: conversations.map((c) => c.id),
-      keys,
-    })
-    const pulledById = new Map<
-      string,
-      { content: string; syncVersion?: number }
-    >()
-    for (const item of pulled.items) {
-      if (!item.ok) {
-        // Batch pull is best-effort: surface per-item failures via
-        // structured logging and keep filling in the rest of the
-        // page. Throwing here would tear down the whole sync on the
-        // first legacy row encrypted under a key this device no
-        // longer holds, which is exactly the scenario the recovery
-        // wizard is supposed to surface. NOT_FOUND is silent because
-        // it just means the row was deleted between list and pull.
-        if (item.code !== 'NOT_FOUND') {
-          logWarning('Skipping chat the sync enclave could not return', {
-            component: 'CloudStorage',
-            action: 'attachInlineContent',
-            metadata: {
-              chatId: item.id,
-              code: item.code ?? 'unknown',
-              reason: item.reason,
-            },
-          })
-        }
-        continue
-      }
-      const plaintext = pullItemPlaintext(item)
-      if (plaintext) {
-        pulledById.set(item.id, {
-          content: new TextDecoder().decode(plaintext),
-          syncVersion: etagToSyncVersion(item.etag),
-        })
-      }
-    }
-    for (const conversation of conversations) {
-      const pulled = pulledById.get(conversation.id)
-      if (pulled) {
-        conversation.content = pulled.content
-        if (pulled.syncVersion) {
-          conversation.syncVersion = pulled.syncVersion
-        }
-      }
     }
   }
 

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -29,6 +29,7 @@ import {
 } from '../sync-enclave/sync-enclave-client'
 import {
   PULL_ITEM_CODE_UNSPECIFIED,
+  PULL_ITEM_CODES,
   RESTORE_DELETED_HEADERS,
 } from '../sync-enclave/wire-contract'
 import type { AccountOperationGuard } from './account-operation'
@@ -501,7 +502,7 @@ export class CloudStorageService {
     })
     const item = resp.items[0]
     if (!item || !item.ok) {
-      if (item && item.code === 'NOT_FOUND') return null
+      if (item && item.code === PULL_ITEM_CODES.NotFound) return null
       throw new Error(item?.code || 'Failed to pull chat from sync enclave')
     }
     const plaintext = pullItemPlaintext(item)
@@ -734,7 +735,7 @@ export class CloudStorageService {
         if (
           error instanceof SyncEnclaveError &&
           (error.status === ATTACHMENT_NOT_FOUND_STATUS ||
-            error.code === 'NOT_FOUND')
+            error.code === PULL_ITEM_CODES.NotFound)
         )
           throw new CloudBackupReadError(
             'item_unavailable',

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -1079,11 +1079,13 @@ export class CloudSyncService {
    * advances; those pages are skipped here so callers only ever see a
    * page with conversations or the end of history.
    */
-  private async listNextChatPage(options: {
-    limit: number
-    continuationToken?: string
-  }): Promise<ChatListResponse> {
-    const visitedTokens = new Set<string>()
+  private async listNextChatPage(
+    options: {
+      limit: number
+      continuationToken?: string
+    },
+    visitedTokens = new Set<string>(),
+  ): Promise<ChatListResponse> {
     let continuationToken = options.continuationToken
     for (;;) {
       if (continuationToken !== undefined) {
@@ -1139,13 +1141,17 @@ export class CloudSyncService {
       }
     }
 
+    const visitedTokens = new Set<string>()
     let nextToken = remote.nextContinuationToken
     while (nextToken) {
       const pageStartToken = nextToken
-      const page = await this.listNextChatPage({
-        limit: PAGINATION.CURSOR_SCAN_PAGE_SIZE,
-        continuationToken: pageStartToken,
-      })
+      const page = await this.listNextChatPage(
+        {
+          limit: PAGINATION.CURSOR_SCAN_PAGE_SIZE,
+          continuationToken: pageStartToken,
+        },
+        visitedTokens,
+      )
       this.ensureCurrentAccount(generation, userId)
       for (const entry of page.conversations) {
         if (deletedChatsTracker.isDeleted(entry.id)) continue

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -14,7 +14,11 @@ import {
 } from '@/services/storage/indexed-db'
 import { decideRecovery } from '@/services/sync-enclave/enclave-error-recovery'
 import { passkeyEvents } from '@/services/sync-enclave/passkey-events'
-import { keyCurrent, newIdempotencyKey } from '@/services/sync-enclave/sync-api'
+import {
+  keyCurrent,
+  newIdempotencyKey,
+  PULL_ITEM_CODES,
+} from '@/services/sync-enclave/sync-api'
 import {
   abortSyncEnclaveRequests,
   resetSyncEnclaveRequestScope,
@@ -24,11 +28,11 @@ import {
   CLOUD_SYNC_SETTING_CHANGED_EVENT,
   isCloudSyncEnabled,
 } from '@/utils/cloud-sync-settings'
-import { logError } from '@/utils/error-handling'
+import { logError, logWarning } from '@/utils/error-handling'
 import type { AccountOperationGuard } from './account-operation'
 import { hasPrimaryKey, primaryKeyIdHexOrNull } from './cek-encoding'
 import { processRemoteChat } from './chat-codec'
-import { ingestRemoteChats } from './chat-ingestion'
+import { ingestRemoteChats, type RemoteChatEntry } from './chat-ingestion'
 import {
   BOOTSTRAP_RECENT_CONTENT_LIMIT,
   drainChatRevisionSync,
@@ -97,6 +101,25 @@ export class CloudSyncLifecycleCanceledError extends Error {
 
 export interface PaginatedChatsResult {
   chats: StoredChat[]
+  hasMore: boolean
+  nextToken?: string
+}
+
+type ChatListEntry = ChatListResponse['conversations'][number]
+
+/** A listed chat whose content the enclave could not return. */
+export interface UnavailableRemoteChat {
+  id: string
+  /** Enclave pull item code, one of PULL_ITEM_CODES. */
+  code: string
+}
+
+interface ChatHydrationResult {
+  saved: number
+  unavailable: UnavailableRemoteChat[]
+}
+
+export interface ChatPageResult extends ChatHydrationResult {
   hasMore: boolean
   nextToken?: string
 }
@@ -895,7 +918,7 @@ export class CloudSyncService {
 
   private isLocalChatCurrent(
     local: StoredChat | null | undefined,
-    remote: ChatListResponse['conversations'][number],
+    remote: ChatListEntry,
     userId: string,
   ): boolean {
     return (
@@ -904,6 +927,87 @@ export class CloudSyncService {
       !local.decryptionFailed &&
       local.syncVersion === remote.syncVersion
     )
+  }
+
+  /**
+   * Pull and store content for the listed chats. Rows the enclave could
+   * not return are reported rather than thrown: a chat sealed under a
+   * key this device does not hold must not block access to the rest of
+   * the history, and the caller decides whether to surface it.
+   */
+  private async hydrateChats(
+    entries: readonly ChatListEntry[],
+    generation: number,
+    userId: string,
+  ): Promise<ChatHydrationResult> {
+    if (entries.length === 0) return { saved: 0, unavailable: [] }
+    const pulled = await cloudStorage.downloadChats(
+      entries.map((entry) => entry.id),
+    )
+    this.ensureCurrentAccount(generation, userId)
+    const metadata = new Map(entries.map((entry) => [entry.id, entry]))
+    const unavailable: UnavailableRemoteChat[] = []
+    const remoteChats: RemoteChatEntry[] = []
+    for (const result of pulled) {
+      if (result.status === 'unavailable') {
+        unavailable.push({ id: result.id, code: result.code })
+        continue
+      }
+      const entry = metadata.get(result.id)!
+      remoteChats.push({
+        id: result.id,
+        content: result.content,
+        syncVersion: result.syncVersion,
+        updatedAt: entry.updatedAt,
+        projectId: entry.projectId,
+      })
+    }
+    const ingest = await ingestRemoteChats(remoteChats, {
+      setLoadedAt: true,
+      eventReason: 'pagination',
+      isCurrent: () =>
+        this.isCurrentGeneration(generation) &&
+        this.readActiveUserId() === userId,
+      userId,
+    })
+    this.ensureCurrentAccount(generation, userId)
+    if (ingest.errors.length > 0) {
+      const [failure] = ingest.errors
+      throw new RemoteChatPageIncompleteError(
+        failure.chatId,
+        'storage',
+        failure.error,
+      )
+    }
+    if (unavailable.length > 0) this.reportUnavailableChats(unavailable)
+    return { saved: ingest.downloaded, unavailable }
+  }
+
+  /**
+   * Route unreadable rows into the sync health store the UI already
+   * renders from. A row sealed under a key this device does not hold
+   * needs the user to recover that key; a row that vanished between
+   * list and pull is a benign race and stays quiet.
+   */
+  private reportUnavailableChats(
+    unavailable: readonly UnavailableRemoteChat[],
+  ): void {
+    for (const row of unavailable) {
+      switch (row.code) {
+        case PULL_ITEM_CODES.NotFound:
+          break
+        case PULL_ITEM_CODES.UnknownKey:
+          reportKeyActionRequired('key-recovery')
+          break
+        default:
+          reportChatSyncFailed(row.id, "This chat couldn't be downloaded")
+      }
+    }
+    logWarning('Sync enclave could not return some chats', {
+      component: 'CloudSync',
+      action: 'hydrateChats',
+      metadata: { unavailable },
+    })
   }
 
   async loadChatsWithPagination(options: {
@@ -918,19 +1022,28 @@ export class CloudSyncService {
         : { chats: [], hasMore: false }
     }
     try {
-      const remote = await cloudStorage.listChats({
-        limit,
-        continuationToken,
-        includeContent: true,
-      })
+      const remote = await cloudStorage.listChats({ limit, continuationToken })
+      const entries = remote.conversations.filter(
+        (entry) => !deletedChatsTracker.isDeleted(entry.id),
+      )
+      const pulled = await cloudStorage.downloadChats(
+        entries.map((entry) => entry.id),
+      )
       const chats: StoredChat[] = []
-      for (const entry of remote.conversations) {
-        if (!entry.content || deletedChatsTracker.isDeleted(entry.id)) continue
+      for (const result of pulled) {
+        if (result.status === 'unavailable') {
+          if (result.code === PULL_ITEM_CODES.NotFound) continue
+          throw new RemoteChatPageIncompleteError(
+            result.id,
+            'missing-content',
+            result.code,
+          )
+        }
         try {
           const decoded = await processRemoteChat({
-            id: entry.id,
-            plaintext: entry.content,
-            syncVersion: entry.syncVersion,
+            id: result.id,
+            plaintext: result.content,
+            syncVersion: result.syncVersion,
             formatVersion: 2,
           })
           chats.push(decoded.chat)
@@ -938,9 +1051,9 @@ export class CloudSyncService {
           logError('Failed to decode paginated remote chat', error, {
             component: 'CloudSync',
             action: 'loadChatsWithPagination',
-            metadata: { chatId: entry.id },
+            metadata: { chatId: result.id },
           })
-          throw new RemoteChatPageIncompleteError(entry.id, 'decode', error)
+          throw new RemoteChatPageIncompleteError(result.id, 'decode', error)
         }
       }
       return {
@@ -959,6 +1072,35 @@ export class CloudSyncService {
     }
   }
 
+  /**
+   * Fetch the next metadata page that carries at least one chat. The
+   * server pages chat updates and chat deletions under one cursor, so
+   * a page may legitimately hold only deletions with a cursor that still
+   * advances; those pages are skipped here so callers only ever see a
+   * page with conversations or the end of history.
+   */
+  private async listNextChatPage(options: {
+    limit: number
+    continuationToken?: string
+  }): Promise<ChatListResponse> {
+    const visitedTokens = new Set<string>()
+    let continuationToken = options.continuationToken
+    for (;;) {
+      if (continuationToken !== undefined) {
+        if (visitedTokens.has(continuationToken)) {
+          throw new Error('Cloud pagination cursor did not advance')
+        }
+        visitedTokens.add(continuationToken)
+      }
+      const page = await cloudStorage.listChats({
+        limit: options.limit,
+        continuationToken,
+      })
+      if (page.conversations.length > 0 || !page.hasMore) return page
+      continuationToken = page.nextContinuationToken
+    }
+  }
+
   async initializeChatPaginationCursor(): Promise<{
     hasMore: boolean
     nextToken?: string
@@ -971,15 +1113,14 @@ export class CloudSyncService {
     }
     this.ensureCurrentAccount(generation, userId)
     if (!userId) throw new Error('Authenticated user ID is unavailable')
-    const remote = await cloudStorage.listChats({
+    const remote = await this.listNextChatPage({
       limit: BOOTSTRAP_RECENT_CONTENT_LIMIT,
-      includeContent: false,
     })
     this.ensureCurrentAccount(generation, userId)
     const prefix = remote.conversations.filter(
       (entry) => !deletedChatsTracker.isDeleted(entry.id),
     )
-    const missingOrStale = []
+    const missingOrStale: ChatListEntry[] = []
     for (const entry of prefix) {
       const local = await indexedDBStorage.getChat(entry.id)
       this.ensureCurrentAccount(generation, userId)
@@ -987,30 +1128,10 @@ export class CloudSyncService {
         missingOrStale.push(entry)
       }
     }
-    if (missingOrStale.length > 0) {
-      const pulled = await cloudStorage.downloadChats(
-        missingOrStale.map((entry) => entry.id),
-      )
-      this.ensureCurrentAccount(generation, userId)
-      const metadata = new Map(missingOrStale.map((entry) => [entry.id, entry]))
-      await ingestRemoteChats(
-        pulled.map((entry) => ({
-          ...entry,
-          updatedAt: metadata.get(entry.id)!.updatedAt,
-          projectId: metadata.get(entry.id)!.projectId,
-        })),
-        {
-          setLoadedAt: true,
-          eventReason: 'pagination',
-          isCurrent: () =>
-            this.isCurrentGeneration(generation) &&
-            this.readActiveUserId() === userId,
-          userId,
-        },
-      )
-      this.ensureCurrentAccount(generation, userId)
-    }
+    const hydrated = await this.hydrateChats(missingOrStale, generation, userId)
+    const unavailableIds = new Set(hydrated.unavailable.map((row) => row.id))
     for (const entry of prefix) {
+      if (unavailableIds.has(entry.id)) continue
       const local = await indexedDBStorage.getChat(entry.id)
       this.ensureCurrentAccount(generation, userId)
       if (!this.isLocalChatCurrent(local, entry, userId)) {
@@ -1019,17 +1140,11 @@ export class CloudSyncService {
     }
 
     let nextToken = remote.nextContinuationToken
-    const visitedTokens = new Set<string>()
     while (nextToken) {
-      if (visitedTokens.has(nextToken)) {
-        throw new Error('Cloud pagination cursor did not advance')
-      }
-      visitedTokens.add(nextToken)
       const pageStartToken = nextToken
-      const page = await cloudStorage.listChats({
+      const page = await this.listNextChatPage({
         limit: PAGINATION.CURSOR_SCAN_PAGE_SIZE,
         continuationToken: pageStartToken,
-        includeContent: false,
       })
       this.ensureCurrentAccount(generation, userId)
       for (const entry of page.conversations) {
@@ -1048,73 +1163,25 @@ export class CloudSyncService {
   async fetchAndStorePage(options: {
     limit: number
     continuationToken?: string
-  }): Promise<{ hasMore: boolean; nextToken?: string; saved: number }> {
+  }): Promise<ChatPageResult> {
     const generation = this.accountGeneration
     const userId = this.readActiveUserId()
     if (!(await cloudStorage.isAuthenticated())) {
       this.ensureCurrentAccount(generation, userId)
-      return { hasMore: false, saved: 0 }
+      return { hasMore: false, saved: 0, unavailable: [] }
     }
     this.ensureCurrentAccount(generation, userId)
     if (!userId) throw new Error('Authenticated user ID is unavailable')
-    const remote = await cloudStorage.listChats({
-      limit: options.limit,
-      continuationToken: options.continuationToken,
-      includeContent: true,
-    })
+    const remote = await this.listNextChatPage(options)
     this.ensureCurrentAccount(generation, userId)
-    let saved = 0
-    for (const entry of remote.conversations) {
-      if (deletedChatsTracker.isDeleted(entry.id)) continue
-      if (!entry.content) continue
-      let decoded: Awaited<ReturnType<typeof processRemoteChat>>
-      try {
-        decoded = await processRemoteChat({
-          id: entry.id,
-          plaintext: entry.content,
-          syncVersion: entry.syncVersion,
-          formatVersion: 2,
-        })
-      } catch (error) {
-        this.ensureCurrentAccount(generation, userId)
-        logError('Failed to decode paginated remote chat', error, {
-          component: 'CloudSync',
-          action: 'fetchAndStorePage',
-          metadata: { chatId: entry.id },
-        })
-        continue
-      }
-      this.ensureCurrentAccount(generation, userId)
-      try {
-        const local = await indexedDBStorage.getChat(entry.id)
-        this.ensureCurrentAccount(generation, userId)
-        const applied = await indexedDBStorage.applyRemoteChatIfFresh({
-          chat: decoded.chat,
-          syncVersion: entry.syncVersion,
-          expectedLocalUpdatedAt: local?.updatedAt ?? null,
-          setLoadedAt: true,
-          isCurrent: () =>
-            this.isCurrentGeneration(generation) &&
-            this.readActiveUserId() === userId,
-          userId,
-        })
-        this.ensureCurrentAccount(generation, userId)
-        if (applied.applied) saved++
-      } catch (error) {
-        this.ensureCurrentAccount(generation, userId)
-        logError('Failed to store paginated remote chat', error, {
-          component: 'CloudSync',
-          action: 'fetchAndStorePage',
-          metadata: { chatId: entry.id },
-        })
-        throw new RemoteChatPageIncompleteError(entry.id, 'storage', error)
-      }
-    }
-    if (saved > 0) chatEvents.emit({ reason: 'pagination', ids: [] })
+    const entries = remote.conversations.filter(
+      (entry) => !deletedChatsTracker.isDeleted(entry.id),
+    )
+    const hydrated = await this.hydrateChats(entries, generation, userId)
     return {
       hasMore: remote.hasMore,
       nextToken: remote.nextContinuationToken,
-      saved,
+      ...hydrated,
     }
   }
 

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -1746,14 +1746,30 @@ export class IndexedDBStorage {
     })
   }
 
+  /**
+   * Remove every synced chat from the local mirror. The revision
+   * checkpoint asserts that the mirror reflects every remote change up
+   * to `appliedRevision`; once the mirror is emptied that assertion is
+   * false, so the checkpoint is cleared in the same transaction and the
+   * next sync re-bootstraps from a snapshot instead of replaying only
+   * the changes made since the wipe.
+   */
   async deleteAllNonLocalChats(): Promise<number> {
     return this.enqueueSave('deleteAllNonLocalChats', async () => {
       const db = await this.ensureDB()
       return new Promise((resolve, reject) => {
         const transaction = db.transaction(
-          [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE, CHAT_SUMMARIES_STORE],
+          [
+            CHATS_STORE,
+            ATTACHMENT_PAYLOADS_STORE,
+            CHAT_SUMMARIES_STORE,
+            SYNC_STATE_STORE,
+            REMOTE_CHAT_STATE_STORE,
+          ],
           'readwrite',
         )
+        transaction.objectStore(SYNC_STATE_STORE).clear()
+        transaction.objectStore(REMOTE_CHAT_STATE_STORE).clear()
         const store = transaction.objectStore(CHATS_STORE)
         const request = store.openCursor()
         let deletedCount = 0

--- a/src/services/sync-enclave/sync-api.ts
+++ b/src/services/sync-enclave/sync-api.ts
@@ -23,6 +23,9 @@
 import { base64ToUint8Array, uint8ArrayToBase64 } from '@/utils/binary-codec'
 import { z } from 'zod'
 import { SyncEnclaveError, getSyncEnclaveClient } from './sync-enclave-client'
+import { MAX_PULL_IDS, PULL_ITEM_CODES } from './wire-contract'
+
+export { MAX_PULL_IDS, PULL_ITEM_CODES }
 
 export type Scope = 'profile' | 'chat' | 'project' | 'project_document'
 
@@ -70,13 +73,6 @@ export interface PullKey {
   key_id?: string
 }
 
-/**
- * Upper bound on `ids` per pull request, mirroring the enclave's
- * MaxPullIDs. The enclave rejects larger batches with 400; callers
- * that need more rows must issue multiple requests.
- */
-export const MAX_PULL_IDS = 100
-
 export interface PullRequest {
   scope: Scope
   ids?: string[]
@@ -90,18 +86,6 @@ export interface PullRequest {
    */
   keys: PullKey[]
 }
-
-/**
- * Per-item `code` values the enclave sets when a pull item has
- * `ok=false`; mirrors the enclave's internal/server/errors.go.
- */
-export const PULL_ITEM_CODES = {
-  NotFound: 'NOT_FOUND',
-  UnknownKey: 'UNKNOWN_KEY',
-  Network: 'NETWORK',
-  BadRequest: 'BAD_REQUEST',
-  LegacyBlobNotMigrated: 'LEGACY_BLOB_NOT_MIGRATED',
-} as const
 
 export interface PullItem {
   id: string

--- a/src/services/sync-enclave/sync-api.ts
+++ b/src/services/sync-enclave/sync-api.ts
@@ -70,6 +70,13 @@ export interface PullKey {
   key_id?: string
 }
 
+/**
+ * Upper bound on `ids` per pull request, mirroring the enclave's
+ * MaxPullIDs. The enclave rejects larger batches with 400; callers
+ * that need more rows must issue multiple requests.
+ */
+export const MAX_PULL_IDS = 100
+
 export interface PullRequest {
   scope: Scope
   ids?: string[]
@@ -84,6 +91,18 @@ export interface PullRequest {
   keys: PullKey[]
 }
 
+/**
+ * Per-item `code` values the enclave sets when a pull item has
+ * `ok=false`; mirrors the enclave's internal/server/errors.go.
+ */
+export const PULL_ITEM_CODES = {
+  NotFound: 'NOT_FOUND',
+  UnknownKey: 'UNKNOWN_KEY',
+  Network: 'NETWORK',
+  BadRequest: 'BAD_REQUEST',
+  LegacyBlobNotMigrated: 'LEGACY_BLOB_NOT_MIGRATED',
+} as const
+
 export interface PullItem {
   id: string
   ok: boolean
@@ -96,7 +115,7 @@ export interface PullItem {
   project_id_set?: boolean
   project_id?: string | null
   needs_rewrap?: boolean
-  /** Error code when `ok=false` (e.g. "NEEDS_REWRAP", "NOT_FOUND"). */
+  /** One of PULL_ITEM_CODES when `ok=false`. */
   code?: string
   reason?: string
 }

--- a/src/services/sync-enclave/wire-contract.ts
+++ b/src/services/sync-enclave/wire-contract.ts
@@ -59,9 +59,38 @@ export const WIRE_CODES = {
   ProfileSyncUpgradeRequired: 'PROFILE_SYNC_UPGRADE_REQUIRED',
 } as const
 
+/**
+ * Sync enclave pull contract; see confidential-sync
+ * internal/server/ops.go (MaxPullIDs) and errors.go (item codes).
+ */
+
+/** Upper bound on `ids` per pull request; larger batches are a 400. */
+export const MAX_PULL_IDS = 100
+
+/**
+ * Per-item `code` values the enclave sets when a pull item has
+ * `ok=false`. Every value here is emitted by the enclave's pullOne.
+ */
+export const PULL_ITEM_CODES = {
+  NotFound: 'NOT_FOUND',
+  UnknownKey: 'UNKNOWN_KEY',
+  Network: 'NETWORK',
+  BadRequest: 'BAD_REQUEST',
+  LegacyBlobNotMigrated: 'LEGACY_BLOB_NOT_MIGRATED',
+} as const
+
+/**
+ * Stand-in used when an `ok=false` item arrives without a code, so
+ * downstream classification never has to handle `undefined`.
+ */
+export const PULL_ITEM_CODE_UNSPECIFIED = 'UNSPECIFIED'
+
 export type SyncHeaderName = (typeof SYNC_HEADERS)[keyof typeof SYNC_HEADERS]
 export type RestoreDeletedHeaderName =
   (typeof RESTORE_DELETED_HEADERS)[keyof typeof RESTORE_DELETED_HEADERS]
 export type IfMatchSentinel =
   (typeof IF_MATCH_SENTINELS)[keyof typeof IF_MATCH_SENTINELS]
 export type WireCode = (typeof WIRE_CODES)[keyof typeof WIRE_CODES]
+export type PullItemCode =
+  | (typeof PULL_ITEM_CODES)[keyof typeof PULL_ITEM_CODES]
+  | typeof PULL_ITEM_CODE_UNSPECIFIED

--- a/src/utils/cloud-sync-settings.ts
+++ b/src/utils/cloud-sync-settings.ts
@@ -1,9 +1,29 @@
 import {
   SETTINGS_CLOUD_SYNC_ENABLED,
+  SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED,
   SETTINGS_LOCAL_ONLY_MODE_ENABLED,
 } from '@/constants/storage-keys'
 
 export const CLOUD_SYNC_SETTING_CHANGED_EVENT = 'cloudSyncSettingChanged'
+
+/**
+ * Record a user's explicit choice to turn cloud sync on or off. The
+ * explicit-disable marker stops the sign-in path from auto-enabling
+ * sync for an account that has an encryption key but opted out.
+ */
+export function recordCloudSyncPreference(enabled: boolean): void {
+  if (typeof window === 'undefined') return
+  try {
+    if (enabled) {
+      localStorage.removeItem(SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED)
+    } else {
+      localStorage.setItem(SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED, 'true')
+    }
+  } catch {
+    // Storage unavailable (e.g., Safari private mode) - silently fail
+  }
+  setCloudSyncEnabled(enabled)
+}
 
 export function isCloudSyncEnabled(): boolean {
   if (typeof window === 'undefined') return false

--- a/tests/services/cloud/chat-revision-sync.test.ts
+++ b/tests/services/cloud/chat-revision-sync.test.ts
@@ -58,7 +58,10 @@ vi.mock('@/services/storage/indexed-db', () => ({
   },
 }))
 
-vi.mock('@/services/sync-enclave/sync-api', () => ({
+vi.mock('@/services/sync-enclave/sync-api', async () => ({
+  ...(await vi.importActual<typeof import('@/services/sync-enclave/sync-api')>(
+    '@/services/sync-enclave/sync-api',
+  )),
   revisionSummary,
   revisionEvents,
   revisionSnapshot,
@@ -256,12 +259,7 @@ describe('chat revision synchronization', () => {
     })
     getChat.mockResolvedValue(null)
     downloadChats.mockResolvedValue([
-      {
-        id: 'remote-chat',
-        updatedAt: '',
-        syncVersion: 4,
-        content: '{}',
-      },
+      { status: 'ok', id: 'remote-chat', syncVersion: 4, content: '{}' },
     ])
     ingestRemoteChats.mockResolvedValue({
       savedIds: ['remote-chat'],
@@ -486,7 +484,7 @@ describe('chat revision synchronization', () => {
         : null,
     )
     downloadChats.mockImplementation(async (ids: string[]) =>
-      ids.map((id) => ({ id, content: '{}', syncVersion: 2, updatedAt: '' })),
+      ids.map((id) => ({ status: 'ok', id, content: '{}', syncVersion: 2 })),
     )
 
     await drainChatRevisionSync(adapter, userId)
@@ -523,14 +521,42 @@ describe('chat revision synchronization', () => {
       locallyModified: false,
     })
     downloadChats.mockResolvedValue([
-      { id: 'failed-chat', content: '{}', syncVersion: 4, updatedAt: '' },
+      { status: 'ok', id: 'failed-chat', content: '{}', syncVersion: 4 },
     ])
 
     await drainChatRevisionSync(adapter, userId)
 
-    expect(downloadChats).toHaveBeenCalledWith(['failed-chat'], {
-      tolerateNotFound: true,
+    expect(downloadChats).toHaveBeenCalledWith(['failed-chat'])
+  })
+
+  it('refuses to advance the checkpoint past a row it cannot read', async () => {
+    getSyncState.mockResolvedValue(null)
+    revisionSummary.mockResolvedValue({
+      current_revision: '10',
+      oldest_replayable_revision: '1',
     })
+    revisionSnapshot.mockResolvedValue({
+      snapshot_revision: '10',
+      items: [
+        {
+          id: 'locked-chat',
+          etag: '4',
+          key_id: 'other-key',
+          project_id: null,
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+    })
+    getChat.mockResolvedValue(null)
+    downloadChats.mockResolvedValue([
+      { status: 'unavailable', id: 'locked-chat', code: 'UNKNOWN_KEY' },
+    ])
+
+    await expect(drainChatRevisionSync(adapter, userId)).rejects.toThrow(
+      'UNKNOWN_KEY',
+    )
+    expect(ingestRemoteChats).not.toHaveBeenCalled()
+    expect(reconcileRevisionSnapshot).not.toHaveBeenCalled()
   })
 
   it('does not pull content for a dirty event row', async () => {
@@ -594,13 +620,13 @@ describe('chat revision synchronization', () => {
       ],
     })
     getChat.mockResolvedValue(null)
-    downloadChats.mockResolvedValue([])
+    downloadChats.mockResolvedValue([
+      { status: 'unavailable', id: 'gone-chat', code: 'NOT_FOUND' },
+    ])
 
     await drainChatRevisionSync(adapter, userId)
 
-    expect(downloadChats).toHaveBeenCalledWith(['gone-chat'], {
-      tolerateNotFound: true,
-    })
+    expect(downloadChats).toHaveBeenCalledWith(['gone-chat'])
     expect(applyRemoteDeletion).toHaveBeenCalledWith(
       'gone-chat',
       userId,

--- a/tests/services/cloud/cloud-storage.test.ts
+++ b/tests/services/cloud/cloud-storage.test.ts
@@ -5,6 +5,7 @@ import {
   CloudStorageService,
 } from '@/services/cloud/cloud-storage'
 import { SyncEnclaveError, SyncNetworkError } from '@/services/sync-enclave'
+import { MAX_PULL_IDS } from '@/services/sync-enclave/sync-api'
 import { EncryptedAttachmentValidationError } from '@/utils/binary-codec'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -118,41 +119,86 @@ describe('CloudStorageService auth readiness', () => {
     vi.unstubAllGlobals()
   })
 
-  it('tolerates only structured not-found items in revision content batches', async () => {
+  it('settles each pulled chat in request order without hiding batch peers', async () => {
     mockEnclavePull.mockResolvedValue({
       items: [
-        { id: 'gone', ok: false, code: 'NOT_FOUND' },
         {
           id: 'present',
           ok: true,
           etag: '2',
           plaintext: btoa('{"title":"Present"}'),
         },
+        { id: 'gone', ok: false, code: 'NOT_FOUND' },
+        { id: 'locked', ok: false, code: 'UNKNOWN_KEY' },
       ],
     })
 
     await expect(
-      new CloudStorageService().downloadChats(['gone', 'present'], {
-        tolerateNotFound: true,
-      }),
+      new CloudStorageService().downloadChats(['gone', 'present', 'locked']),
     ).resolves.toEqual([
-      expect.objectContaining({ id: 'present', syncVersion: 2 }),
+      { status: 'unavailable', id: 'gone', code: 'NOT_FOUND' },
+      {
+        status: 'ok',
+        id: 'present',
+        syncVersion: 2,
+        content: '{"title":"Present"}',
+      },
+      { status: 'unavailable', id: 'locked', code: 'UNKNOWN_KEY' },
     ])
   })
 
-  it('rejects non-not-found and incomplete revision content batches', async () => {
+  it('rejects incomplete, unexpected, and empty chat batches', async () => {
     const storage = new CloudStorageService()
-    mockEnclavePull.mockResolvedValueOnce({
-      items: [{ id: 'chat-1', ok: false, code: 'NEEDS_REWRAP' }],
-    })
-    await expect(
-      storage.downloadChats(['chat-1'], { tolerateNotFound: true }),
-    ).rejects.toThrow('NEEDS_REWRAP')
-
     mockEnclavePull.mockResolvedValueOnce({ items: [] })
-    await expect(
-      storage.downloadChats(['chat-1'], { tolerateNotFound: true }),
-    ).rejects.toThrow('incomplete chat batch')
+    await expect(storage.downloadChats(['chat-1'])).rejects.toThrow(
+      'incomplete chat batch',
+    )
+
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [
+        { id: 'chat-1', ok: true, etag: '1', plaintext: btoa('{}') },
+        { id: 'chat-1', ok: true, etag: '1', plaintext: btoa('{}') },
+      ],
+    })
+    await expect(storage.downloadChats(['chat-1'])).rejects.toThrow(
+      'unexpected chat batch item',
+    )
+
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [
+        { id: 'chat-1', ok: true, etag: '1', plaintext: btoa('{}') },
+        { id: 'chat-2', ok: true, etag: '1', plaintext: btoa('{}') },
+      ],
+    })
+    await expect(storage.downloadChats(['chat-1'])).rejects.toThrow(
+      'unexpected chat batch item',
+    )
+
+    mockEnclavePull.mockResolvedValueOnce({
+      items: [{ id: 'chat-1', ok: true, etag: '1' }],
+    })
+    await expect(storage.downloadChats(['chat-1'])).rejects.toThrow(
+      'empty chat content',
+    )
+  })
+
+  it('splits large downloads into enclave-sized pull requests', async () => {
+    const ids = Array.from({ length: MAX_PULL_IDS + 1 }, (_, i) => `chat-${i}`)
+    mockEnclavePull.mockImplementation(async ({ ids: batch }) => ({
+      items: batch.map((id: string) => ({
+        id,
+        ok: true,
+        etag: '1',
+        plaintext: btoa('{}'),
+      })),
+    }))
+
+    const results = await new CloudStorageService().downloadChats(ids)
+
+    expect(results.map((result) => result.id)).toEqual(ids)
+    expect(mockEnclavePull).toHaveBeenCalledTimes(2)
+    expect(mockEnclavePull.mock.calls[0][0].ids).toHaveLength(MAX_PULL_IDS)
+    expect(mockEnclavePull.mock.calls[1][0].ids).toEqual([ids[MAX_PULL_IDS]])
   })
 
   it('preserves structured backup attachment failures instead of swallowing them', async () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -28,6 +28,7 @@ const {
   getAllChats,
   deleteStoredChat,
   clearRevisionCheckpoint,
+  reportKeyActionRequired,
 } = vi.hoisted(() => ({
   drainChatRevisionSync: vi.fn(),
   isAuthenticated: vi.fn(),
@@ -45,6 +46,7 @@ const {
   getAllChats: vi.fn(),
   deleteStoredChat: vi.fn(),
   clearRevisionCheckpoint: vi.fn(),
+  reportKeyActionRequired: vi.fn(),
 }))
 
 vi.mock('@/services/cloud/chat-revision-sync', () => ({
@@ -95,12 +97,13 @@ vi.mock('@/services/cloud/streaming-tracker', () => ({
 vi.mock('@/services/cloud/sync-health', () => ({
   reportChatSynced: vi.fn(),
   reportChatSyncFailed: vi.fn(),
-  reportKeyActionRequired: vi.fn(),
+  reportKeyActionRequired,
   reportSyncPaused: vi.fn(),
 }))
 vi.mock('@/utils/error-handling', () => ({
   logError: vi.fn(),
   logInfo: vi.fn(),
+  logWarning: vi.fn(),
 }))
 
 describe('CloudSyncService revision coordinator routing', () => {
@@ -390,9 +393,12 @@ describe('CloudSyncService revision coordinator routing', () => {
 
   it('prevents a pagination write after the active account changes', async () => {
     listChats.mockResolvedValue({
-      conversations: [{ id: 'chat-1', content: '{}', syncVersion: 1 }],
+      conversations: [{ id: 'chat-1', syncVersion: 1, updatedAt: '' }],
       hasMore: false,
     })
+    downloadChats.mockResolvedValue([
+      { status: 'ok', id: 'chat-1', syncVersion: 1, content: '{}' },
+    ])
     processRemoteChat.mockImplementationOnce(async () => {
       localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user-2')
       return { chat: { id: 'chat-1', messages: [] } }
@@ -440,7 +446,7 @@ describe('CloudSyncService revision coordinator routing', () => {
     ).resolves.toEqual({ hasMore: true, nextToken: 'page-2' })
     expect(listChats).toHaveBeenCalledWith({
       limit: 50,
-      includeContent: false,
+      continuationToken: undefined,
     })
     expect(downloadChats).not.toHaveBeenCalled()
     expect(processRemoteChat).not.toHaveBeenCalled()
@@ -488,8 +494,8 @@ describe('CloudSyncService revision coordinator routing', () => {
         hasMore: false,
       })
     downloadChats.mockResolvedValue([
-      { ...metadata[1], content: '{"id":"missing-chat"}' },
-      { ...metadata[2], content: '{"id":"stale-chat"}' },
+      { status: 'ok', ...metadata[1], content: '{"id":"missing-chat"}' },
+      { status: 'ok', ...metadata[2], content: '{"id":"stale-chat"}' },
     ])
     getChat.mockImplementation(async (id: string) => localChats.get(id))
     processRemoteChat.mockImplementation(async ({ id, syncVersion }) => ({
@@ -547,9 +553,12 @@ describe('CloudSyncService revision coordinator routing', () => {
         hasMore: false,
       })
       .mockResolvedValueOnce({
-        conversations: [{ ...unseen, content: '{}' }],
+        conversations: [unseen],
         hasMore: false,
       })
+    downloadChats.mockResolvedValue([
+      { status: 'ok', ...unseen, content: '{}' },
+    ])
     getChat.mockImplementation(async (id: string) => cachedChats.get(id))
     processRemoteChat.mockResolvedValue({
       chat: { ...unseen, syncUserId: 'user-1', messages: [] },
@@ -560,26 +569,76 @@ describe('CloudSyncService revision coordinator routing', () => {
       hasMore: true,
       nextToken: 'unseen-page',
     })
-    await service.fetchAndStorePage({
-      limit: 20,
-      continuationToken: 'unseen-page',
+    await expect(
+      service.fetchAndStorePage({
+        limit: 20,
+        continuationToken: 'unseen-page',
+      }),
+    ).resolves.toEqual({
+      hasMore: false,
+      nextToken: undefined,
+      saved: 1,
+      unavailable: [],
     })
 
-    expect(downloadChats).not.toHaveBeenCalled()
+    expect(downloadChats).toHaveBeenCalledTimes(1)
+    expect(downloadChats).toHaveBeenCalledWith([unseen.id])
     expect(listChats).toHaveBeenNthCalledWith(2, {
       limit: PAGINATION.CURSOR_SCAN_PAGE_SIZE,
       continuationToken: 'cached-page',
-      includeContent: false,
     })
     expect(listChats).toHaveBeenNthCalledWith(3, {
       limit: PAGINATION.CURSOR_SCAN_PAGE_SIZE,
       continuationToken: 'unseen-page',
-      includeContent: false,
     })
     expect(listChats).toHaveBeenNthCalledWith(4, {
       limit: 20,
       continuationToken: 'unseen-page',
-      includeContent: true,
+    })
+  })
+
+  it('skips metadata pages that carry only deletions', async () => {
+    const chat = {
+      id: 'older-chat',
+      syncVersion: 3,
+      updatedAt: '2026-01-01T00:00:00Z',
+    }
+    listChats
+      .mockResolvedValueOnce({
+        conversations: [],
+        hasMore: true,
+        nextContinuationToken: 'tombstones-2',
+      })
+      .mockResolvedValueOnce({
+        conversations: [],
+        hasMore: true,
+        nextContinuationToken: 'tombstones-3',
+      })
+      .mockResolvedValueOnce({
+        conversations: [chat],
+        hasMore: false,
+      })
+    downloadChats.mockResolvedValue([{ status: 'ok', ...chat, content: '{}' }])
+    processRemoteChat.mockResolvedValue({
+      chat: { ...chat, syncUserId: 'user-1', messages: [] },
+    })
+    getChat.mockResolvedValue(undefined)
+
+    await expect(
+      new CloudSyncService().fetchAndStorePage({
+        limit: 20,
+        continuationToken: 'tombstones-1',
+      }),
+    ).resolves.toEqual({
+      hasMore: false,
+      nextToken: undefined,
+      saved: 1,
+      unavailable: [],
+    })
+    expect(listChats).toHaveBeenCalledTimes(3)
+    expect(listChats).toHaveBeenNthCalledWith(3, {
+      limit: 20,
+      continuationToken: 'tombstones-3',
     })
   })
 
@@ -591,26 +650,19 @@ describe('CloudSyncService revision coordinator routing', () => {
         updatedAt: '2026-01-01T00:00:00Z',
       },
     ]
-    const cachedPage = [
-      {
-        id: 'cached-chat',
-        syncVersion: 2,
-        updatedAt: '2025-12-31T00:00:00Z',
-      },
-    ]
     listChats
       .mockResolvedValueOnce({
         conversations: boundary,
         hasMore: true,
         nextContinuationToken: 'repeated-page',
       })
-      .mockResolvedValueOnce({
-        conversations: cachedPage,
+      .mockResolvedValue({
+        conversations: [],
         hasMore: true,
         nextContinuationToken: 'repeated-page',
       })
-    getChat.mockImplementation(async (id: string) => ({
-      ...(id === 'boundary-chat' ? boundary[0] : cachedPage[0]),
+    getChat.mockImplementation(async () => ({
+      ...boundary[0],
       syncUserId: 'user-1',
       messages: [],
     }))
@@ -635,12 +687,7 @@ describe('CloudSyncService revision coordinator routing', () => {
     })
     getChat.mockResolvedValue(undefined)
     downloadChats.mockResolvedValue([
-      {
-        id: 'new-boundary-chat',
-        syncVersion: 2,
-        updatedAt: '',
-        content: '{}',
-      },
+      { status: 'ok', id: 'new-boundary-chat', syncVersion: 2, content: '{}' },
     ])
     processRemoteChat.mockResolvedValue({
       chat: { id: 'new-boundary-chat', syncVersion: 2, messages: [] },
@@ -671,61 +718,102 @@ describe('CloudSyncService revision coordinator routing', () => {
     ).rejects.toThrow('Cloud account changed during synchronization')
   })
 
-  it('skips unavailable rows and continues into later history', async () => {
+  it('keeps paginating past chats the enclave cannot return', async () => {
+    listChats.mockResolvedValue({
+      conversations: [
+        {
+          id: 'gone-chat',
+          syncVersion: 1,
+          updatedAt: '2026-01-03T00:00:00Z',
+        },
+        {
+          id: 'locked-chat',
+          syncVersion: 2,
+          updatedAt: '2026-01-02T00:00:00Z',
+        },
+        {
+          id: 'readable-chat',
+          syncVersion: 3,
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ],
+      hasMore: true,
+      nextContinuationToken: 'page-3',
+    })
+    downloadChats.mockResolvedValue([
+      { status: 'unavailable', id: 'gone-chat', code: 'NOT_FOUND' },
+      { status: 'unavailable', id: 'locked-chat', code: 'UNKNOWN_KEY' },
+      { status: 'ok', id: 'readable-chat', syncVersion: 3, content: '{}' },
+    ])
+    processRemoteChat.mockResolvedValue({
+      chat: { id: 'readable-chat', syncVersion: 3, messages: [] },
+    })
+    getChat.mockResolvedValue(undefined)
+
+    await expect(
+      new CloudSyncService().fetchAndStorePage({
+        limit: 20,
+        continuationToken: 'page-2',
+      }),
+    ).resolves.toEqual({
+      hasMore: true,
+      nextToken: 'page-3',
+      saved: 1,
+      unavailable: [
+        { id: 'gone-chat', code: 'NOT_FOUND' },
+        { id: 'locked-chat', code: 'UNKNOWN_KEY' },
+      ],
+    })
+    expect(applyRemoteChatIfFresh).toHaveBeenCalledOnce()
+    expect(reportKeyActionRequired).toHaveBeenCalledWith('key-recovery')
+  })
+
+  it('does not block the boundary on a chat the enclave cannot return', async () => {
+    const readable = {
+      id: 'readable-chat',
+      syncVersion: 1,
+      updatedAt: '2026-01-02T00:00:00Z',
+    }
     listChats
       .mockResolvedValueOnce({
         conversations: [
+          readable,
           {
-            id: 'missing-chat',
-            syncVersion: 1,
-            updatedAt: '2026-01-03T00:00:00Z',
-          },
-          {
-            id: 'invalid-chat',
+            id: 'locked-chat',
             syncVersion: 2,
-            updatedAt: '2026-01-02T00:00:00Z',
-            content: 'invalid',
+            updatedAt: '2026-01-01T00:00:00Z',
           },
         ],
         hasMore: true,
-        nextContinuationToken: 'page-3',
+        nextContinuationToken: 'page-2',
       })
       .mockResolvedValueOnce({
         conversations: [
           {
-            id: 'older-chat',
+            id: 'uncached-chat',
             syncVersion: 3,
-            updatedAt: '2026-01-01T00:00:00Z',
-            content: '{}',
+            updatedAt: '2025-12-31T00:00:00Z',
           },
         ],
         hasMore: false,
       })
-    processRemoteChat
-      .mockRejectedValueOnce(new Error('invalid ciphertext'))
-      .mockResolvedValueOnce({
-        chat: { id: 'older-chat', syncVersion: 3, messages: [] },
-      })
-    getChat.mockResolvedValue(undefined)
+    const localChats = new Map<string, Record<string, unknown>>()
+    getChat.mockImplementation(async (id: string) => localChats.get(id))
+    downloadChats.mockResolvedValue([
+      { status: 'ok', ...readable, content: '{}' },
+      { status: 'unavailable', id: 'locked-chat', code: 'UNKNOWN_KEY' },
+    ])
+    processRemoteChat.mockResolvedValue({
+      chat: { ...readable, syncUserId: 'user-1', messages: [] },
+    })
+    applyRemoteChatIfFresh.mockImplementation(async ({ chat }) => {
+      localChats.set(chat.id, chat)
+      return { applied: true }
+    })
 
-    const service = new CloudSyncService()
     await expect(
-      service.fetchAndStorePage({ limit: 20, continuationToken: 'page-2' }),
-    ).resolves.toEqual({ hasMore: true, nextToken: 'page-3', saved: 0 })
-    await expect(
-      service.fetchAndStorePage({ limit: 20, continuationToken: 'page-3' }),
-    ).resolves.toEqual({ hasMore: false, nextToken: undefined, saved: 1 })
-    expect(listChats).toHaveBeenNthCalledWith(1, {
-      limit: 20,
-      continuationToken: 'page-2',
-      includeContent: true,
-    })
-    expect(listChats).toHaveBeenNthCalledWith(2, {
-      limit: 20,
-      continuationToken: 'page-3',
-      includeContent: true,
-    })
-    expect(applyRemoteChatIfFresh).toHaveBeenCalledOnce()
+      new CloudSyncService().initializeChatPaginationCursor(),
+    ).resolves.toEqual({ hasMore: true, nextToken: 'page-2' })
   })
 
   it('retains the page cursor for retry when storage fails', async () => {
@@ -735,11 +823,13 @@ describe('CloudSyncService revision coordinator routing', () => {
           id: 'chat-1',
           syncVersion: 2,
           updatedAt: '2026-01-01T00:00:00Z',
-          content: '{}',
         },
       ],
       hasMore: false,
     })
+    downloadChats.mockResolvedValue([
+      { status: 'ok', id: 'chat-1', syncVersion: 2, content: '{}' },
+    ])
     processRemoteChat.mockResolvedValue({
       chat: { id: 'chat-1', syncVersion: 2, messages: [] },
     })
@@ -764,24 +854,27 @@ describe('CloudSyncService revision coordinator routing', () => {
         limit: 20,
         continuationToken: 'page-2',
       }),
-    ).resolves.toEqual({ hasMore: false, nextToken: undefined, saved: 1 })
-    expect(listChats).toHaveBeenNthCalledWith(1, {
-      limit: 20,
-      continuationToken: 'page-2',
-      includeContent: true,
+    ).resolves.toEqual({
+      hasMore: false,
+      nextToken: undefined,
+      saved: 1,
+      unavailable: [],
     })
+    expect(listChats).toHaveBeenCalledTimes(2)
     expect(listChats).toHaveBeenNthCalledWith(2, {
       limit: 20,
       continuationToken: 'page-2',
-      includeContent: true,
     })
   })
 
   it('rejects an incomplete export page instead of falling back locally', async () => {
     listChats.mockResolvedValue({
-      conversations: [{ id: 'corrupt-chat', content: '{}', syncVersion: 1 }],
+      conversations: [{ id: 'corrupt-chat', syncVersion: 1, updatedAt: '' }],
       hasMore: false,
     })
+    downloadChats.mockResolvedValue([
+      { status: 'ok', id: 'corrupt-chat', syncVersion: 1, content: '{}' },
+    ])
     processRemoteChat.mockRejectedValueOnce(new Error('invalid ciphertext'))
 
     await expect(

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -602,6 +602,7 @@ describe('CloudSyncService revision coordinator routing', () => {
       id: 'older-chat',
       syncVersion: 3,
       updatedAt: '2026-01-01T00:00:00Z',
+      projectId: null,
     }
     listChats
       .mockResolvedValueOnce({
@@ -640,6 +641,10 @@ describe('CloudSyncService revision coordinator routing', () => {
       limit: 20,
       continuationToken: 'tombstones-3',
     })
+    expect(processRemoteChat).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'older-chat' }),
+      expect.objectContaining({ projectId: null }),
+    )
   })
 
   it('rejects a non-advancing metadata cursor', async () => {
@@ -671,6 +676,40 @@ describe('CloudSyncService revision coordinator routing', () => {
       new CloudSyncService().initializeChatPaginationCursor(),
     ).rejects.toThrow('Cloud pagination cursor did not advance')
     expect(listChats).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects a cursor cycle that spans cached metadata pages', async () => {
+    const cached = new Map<string, Record<string, unknown>>()
+    const page = (id: string) => ({
+      id,
+      syncVersion: 1,
+      updatedAt: '2026-01-01T00:00:00Z',
+    })
+    for (const id of ['boundary-chat', 'cached-a', 'cached-b']) {
+      cached.set(id, { ...page(id), syncUserId: 'user-1', messages: [] })
+    }
+    listChats
+      .mockResolvedValueOnce({
+        conversations: [page('boundary-chat')],
+        hasMore: true,
+        nextContinuationToken: 'page-a',
+      })
+      .mockResolvedValueOnce({
+        conversations: [page('cached-a')],
+        hasMore: true,
+        nextContinuationToken: 'page-b',
+      })
+      .mockResolvedValueOnce({
+        conversations: [page('cached-b')],
+        hasMore: true,
+        nextContinuationToken: 'page-a',
+      })
+    getChat.mockImplementation(async (id: string) => cached.get(id))
+
+    await expect(
+      new CloudSyncService().initializeChatPaginationCursor(),
+    ).rejects.toThrow('Cloud pagination cursor did not advance')
+    expect(listChats).toHaveBeenCalledTimes(3)
   })
 
   it('withholds a cursor when a boundary mutation is not fully stored', async () => {

--- a/tests/services/storage/indexed-db-sync-v2.test.ts
+++ b/tests/services/storage/indexed-db-sync-v2.test.ts
@@ -558,6 +558,34 @@ describe('IndexedDB sync protocol v2 migration', () => {
     await expect(storage.getSyncState('user-2')).resolves.toBeNull()
   })
 
+  it('invalidates the revision checkpoint when synced chats are wiped locally', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat({
+      id: 'synced-chat',
+      title: 'Synced',
+      messages: [{ role: 'user', content: 'hello' } as any],
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    })
+    await storage.markAsSynced('synced-chat', 1)
+    await storage.saveChat({
+      id: 'local-chat',
+      title: 'Local',
+      messages: [{ role: 'user', content: 'hello' } as any],
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      isLocalOnly: true,
+    })
+    await storage.commitRevisionBatch([], '7', 'user-1')
+
+    await expect(storage.deleteAllNonLocalChats()).resolves.toBe(1)
+
+    await expect(storage.getChat('synced-chat')).resolves.toBeNull()
+    await expect(storage.getChat('local-chat')).resolves.not.toBeNull()
+    await expect(storage.getSyncState('user-1')).resolves.toBeNull()
+  })
+
   it('preserves other-account delete intents across checkpoint resets', async () => {
     const storage = new IndexedDBStorage()
     await storage.initialize()

--- a/tests/services/sync-enclave/wire-contract.test.ts
+++ b/tests/services/sync-enclave/wire-contract.test.ts
@@ -10,6 +10,7 @@
 import {
   IF_MATCH_SENTINELS,
   MAX_PULL_IDS,
+  PULL_ITEM_CODE_UNSPECIFIED,
   PULL_ITEM_CODES,
   RESTORE_DELETED_HEADERS,
   SYNC_HEADERS,
@@ -74,5 +75,6 @@ describe('wire-contract', () => {
       BadRequest: 'BAD_REQUEST',
       LegacyBlobNotMigrated: 'LEGACY_BLOB_NOT_MIGRATED',
     })
+    expect(PULL_ITEM_CODE_UNSPECIFIED).toBe('UNSPECIFIED')
   })
 })

--- a/tests/services/sync-enclave/wire-contract.test.ts
+++ b/tests/services/sync-enclave/wire-contract.test.ts
@@ -9,6 +9,8 @@
  */
 import {
   IF_MATCH_SENTINELS,
+  MAX_PULL_IDS,
+  PULL_ITEM_CODES,
   RESTORE_DELETED_HEADERS,
   SYNC_HEADERS,
   SYNC_PROTOCOL_VERSION,
@@ -60,6 +62,17 @@ describe('wire-contract', () => {
       ExistingDataUnderOtherKey: 'EXISTING_DATA_UNDER_OTHER_KEY',
       SyncConflict: 'SYNC_CONFLICT',
       ProfileSyncUpgradeRequired: 'PROFILE_SYNC_UPGRADE_REQUIRED',
+    })
+  })
+
+  it('pull contract matches confidential-sync internal/server', () => {
+    expect(MAX_PULL_IDS).toBe(100)
+    expect(PULL_ITEM_CODES).toEqual({
+      NotFound: 'NOT_FOUND',
+      UnknownKey: 'UNKNOWN_KEY',
+      Network: 'NETWORK',
+      BadRequest: 'BAD_REQUEST',
+      LegacyBlobNotMigrated: 'LEGACY_BLOB_NOT_MIGRATED',
     })
   })
 })

--- a/tests/utils/cloud-sync-settings.test.ts
+++ b/tests/utils/cloud-sync-settings.test.ts
@@ -1,0 +1,41 @@
+import {
+  SETTINGS_CLOUD_SYNC_ENABLED,
+  SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED,
+} from '@/constants/storage-keys'
+import {
+  CLOUD_SYNC_SETTING_CHANGED_EVENT,
+  isCloudSyncEnabled,
+  recordCloudSyncPreference,
+} from '@/utils/cloud-sync-settings'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('recordCloudSyncPreference', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('marks an explicit opt-out so sign-in does not auto-enable sync', () => {
+    const listener = vi.fn()
+    window.addEventListener(CLOUD_SYNC_SETTING_CHANGED_EVENT, listener)
+
+    recordCloudSyncPreference(false)
+
+    expect(isCloudSyncEnabled()).toBe(false)
+    expect(localStorage.getItem(SETTINGS_CLOUD_SYNC_ENABLED)).toBe('false')
+    expect(localStorage.getItem(SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED)).toBe(
+      'true',
+    )
+    expect(listener).toHaveBeenCalledTimes(1)
+    window.removeEventListener(CLOUD_SYNC_SETTING_CHANGED_EVENT, listener)
+  })
+
+  it('clears the opt-out marker when sync is turned back on', () => {
+    recordCloudSyncPreference(false)
+    recordCloudSyncPreference(true)
+
+    expect(isCloudSyncEnabled()).toBe(true)
+    expect(
+      localStorage.getItem(SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED),
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
Fixes the report that "Load more chats" stops adding chats past the first 50 after turning Encrypted Cloud Sync off and back on.

Two independent defects were involved:

1. **Turning sync off wiped local chats but kept the revision checkpoint.** On re-enable, revision sync saw a valid checkpoint and only replayed changes since then, i.e. nothing. The wipe now clears the checkpoint in the same IndexedDB transaction, so the next sync bootstraps from a snapshot.
2. **Page 1 and page 2+ used different content paths with different failure semantics.** Init used a strict batch pull; later pages used a best-effort inline pull that silently dropped any row the enclave couldn't return (`UNKNOWN_KEY`, deadline `NETWORK`, etc.). The cursor still advanced, so the button appeared to work while adding nothing. Both paths now share one batched, settled-result content fetch, unreadable rows are reported into the existing sync-health store, and tombstone-only metadata pages from the server's shared updates/deletes cursor are skipped.

## Changes
- `deleteAllNonLocalChats` clears `sync_state` / `remote_chat_state` alongside the chats.
- Toggle side effects deduplicated into `recordCloudSyncPreference()`; redundant manual event dispatch removed.
- `cloudStorage.downloadChats` chunks at `MAX_PULL_IDS` and returns `PulledChatResult[]` (`ok` | `unavailable` + enclave code) in request order. `attachInlineContent` / `listChats({ includeContent })` removed.
- `CloudSyncService.hydrateChats` shared by cursor init and page fetch; `listNextChatPage` skips empty pages with loop detection; `ChatPageResult` exposes `unavailable`.
- `ingestRemoteChats` errors are structured `{ chatId, error }` so callers can name the failing chat.
- `PULL_ITEM_CODES` constants replace ad-hoc string literals (and a stale `NEEDS_REWRAP` doc comment).
- Sidebar skips the reload/reveal step when a page saved zero chats.

Companion enclave change: tinfoilsh/confidential-sync#44 (concurrent pull + `MaxPullIDs`). No deploy ordering constraint; the client-side chunk size works against the current enclave.

## Test plan
- New IndexedDB test: wiping synced chats nulls the checkpoint (verified to fail without the fix).
- New `recordCloudSyncPreference` tests.
- `downloadChats`: request-order settling with mixed outcomes, protocol violations, chunking across `MAX_PULL_IDS`.
- Revision sync: refuses to advance past an `UNKNOWN_KEY` row.
- Pagination: skips tombstone-only pages, continues past unavailable rows and reports key recovery, boundary check ignores unavailable rows, cursor retained on storage failure.
- Full suite (2064 tests), `eslint --max-warnings=0`, `tsc --noEmit` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turning cloud sync off and back on now re-downloads chats instead of leaving the local mirror empty. Pagination also continues past unreadable or deletion-only rows, while reporting meaningful failures through sync health.

**Bug Fixes**

- Shares batched content hydration between revision sync and pagination, splitting requests at the enclave limit and preserving result order.
- Prevents revision checkpoints from advancing past unreadable rows.
- Detects cursor cycles across the full pagination scan and skips sidebar refreshes when a page saves no chats.
- Preserves cleared project assignments when importing older chats.
- Centralizes preference persistence so explicit opt-outs remain respected without duplicate setting events.

<sup>Written for commit 2013ce659d50b4489ac36d205f49b9f176cd5c6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

