### PR TITLE
feat: redesign the chat input area and welcome screen

### DIFF
--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -333,6 +333,70 @@ export const WelcomeScreen = memo(function WelcomeScreen({
             {getGreeting()}
           </motion.h1>
 
+          {/* Privacy explainer */}
+          <motion.div
+            className="mt-3"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{
+              duration: 0.5,
+              ease: 'easeOut',
+              delay: 0.3,
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => setIsPrivacyOpen(true)}
+              className="group flex w-full items-center justify-center gap-1.5 py-1.5 text-sm text-content-secondary transition-colors hover:text-content-primary sm:gap-2 sm:text-base"
+            >
+              <BiSolidLock
+                className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light"
+                aria-hidden="true"
+              />
+              <span className="shrink-0 whitespace-nowrap">
+                Your chats are private by design
+              </span>
+            </button>
+
+            <Modal
+              isOpen={isPrivacyOpen}
+              onClose={() => setIsPrivacyOpen(false)}
+              className="max-w-2xl"
+            >
+              <ModalTitle className="pr-8 font-semibold leading-none tracking-tight">
+                Your Chats Are Private by Design
+              </ModalTitle>
+
+              <div className="mt-4 text-base leading-relaxed text-content-secondary">
+                <FadeInLines
+                  segments={[
+                    {
+                      type: 'text',
+                      content:
+                        'Your messages are encrypted directly to the AI models running inside secure hardware enclaves.',
+                    },
+                    {
+                      type: 'citation',
+                      content: 'Technology',
+                      href: 'https://tinfoil.sh/technology',
+                    },
+                    {
+                      type: 'text',
+                      content:
+                        ' These are hardware-isolated environments powered by confidential computing GPUs with verifiable confidentiality and integrity guarantees. Not even Tinfoil can access your data. This applies to all chats, images, documents, and voice input. Our open-source stack lets you verify this yourself by inspecting the hardware attestation.',
+                    },
+                    {
+                      type: 'citation',
+                      content: 'Source',
+                      href: 'https://github.com/tinfoilsh',
+                    },
+                  ]}
+                />
+              </div>
+              <DataFlowDiagram />
+            </Modal>
+          </motion.div>
+
           <div className="mt-8">
             {/* Centered Chat Input - Desktop only */}
             {onSubmit && input !== undefined && setInput && (
@@ -343,7 +407,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                 transition={{
                   duration: 0.5,
                   ease: 'easeOut',
-                  delay: 0.3,
+                  delay: 0.4,
                 }}
               >
                 <ChatInput
@@ -470,70 +534,6 @@ export const WelcomeScreen = memo(function WelcomeScreen({
               </motion.div>
             )}
           </div>
-
-          {/* Privacy explainer */}
-          <motion.div
-            className="mt-4"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{
-              duration: 0.5,
-              ease: 'easeOut',
-              delay: 0.45,
-            }}
-          >
-            <button
-              type="button"
-              onClick={() => setIsPrivacyOpen(true)}
-              className="group flex w-full items-center justify-center gap-1.5 py-1.5 text-sm text-content-secondary transition-colors hover:text-content-primary sm:gap-2 sm:text-base"
-            >
-              <BiSolidLock
-                className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light"
-                aria-hidden="true"
-              />
-              <span className="shrink-0 whitespace-nowrap">
-                Your chats are private by design
-              </span>
-            </button>
-
-            <Modal
-              isOpen={isPrivacyOpen}
-              onClose={() => setIsPrivacyOpen(false)}
-              className="max-w-2xl"
-            >
-              <ModalTitle className="pr-8 font-semibold leading-none tracking-tight">
-                Your Chats Are Private by Design
-              </ModalTitle>
-
-              <div className="mt-4 text-base leading-relaxed text-content-secondary">
-                <FadeInLines
-                  segments={[
-                    {
-                      type: 'text',
-                      content:
-                        'Your messages are encrypted directly to the AI models running inside secure hardware enclaves.',
-                    },
-                    {
-                      type: 'citation',
-                      content: 'Technology',
-                      href: 'https://tinfoil.sh/technology',
-                    },
-                    {
-                      type: 'text',
-                      content:
-                        ' These are hardware-isolated environments powered by confidential computing GPUs with verifiable confidentiality and integrity guarantees. Not even Tinfoil can access your data. This applies to all chats, images, documents, and voice input. Our open-source stack lets you verify this yourself by inspecting the hardware attestation.',
-                    },
-                    {
-                      type: 'citation',
-                      content: 'Source',
-                      href: 'https://github.com/tinfoilsh',
-                    },
-                  ]}
-                />
-              </div>
-              <DataFlowDiagram />
-            </Modal>
-          </motion.div>
         </div>
       </div>
     </motion.div>

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -321,7 +321,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
       <div className="flex w-full justify-center">
         <div className="w-full max-w-2xl">
           <motion.h1
-            className="flex items-center justify-center gap-3 text-2xl font-medium tracking-tight text-content-primary md:justify-start md:text-3xl"
+            className="flex items-center justify-center gap-3 text-2xl font-medium tracking-tight text-content-primary md:text-3xl"
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{
@@ -333,81 +333,17 @@ export const WelcomeScreen = memo(function WelcomeScreen({
             {getGreeting()}
           </motion.h1>
 
-          {/* Privacy explainer */}
-          <motion.div
-            className="mt-3"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{
-              duration: 0.5,
-              ease: 'easeOut',
-              delay: 0.3,
-            }}
-          >
-            <button
-              type="button"
-              onClick={() => setIsPrivacyOpen(true)}
-              className="group flex w-full items-center justify-center gap-1.5 py-1.5 text-sm text-content-secondary transition-colors hover:text-content-primary sm:gap-2 sm:text-base md:justify-start"
-            >
-              <BiSolidLock
-                className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light"
-                aria-hidden="true"
-              />
-              <span className="shrink-0 whitespace-nowrap">
-                Your chats are private by design
-              </span>
-            </button>
-
-            <Modal
-              isOpen={isPrivacyOpen}
-              onClose={() => setIsPrivacyOpen(false)}
-              className="max-w-2xl"
-            >
-              <ModalTitle className="pr-8 font-semibold leading-none tracking-tight">
-                Your Chats Are Private by Design
-              </ModalTitle>
-
-              <div className="mt-4 text-base leading-relaxed text-content-secondary">
-                <FadeInLines
-                  segments={[
-                    {
-                      type: 'text',
-                      content:
-                        'Your messages are encrypted directly to the AI models running inside secure hardware enclaves.',
-                    },
-                    {
-                      type: 'citation',
-                      content: 'Technology',
-                      href: 'https://tinfoil.sh/technology',
-                    },
-                    {
-                      type: 'text',
-                      content:
-                        ' These are hardware-isolated environments powered by confidential computing GPUs with verifiable confidentiality and integrity guarantees. Not even Tinfoil can access your data. This applies to all chats, images, documents, and voice input. Our open-source stack lets you verify this yourself by inspecting the hardware attestation.',
-                    },
-                    {
-                      type: 'citation',
-                      content: 'Source',
-                      href: 'https://github.com/tinfoilsh',
-                    },
-                  ]}
-                />
-              </div>
-              <DataFlowDiagram />
-            </Modal>
-          </motion.div>
-
           <div className="mt-8">
             {/* Centered Chat Input - Desktop only */}
             {onSubmit && input !== undefined && setInput && (
               <motion.div
-                className="mt-8 hidden md:block"
+                className="hidden md:block"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 transition={{
                   duration: 0.5,
                   ease: 'easeOut',
-                  delay: 0.4,
+                  delay: 0.3,
                 }}
               >
                 <ChatInput
@@ -523,7 +459,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                 transition={{
                   duration: 0.5,
                   ease: 'easeOut',
-                  delay: 0.45,
+                  delay: 0.4,
                 }}
               >
                 <PromptPresetSuggestions
@@ -534,6 +470,70 @@ export const WelcomeScreen = memo(function WelcomeScreen({
               </motion.div>
             )}
           </div>
+
+          {/* Privacy explainer */}
+          <motion.div
+            className="mt-4"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{
+              duration: 0.5,
+              ease: 'easeOut',
+              delay: 0.45,
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => setIsPrivacyOpen(true)}
+              className="group flex w-full items-center justify-center gap-1.5 py-1.5 text-sm text-content-secondary transition-colors hover:text-content-primary sm:gap-2 sm:text-base"
+            >
+              <BiSolidLock
+                className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light"
+                aria-hidden="true"
+              />
+              <span className="shrink-0 whitespace-nowrap">
+                Your chats are private by design
+              </span>
+            </button>
+
+            <Modal
+              isOpen={isPrivacyOpen}
+              onClose={() => setIsPrivacyOpen(false)}
+              className="max-w-2xl"
+            >
+              <ModalTitle className="pr-8 font-semibold leading-none tracking-tight">
+                Your Chats Are Private by Design
+              </ModalTitle>
+
+              <div className="mt-4 text-base leading-relaxed text-content-secondary">
+                <FadeInLines
+                  segments={[
+                    {
+                      type: 'text',
+                      content:
+                        'Your messages are encrypted directly to the AI models running inside secure hardware enclaves.',
+                    },
+                    {
+                      type: 'citation',
+                      content: 'Technology',
+                      href: 'https://tinfoil.sh/technology',
+                    },
+                    {
+                      type: 'text',
+                      content:
+                        ' These are hardware-isolated environments powered by confidential computing GPUs with verifiable confidentiality and integrity guarantees. Not even Tinfoil can access your data. This applies to all chats, images, documents, and voice input. Our open-source stack lets you verify this yourself by inspecting the hardware attestation.',
+                    },
+                    {
+                      type: 'citation',
+                      content: 'Source',
+                      href: 'https://github.com/tinfoilsh',
+                    },
+                  ]}
+                />
+              </div>
+              <DataFlowDiagram />
+            </Modal>
+          </motion.div>
         </div>
       </div>
     </motion.div>

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -335,7 +335,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
 
           {/* Privacy explainer */}
           <motion.div
-            className="mt-3"
+            className="mt-4 flex justify-center"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{
@@ -347,7 +347,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
             <button
               type="button"
               onClick={() => setIsPrivacyOpen(true)}
-              className="group flex w-full items-center justify-center gap-1.5 py-1.5 text-sm text-content-secondary transition-colors hover:text-content-primary sm:gap-2 sm:text-base"
+              className="inline-flex items-center gap-1.5 rounded-full border border-border-subtle bg-surface-chat-background px-3.5 py-1.5 text-sm text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
             >
               <BiSolidLock
                 className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light"

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -347,7 +347,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
             <button
               type="button"
               onClick={() => setIsPrivacyOpen(true)}
-              className="inline-flex items-center gap-1.5 rounded-full border border-border-subtle bg-surface-chat-background px-3.5 py-1.5 text-sm text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-sm text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
             >
               <BiSolidLock
                 className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light"

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -951,6 +951,9 @@ export function ChatInput({
               button groups become flex siblings of the textarea and can be
               ordered around it. */}
           <div className={cn(isCompact && 'flex items-end gap-2')}>
+            {/* The button groups are sized to the send button so a one-line
+                textarea centers against them; when it grows they stay pinned
+                to the bottom via items-end. */}
             <textarea
               id="chat-input"
               aria-label="Message"
@@ -1206,7 +1209,7 @@ export function ChatInput({
               rows={1}
               className={cn(
                 'w-full resize-none bg-transparent font-chat text-lg leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none',
-                isCompact && 'min-w-0 flex-1 self-center py-1',
+                isCompact && 'min-w-0 flex-1 self-center',
               )}
               style={{
                 minHeight: inputMinHeight,
@@ -1227,7 +1230,7 @@ export function ChatInput({
               <div
                 className={cn(
                   'flex items-center gap-1',
-                  isCompact && 'order-first',
+                  isCompact && 'order-first h-10 md:h-8',
                 )}
               >
                 {/* Unified + button opening the input options menu */}
@@ -1338,7 +1341,12 @@ export function ChatInput({
                 </div>
               </div>
 
-              <div className="flex items-center gap-2">
+              <div
+                className={cn(
+                  'flex items-center gap-2',
+                  isCompact && 'h-10 md:h-8',
+                )}
+              >
                 {/* Once a conversation is underway these move to the footer
                   below the card so the card itself stays focused on composing. */}
                 {!hasMessages && contextUsage && (
@@ -1420,7 +1428,10 @@ export function ChatInput({
                           }
                         }
                       }}
-                      className="group ml-2 flex h-10 w-10 items-center justify-center rounded-site-control bg-button-send-background text-button-send-foreground transition-colors hover:bg-button-send-background/80 disabled:opacity-50 md:h-8 md:w-8"
+                      className={cn(
+                        'group flex h-10 w-10 items-center justify-center rounded-site-control bg-button-send-background text-button-send-foreground transition-colors hover:bg-button-send-background/80 disabled:opacity-50 md:h-8 md:w-8',
+                        !isCompact && 'ml-2',
+                      )}
                       style={{ WebkitTapHighlightColor: 'transparent' }}
                       disabled={
                         showStopAction

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -364,20 +364,6 @@ export function ChatInput({
     }
   }
 
-  // Random placeholder - use first one initially to avoid SSR hydration mismatch,
-  // then randomize after mount
-  const [placeholder, setPlaceholder] = useState<string>(
-    CONSTANTS.INPUT_PLACEHOLDERS[0],
-  )
-
-  useEffect(() => {
-    setPlaceholder(
-      CONSTANTS.INPUT_PLACEHOLDERS[
-        Math.floor(Math.random() * CONSTANTS.INPUT_PLACEHOLDERS.length)
-      ],
-    )
-  }, [])
-
   // Scroll to the end when new documents are added
   useEffect(() => {
     if (documentsScrollRef.current && processedDocuments?.length) {
@@ -1205,7 +1191,11 @@ export function ChatInput({
                   cancelGeneration()
                 }
               }}
-              placeholder={hasMessages ? 'Reply to Tin...' : placeholder}
+              placeholder={
+                hasMessages
+                  ? CONSTANTS.REPLY_PLACEHOLDER
+                  : CONSTANTS.INPUT_PLACEHOLDER
+              }
               rows={1}
               className={cn(
                 'w-full resize-none bg-transparent font-chat text-lg leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none',

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -1310,13 +1310,17 @@ export function ChatInput({
             </div>
 
             <div className="flex items-center gap-2">
-              {contextUsage && (
+              {/* Once a conversation is underway these move to the footer
+                  below the card so the card itself stays focused on composing. */}
+              {!hasMessages && contextUsage && (
                 <ContextUsageIndicator
                   usage={contextUsage}
                   className="hidden md:flex"
                 />
               )}
-              {modelSelectorButton && <div>{modelSelectorButton}</div>}
+              {!hasMessages && modelSelectorButton && (
+                <div>{modelSelectorButton}</div>
+              )}
               {isPremium && audioModel && (
                 <button
                   type="button"
@@ -1406,10 +1410,19 @@ export function ChatInput({
       </div>
 
       {hasMessages && (
-        <div className="text-center">
+        <div className="flex items-center justify-between gap-4 px-3 md:px-6">
           <p className="text-xs text-content-muted">
             AI can make mistakes. Verify important information.
           </p>
+          <div className="flex items-center gap-2">
+            {contextUsage && (
+              <ContextUsageIndicator
+                usage={contextUsage}
+                className="hidden md:flex"
+              />
+            )}
+            {modelSelectorButton}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -713,6 +713,11 @@ export function ChatInput({
     [handleDocumentUpload],
   )
 
+  // Once a conversation is underway the composer collapses into a single row
+  // with the controls flanking the textarea; the welcome screen keeps the
+  // taller two-row layout.
+  const isCompact = Boolean(hasMessages)
+
   return (
     <div className="flex flex-col gap-2">
       <div className="relative">
@@ -721,6 +726,7 @@ export function ChatInput({
           className={cn(
             // relative anchors the folder-style tabs below to the card itself.
             'relative rounded-3xl border bg-white px-3 py-3 shadow-md transition-colors dark:bg-surface-chat md:rounded-4xl md:px-6 md:py-4',
+            isCompact && 'md:px-4 md:py-3',
             isTemporaryMode
               ? 'border-dashed border-content-muted'
               : 'border-border-subtle',
@@ -941,469 +947,497 @@ export function ChatInput({
             </div>
           )}
 
-          <textarea
-            id="chat-input"
-            aria-label="Message"
-            ref={attachTextareaRef}
-            key={textareaResetNonce}
-            value={input}
-            onFocus={handleInputFocus}
-            onChange={(e) => {
-              // Resize is driven by the layout effect on the resulting value
-              // change; avoid an extra synchronous reflow here.
-              setInput(e.target.value)
-            }}
-            onInput={(e) => {
-              // Some mobile Safari builds update `scrollHeight` more reliably on
-              // `input`; schedule a coalesced resize rather than reflowing now.
-              scheduleResize(e.currentTarget as HTMLTextAreaElement)
-            }}
-            onPaste={handlePaste}
-            onKeyDown={(e) => {
-              // Enter during IME composition only confirms the conversion;
-              // it must not send the message or edit the list structure.
-              if (e.key === 'Enter' && isImeComposition(e)) {
-                return
-              }
-              if (e.key === 'Tab') {
-                const textarea = e.currentTarget
-                const cursorPosition = textarea.selectionStart
-                const textBeforeCursor = input.slice(0, cursorPosition)
-                const lastLineStart = textBeforeCursor.lastIndexOf('\n') + 1
-                const currentLine = textBeforeCursor.slice(lastLineStart)
+          {/* In compact mode the toolbar below uses display: contents so its
+              button groups become flex siblings of the textarea and can be
+              ordered around it. */}
+          <div className={cn(isCompact && 'flex items-end gap-2')}>
+            <textarea
+              id="chat-input"
+              aria-label="Message"
+              ref={attachTextareaRef}
+              key={textareaResetNonce}
+              value={input}
+              onFocus={handleInputFocus}
+              onChange={(e) => {
+                // Resize is driven by the layout effect on the resulting value
+                // change; avoid an extra synchronous reflow here.
+                setInput(e.target.value)
+              }}
+              onInput={(e) => {
+                // Some mobile Safari builds update `scrollHeight` more reliably on
+                // `input`; schedule a coalesced resize rather than reflowing now.
+                scheduleResize(e.currentTarget as HTMLTextAreaElement)
+              }}
+              onPaste={handlePaste}
+              onKeyDown={(e) => {
+                // Enter during IME composition only confirms the conversion;
+                // it must not send the message or edit the list structure.
+                if (e.key === 'Enter' && isImeComposition(e)) {
+                  return
+                }
+                if (e.key === 'Tab') {
+                  const textarea = e.currentTarget
+                  const cursorPosition = textarea.selectionStart
+                  const textBeforeCursor = input.slice(0, cursorPosition)
+                  const lastLineStart = textBeforeCursor.lastIndexOf('\n') + 1
+                  const currentLine = textBeforeCursor.slice(lastLineStart)
 
-                // Check if we're on a list line
-                const listMatch = currentLine.match(
-                  /^(\s*)(\s*\u2022\s+|[-*+]|\s*\d+\.)\s+(?!\[[ x]\])/,
-                )
+                  // Check if we're on a list line
+                  const listMatch = currentLine.match(
+                    /^(\s*)(\s*\u2022\s+|[-*+]|\s*\d+\.)\s+(?!\[[ x]\])/,
+                  )
 
-                if (listMatch) {
-                  e.preventDefault()
-                  const textAfterCursor = input.slice(cursorPosition)
+                  if (listMatch) {
+                    e.preventDefault()
+                    const textAfterCursor = input.slice(cursorPosition)
 
-                  if (e.shiftKey) {
-                    // Shift+Tab: decrease indent (remove 4 spaces or exit list)
-                    const dedentMatch = currentLine.match(/^    /)
-                    if (dedentMatch) {
-                      // Has 4+ spaces, remove 4 spaces
-                      const newText =
-                        input.slice(0, lastLineStart) +
-                        currentLine.slice(4) +
-                        textAfterCursor
-
-                      setInput(newText)
-
-                      setTimeout(() => {
-                        textarea.selectionStart = textarea.selectionEnd =
-                          Math.max(lastLineStart, cursorPosition - 4)
-                      }, 0)
-                    } else {
-                      // Single indent level - remove the bullet/marker entirely
-                      const contentMatch = currentLine.match(
-                        /^(\s*)(\s*\u2022\s+|[-*+]|\s*\d+\.)\s+(.*)$/,
-                      )
-                      if (contentMatch) {
-                        const [, , , content] = contentMatch
+                    if (e.shiftKey) {
+                      // Shift+Tab: decrease indent (remove 4 spaces or exit list)
+                      const dedentMatch = currentLine.match(/^    /)
+                      if (dedentMatch) {
+                        // Has 4+ spaces, remove 4 spaces
                         const newText =
                           input.slice(0, lastLineStart) +
-                          content +
+                          currentLine.slice(4) +
                           textAfterCursor
 
                         setInput(newText)
 
                         setTimeout(() => {
                           textarea.selectionStart = textarea.selectionEnd =
-                            lastLineStart + content.length
+                            Math.max(lastLineStart, cursorPosition - 4)
                         }, 0)
+                      } else {
+                        // Single indent level - remove the bullet/marker entirely
+                        const contentMatch = currentLine.match(
+                          /^(\s*)(\s*\u2022\s+|[-*+]|\s*\d+\.)\s+(.*)$/,
+                        )
+                        if (contentMatch) {
+                          const [, , , content] = contentMatch
+                          const newText =
+                            input.slice(0, lastLineStart) +
+                            content +
+                            textAfterCursor
+
+                          setInput(newText)
+
+                          setTimeout(() => {
+                            textarea.selectionStart = textarea.selectionEnd =
+                              lastLineStart + content.length
+                          }, 0)
+                        }
                       }
+                    } else {
+                      // Tab: increase indent (add 4 spaces)
+                      const newText =
+                        input.slice(0, lastLineStart) +
+                        '    ' +
+                        currentLine +
+                        textAfterCursor
+
+                      setInput(newText)
+
+                      setTimeout(() => {
+                        textarea.selectionStart = textarea.selectionEnd =
+                          cursorPosition + 4
+                      }, 0)
                     }
-                  } else {
-                    // Tab: increase indent (add 4 spaces)
-                    const newText =
-                      input.slice(0, lastLineStart) +
-                      '    ' +
-                      currentLine +
-                      textAfterCursor
-
-                    setInput(newText)
-
-                    setTimeout(() => {
-                      textarea.selectionStart = textarea.selectionEnd =
-                        cursorPosition + 4
-                    }, 0)
                   }
-                }
-              } else if (e.key === ' ') {
-                const textarea = e.currentTarget
-                const cursorPosition = textarea.selectionStart
-                const textBeforeCursor = input.slice(0, cursorPosition)
-                const lastLineStart = textBeforeCursor.lastIndexOf('\n') + 1
-                const currentLine = textBeforeCursor.slice(lastLineStart)
+                } else if (e.key === ' ') {
+                  const textarea = e.currentTarget
+                  const cursorPosition = textarea.selectionStart
+                  const textBeforeCursor = input.slice(0, cursorPosition)
+                  const lastLineStart = textBeforeCursor.lastIndexOf('\n') + 1
+                  const currentLine = textBeforeCursor.slice(lastLineStart)
 
-                // Check if the line starts with * or - or + (for bullets)
-                const bulletMatch = currentLine.match(/^(\s*)([-*+])$/)
+                  // Check if the line starts with * or - or + (for bullets)
+                  const bulletMatch = currentLine.match(/^(\s*)([-*+])$/)
 
-                if (bulletMatch) {
-                  e.preventDefault()
-                  const [, indent] = bulletMatch
-                  const textAfterCursor = input.slice(cursorPosition)
-
-                  // Replace the marker with a bullet point and add space with indentation
-                  // Extra space after bullet to align with numbered lists
-                  const newText =
-                    input.slice(0, lastLineStart) +
-                    indent +
-                    '  \u2022  ' +
-                    textAfterCursor
-
-                  setInput(newText)
-
-                  setTimeout(() => {
-                    textarea.selectionStart = textarea.selectionEnd =
-                      lastLineStart + indent.length + 5
-                  }, 0)
-                } else {
-                  // Check if the line starts with a number (for numbered lists)
-                  const numberMatch = currentLine.match(/^(\s*)(\d+\.)$/)
-
-                  if (numberMatch) {
+                  if (bulletMatch) {
                     e.preventDefault()
-                    const [, indent, marker] = numberMatch
+                    const [, indent] = bulletMatch
                     const textAfterCursor = input.slice(cursorPosition)
 
-                    // Just add a space after the number marker (no extra indentation)
+                    // Replace the marker with a bullet point and add space with indentation
+                    // Extra space after bullet to align with numbered lists
                     const newText =
                       input.slice(0, lastLineStart) +
                       indent +
-                      marker +
-                      ' ' +
+                      '  \u2022  ' +
                       textAfterCursor
 
                     setInput(newText)
 
                     setTimeout(() => {
                       textarea.selectionStart = textarea.selectionEnd =
-                        lastLineStart + indent.length + marker.length + 1
-                    }, 0)
-                  }
-                }
-              } else if (
-                e.key === 'Enter' &&
-                !e.shiftKey &&
-                (!enterToNewline || e.metaKey || e.ctrlKey)
-              ) {
-                // On mobile, Enter should insert a newline, not submit
-                const isMobile = /iPhone|iPad|iPod|Android/i.test(
-                  navigator.userAgent,
-                )
-                if (isMobile && !e.metaKey && !e.ctrlKey) {
-                  return
-                }
-                e.preventDefault()
-                const hasDocuments =
-                  processedDocuments &&
-                  processedDocuments.some((doc) => isDocumentSubmittable(doc))
-                const hasInput = input.trim().length > 0
-                const hasQuote = Boolean(quote)
-                if (!isTranscribing && (hasInput || hasDocuments || hasQuote)) {
-                  shouldRemountOnClearRef.current = true
-                  handleSubmit(e)
-                }
-              } else if (e.key === 'Enter') {
-                const textarea = e.currentTarget
-                const cursorPosition = textarea.selectionStart
-                const textBeforeCursor = input.slice(0, cursorPosition)
-                const lastLineStart = textBeforeCursor.lastIndexOf('\n') + 1
-                const currentLine = textBeforeCursor.slice(lastLineStart)
-
-                // Match list markers: •, -, *, +, 1.
-                const listMarkerMatch = currentLine.match(
-                  /^(\s*)(\s*\u2022\s+|[-*+]|\s*\d+\.)\s+/,
-                )
-
-                if (!listMarkerMatch) {
-                  setTimeout(() => {
-                    resizeTextarea(textarea)
-                    textarea.scrollTop = textarea.scrollHeight
-                  }, 0)
-                } else {
-                  e.preventDefault()
-                  const [fullMatch, indent, marker] = listMarkerMatch
-
-                  const contentAfterMarker = currentLine
-                    .slice(fullMatch.length)
-                    .trim()
-
-                  if (!contentAfterMarker) {
-                    // Empty list item - exit the list
-                    const textAfterCursor = input.slice(cursorPosition)
-                    const newText =
-                      input.slice(0, lastLineStart) + indent + textAfterCursor
-
-                    setInput(newText)
-
-                    setTimeout(() => {
-                      textarea.selectionStart = textarea.selectionEnd =
-                        lastLineStart + indent.length
+                        lastLineStart + indent.length + 5
                     }, 0)
                   } else {
-                    // Continue the list
-                    const textAfterCursor = input.slice(cursorPosition)
-                    let newMarker = marker
+                    // Check if the line starts with a number (for numbered lists)
+                    const numberMatch = currentLine.match(/^(\s*)(\d+\.)$/)
 
-                    // Increment numbered lists (handle with or without leading spaces)
-                    const numberMatch = marker.match(/^(\s*)(\d+\.)$/)
                     if (numberMatch) {
-                      const [, markerIndent, number] = numberMatch
-                      const currentNumber = parseInt(number)
-                      newMarker = `${markerIndent}${currentNumber + 1}.`
+                      e.preventDefault()
+                      const [, indent, marker] = numberMatch
+                      const textAfterCursor = input.slice(cursorPosition)
+
+                      // Just add a space after the number marker (no extra indentation)
+                      const newText =
+                        input.slice(0, lastLineStart) +
+                        indent +
+                        marker +
+                        ' ' +
+                        textAfterCursor
+
+                      setInput(newText)
+
+                      setTimeout(() => {
+                        textarea.selectionStart = textarea.selectionEnd =
+                          lastLineStart + indent.length + marker.length + 1
+                      }, 0)
                     }
+                  }
+                } else if (
+                  e.key === 'Enter' &&
+                  !e.shiftKey &&
+                  (!enterToNewline || e.metaKey || e.ctrlKey)
+                ) {
+                  // On mobile, Enter should insert a newline, not submit
+                  const isMobile = /iPhone|iPad|iPod|Android/i.test(
+                    navigator.userAgent,
+                  )
+                  if (isMobile && !e.metaKey && !e.ctrlKey) {
+                    return
+                  }
+                  e.preventDefault()
+                  const hasDocuments =
+                    processedDocuments &&
+                    processedDocuments.some((doc) => isDocumentSubmittable(doc))
+                  const hasInput = input.trim().length > 0
+                  const hasQuote = Boolean(quote)
+                  if (
+                    !isTranscribing &&
+                    (hasInput || hasDocuments || hasQuote)
+                  ) {
+                    shouldRemountOnClearRef.current = true
+                    handleSubmit(e)
+                  }
+                } else if (e.key === 'Enter') {
+                  const textarea = e.currentTarget
+                  const cursorPosition = textarea.selectionStart
+                  const textBeforeCursor = input.slice(0, cursorPosition)
+                  const lastLineStart = textBeforeCursor.lastIndexOf('\n') + 1
+                  const currentLine = textBeforeCursor.slice(lastLineStart)
 
-                    const newText =
-                      textBeforeCursor +
-                      '\n' +
-                      indent +
-                      newMarker +
-                      ' ' +
-                      textAfterCursor
+                  // Match list markers: •, -, *, +, 1.
+                  const listMarkerMatch = currentLine.match(
+                    /^(\s*)(\s*\u2022\s+|[-*+]|\s*\d+\.)\s+/,
+                  )
 
-                    setInput(newText)
-
-                    const newCursorPos =
-                      cursorPosition + 1 + indent.length + newMarker.length + 1
-
+                  if (!listMarkerMatch) {
                     setTimeout(() => {
                       resizeTextarea(textarea)
-                      textarea.selectionStart = textarea.selectionEnd =
-                        newCursorPos
                       textarea.scrollTop = textarea.scrollHeight
                     }, 0)
-                  }
-                }
-              } else if (e.key === 'Escape' && loadingState === 'loading') {
-                e.preventDefault()
-                cancelGeneration()
-              }
-            }}
-            placeholder={hasMessages ? 'Reply to Tin...' : placeholder}
-            rows={1}
-            className={cn(
-              'w-full resize-none bg-transparent font-chat text-lg leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none',
-            )}
-            style={{
-              minHeight: inputMinHeight,
-              maxHeight: `${CONSTANTS.INPUT_MAX_HEIGHT_PX}px`,
-            }}
-          />
+                  } else {
+                    e.preventDefault()
+                    const [fullMatch, indent, marker] = listMarkerMatch
 
-          <div className="mt-3 flex items-center justify-between">
-            <span className="sr-only" role="status" aria-live="polite">
-              {audioStatus}
-            </span>
-            <div className="flex items-center gap-1">
-              {/* Unified + button opening the input options menu */}
-              <div className="relative">
-                <button
-                  id="input-options-button"
-                  ref={inputMenuTriggerRef}
-                  type="button"
-                  onClick={() => setIsInputMenuOpen(!isInputMenuOpen)}
-                  aria-label="Input options"
-                  aria-expanded={isInputMenuOpen}
-                  aria-haspopup="menu"
-                  className="flex h-7 w-7 items-center justify-center rounded-lg text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
-                >
-                  <PiPlusLight className="h-5 w-5" />
-                </button>
-                {isInputMenuOpen && (
-                  <>
-                    <div
-                      className="fixed inset-0 z-10"
-                      onClick={() => closeInputMenu(false)}
-                    />
-                    <div
-                      ref={inputMenuRef}
-                      role="menu"
-                      aria-label="Input options"
-                      onKeyDown={handleInputMenuKeyDown}
-                      className="absolute bottom-full left-0 z-20 mb-2 min-w-[220px] rounded-xl border border-border-subtle bg-surface-chat py-1.5 shadow-lg"
-                    >
-                      <button
-                        type="button"
-                        role="menuitem"
-                        onClick={() => {
-                          triggerFileInput()
-                          closeInputMenu(true)
-                        }}
-                        className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
+                    const contentAfterMarker = currentLine
+                      .slice(fullMatch.length)
+                      .trim()
+
+                    if (!contentAfterMarker) {
+                      // Empty list item - exit the list
+                      const textAfterCursor = input.slice(cursorPosition)
+                      const newText =
+                        input.slice(0, lastLineStart) + indent + textAfterCursor
+
+                      setInput(newText)
+
+                      setTimeout(() => {
+                        textarea.selectionStart = textarea.selectionEnd =
+                          lastLineStart + indent.length
+                      }, 0)
+                    } else {
+                      // Continue the list
+                      const textAfterCursor = input.slice(cursorPosition)
+                      let newMarker = marker
+
+                      // Increment numbered lists (handle with or without leading spaces)
+                      const numberMatch = marker.match(/^(\s*)(\d+\.)$/)
+                      if (numberMatch) {
+                        const [, markerIndent, number] = numberMatch
+                        const currentNumber = parseInt(number)
+                        newMarker = `${markerIndent}${currentNumber + 1}.`
+                      }
+
+                      const newText =
+                        textBeforeCursor +
+                        '\n' +
+                        indent +
+                        newMarker +
+                        ' ' +
+                        textAfterCursor
+
+                      setInput(newText)
+
+                      const newCursorPos =
+                        cursorPosition +
+                        1 +
+                        indent.length +
+                        newMarker.length +
+                        1
+
+                      setTimeout(() => {
+                        resizeTextarea(textarea)
+                        textarea.selectionStart = textarea.selectionEnd =
+                          newCursorPos
+                        textarea.scrollTop = textarea.scrollHeight
+                      }, 0)
+                    }
+                  }
+                } else if (e.key === 'Escape' && loadingState === 'loading') {
+                  e.preventDefault()
+                  cancelGeneration()
+                }
+              }}
+              placeholder={hasMessages ? 'Reply to Tin...' : placeholder}
+              rows={1}
+              className={cn(
+                'w-full resize-none bg-transparent font-chat text-lg leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none',
+                isCompact && 'min-w-0 flex-1 self-center py-1',
+              )}
+              style={{
+                minHeight: inputMinHeight,
+                maxHeight: `${CONSTANTS.INPUT_MAX_HEIGHT_PX}px`,
+              }}
+            />
+
+            <div
+              className={cn(
+                isCompact
+                  ? 'contents'
+                  : 'mt-3 flex items-center justify-between',
+              )}
+            >
+              <span className="sr-only" role="status" aria-live="polite">
+                {audioStatus}
+              </span>
+              <div
+                className={cn(
+                  'flex items-center gap-1',
+                  isCompact && 'order-first',
+                )}
+              >
+                {/* Unified + button opening the input options menu */}
+                <div className="relative">
+                  <button
+                    id="input-options-button"
+                    ref={inputMenuTriggerRef}
+                    type="button"
+                    onClick={() => setIsInputMenuOpen(!isInputMenuOpen)}
+                    aria-label="Input options"
+                    aria-expanded={isInputMenuOpen}
+                    aria-haspopup="menu"
+                    className="flex h-7 w-7 items-center justify-center rounded-lg text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
+                  >
+                    <PiPlusLight className="h-5 w-5" />
+                  </button>
+                  {isInputMenuOpen && (
+                    <>
+                      <div
+                        className="fixed inset-0 z-10"
+                        onClick={() => closeInputMenu(false)}
+                      />
+                      <div
+                        ref={inputMenuRef}
+                        role="menu"
+                        aria-label="Input options"
+                        onKeyDown={handleInputMenuKeyDown}
+                        className="absolute bottom-full left-0 z-20 mb-2 min-w-[220px] rounded-xl border border-border-subtle bg-surface-chat py-1.5 shadow-lg"
                       >
-                        <PiPaperclipLight className="h-5 w-5 text-content-secondary" />
-                        Add files or photos
-                      </button>
-                      {onOpenPromptLibrary && (
                         <button
                           type="button"
                           role="menuitem"
                           onClick={() => {
-                            onOpenPromptLibrary()
+                            triggerFileInput()
                             closeInputMenu(true)
                           }}
                           className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                         >
-                          <Squares2X2Icon className="h-5 w-5 text-content-secondary" />
-                          Change system prompt
+                          <PiPaperclipLight className="h-5 w-5 text-content-secondary" />
+                          Add files or photos
                         </button>
-                      )}
-                      {(onWebSearchToggle || onCodeExecutionToggle) && (
-                        <div className="my-1.5 border-t border-border-subtle" />
-                      )}
-                      {onWebSearchToggle && (
-                        <button
-                          type="button"
-                          role="menuitemcheckbox"
-                          aria-checked={webSearchEnabled}
-                          onClick={() => {
-                            onWebSearchToggle()
-                            closeInputMenu(true)
-                          }}
-                          className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
-                        >
-                          {webSearchEnabled ? (
-                            <PiGlobe className="h-5 w-5 text-content-secondary" />
-                          ) : (
-                            <PiGlobeX className="h-5 w-5 text-content-secondary" />
-                          )}
-                          <span className="flex-1">Web search</span>
-                          {webSearchEnabled && (
-                            <MenuCheckmark className="h-4 w-4 text-brand-accent-light" />
-                          )}
-                        </button>
-                      )}
-                      {onCodeExecutionToggle && (
-                        <button
-                          type="button"
-                          role="menuitemcheckbox"
-                          aria-checked={codeExecutionEnabled}
-                          onClick={() => {
-                            onCodeExecutionToggle()
-                            closeInputMenu(true)
-                          }}
-                          className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
-                        >
-                          <PiTerminalWindow className="h-5 w-5 text-content-secondary" />
-                          <span className="flex-1">Code execution</span>
-                          {codeExecutionEnabled && (
-                            <MenuCheckmark className="h-4 w-4 text-brand-accent-light" />
-                          )}
-                        </button>
-                      )}
-                      {contextUsage && (
-                        <div className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary md:hidden">
-                          <span className="flex-1">Context</span>
-                          <ContextUsageIndicator usage={contextUsage} />
-                        </div>
-                      )}
-                    </div>
-                  </>
-                )}
+                        {onOpenPromptLibrary && (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            onClick={() => {
+                              onOpenPromptLibrary()
+                              closeInputMenu(true)
+                            }}
+                            className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
+                          >
+                            <Squares2X2Icon className="h-5 w-5 text-content-secondary" />
+                            Change system prompt
+                          </button>
+                        )}
+                        {(onWebSearchToggle || onCodeExecutionToggle) && (
+                          <div className="my-1.5 border-t border-border-subtle" />
+                        )}
+                        {onWebSearchToggle && (
+                          <button
+                            type="button"
+                            role="menuitemcheckbox"
+                            aria-checked={webSearchEnabled}
+                            onClick={() => {
+                              onWebSearchToggle()
+                              closeInputMenu(true)
+                            }}
+                            className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
+                          >
+                            {webSearchEnabled ? (
+                              <PiGlobe className="h-5 w-5 text-content-secondary" />
+                            ) : (
+                              <PiGlobeX className="h-5 w-5 text-content-secondary" />
+                            )}
+                            <span className="flex-1">Web search</span>
+                            {webSearchEnabled && (
+                              <MenuCheckmark className="h-4 w-4 text-brand-accent-light" />
+                            )}
+                          </button>
+                        )}
+                        {onCodeExecutionToggle && (
+                          <button
+                            type="button"
+                            role="menuitemcheckbox"
+                            aria-checked={codeExecutionEnabled}
+                            onClick={() => {
+                              onCodeExecutionToggle()
+                              closeInputMenu(true)
+                            }}
+                            className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
+                          >
+                            <PiTerminalWindow className="h-5 w-5 text-content-secondary" />
+                            <span className="flex-1">Code execution</span>
+                            {codeExecutionEnabled && (
+                              <MenuCheckmark className="h-4 w-4 text-brand-accent-light" />
+                            )}
+                          </button>
+                        )}
+                        {contextUsage && (
+                          <div className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary md:hidden">
+                            <span className="flex-1">Context</span>
+                            <ContextUsageIndicator usage={contextUsage} />
+                          </div>
+                        )}
+                      </div>
+                    </>
+                  )}
+                </div>
               </div>
-            </div>
 
-            <div className="flex items-center gap-2">
-              {/* Once a conversation is underway these move to the footer
+              <div className="flex items-center gap-2">
+                {/* Once a conversation is underway these move to the footer
                   below the card so the card itself stays focused on composing. */}
-              {!hasMessages && contextUsage && (
-                <ContextUsageIndicator
-                  usage={contextUsage}
-                  className="hidden md:flex"
-                />
-              )}
-              {!hasMessages && modelSelectorButton && (
-                <div>{modelSelectorButton}</div>
-              )}
-              {isPremium && audioModel && (
-                <button
-                  type="button"
-                  onClick={isRecording ? stopRecording : startRecording}
-                  className={cn(
-                    'disabled:opacity-50',
-                    isRecording
-                      ? 'flex h-10 w-10 animate-pulse items-center justify-center rounded-full bg-red-500 text-white md:h-8 md:w-8'
-                      : 'rounded-lg bg-transparent p-2.5 text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary md:p-1.5',
-                  )}
-                  style={{ WebkitTapHighlightColor: 'transparent' }}
-                  title={recordingButtonLabel}
-                  aria-label={recordingButtonLabel}
-                  disabled={isTranscribing}
-                >
-                  {isRecording ? (
-                    <StopIcon
-                      className="h-6 w-6 md:h-5 md:w-5"
-                      aria-hidden="true"
-                    />
-                  ) : isTranscribing ? (
-                    <PiSpinner
-                      className="h-6 w-6 animate-spin text-current md:h-5 md:w-5"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <MicrophoneIcon
-                      className="h-6 w-6 md:h-5 md:w-5"
-                      aria-hidden="true"
-                    />
-                  )}
-                </button>
-              )}
-              {(() => {
-                const isBusy = loadingState !== 'idle'
-                const hasCompletedDocuments = Boolean(
-                  processedDocuments &&
-                  processedDocuments.some((doc) => isDocumentSubmittable(doc)),
-                )
-                const hasSubmittableContent =
-                  Boolean(input.trim()) ||
-                  Boolean(quote) ||
-                  hasCompletedDocuments
-                const showStopAction = isBusy && !hasSubmittableContent
-
-                return (
+                {!hasMessages && contextUsage && (
+                  <ContextUsageIndicator
+                    usage={contextUsage}
+                    className="hidden md:flex"
+                  />
+                )}
+                {!hasMessages && modelSelectorButton && (
+                  <div>{modelSelectorButton}</div>
+                )}
+                {isPremium && audioModel && (
                   <button
-                    id="send-button"
                     type="button"
-                    onClick={(e) => {
-                      if (showStopAction) {
-                        e.preventDefault()
-                        cancelGeneration()
-                      } else {
-                        shouldRemountOnClearRef.current = true
-                        handleSubmit(e)
-                        // On iOS Safari, forcing blur here can lead to a "dead" touch region
-                        // after the keyboard dismisses. Keep focus on mobile; desktop can blur.
-                        const isMobile =
-                          typeof navigator !== 'undefined' &&
-                          /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
-                        if (!isMobile) {
-                          ownTextareaRef.current?.blur()
-                        }
-                      }
-                    }}
-                    className="group ml-2 flex h-10 w-10 items-center justify-center rounded-site-control bg-button-send-background text-button-send-foreground transition-colors hover:bg-button-send-background/80 disabled:opacity-50 md:h-8 md:w-8"
+                    onClick={isRecording ? stopRecording : startRecording}
+                    className={cn(
+                      'disabled:opacity-50',
+                      isRecording
+                        ? 'flex h-10 w-10 animate-pulse items-center justify-center rounded-full bg-red-500 text-white md:h-8 md:w-8'
+                        : 'rounded-lg bg-transparent p-2.5 text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary md:p-1.5',
+                    )}
                     style={{ WebkitTapHighlightColor: 'transparent' }}
-                    disabled={
-                      showStopAction
-                        ? false
-                        : isTranscribing || !hasSubmittableContent
-                    }
-                    aria-label={showStopAction ? 'Stop generation' : 'Send'}
+                    title={recordingButtonLabel}
+                    aria-label={recordingButtonLabel}
+                    disabled={isTranscribing}
                   >
-                    {showStopAction ? (
-                      <div className="h-3.5 w-3.5 bg-button-send-foreground/80 transition-colors md:h-3 md:w-3" />
+                    {isRecording ? (
+                      <StopIcon
+                        className="h-6 w-6 md:h-5 md:w-5"
+                        aria-hidden="true"
+                      />
+                    ) : isTranscribing ? (
+                      <PiSpinner
+                        className="h-6 w-6 animate-spin text-current md:h-5 md:w-5"
+                        aria-hidden="true"
+                      />
                     ) : (
-                      <FiArrowUp className="h-6 w-6 text-button-send-foreground transition-colors md:h-5 md:w-5" />
+                      <MicrophoneIcon
+                        className="h-6 w-6 md:h-5 md:w-5"
+                        aria-hidden="true"
+                      />
                     )}
                   </button>
-                )
-              })()}
+                )}
+                {(() => {
+                  const isBusy = loadingState !== 'idle'
+                  const hasCompletedDocuments = Boolean(
+                    processedDocuments &&
+                    processedDocuments.some((doc) =>
+                      isDocumentSubmittable(doc),
+                    ),
+                  )
+                  const hasSubmittableContent =
+                    Boolean(input.trim()) ||
+                    Boolean(quote) ||
+                    hasCompletedDocuments
+                  const showStopAction = isBusy && !hasSubmittableContent
+
+                  return (
+                    <button
+                      id="send-button"
+                      type="button"
+                      onClick={(e) => {
+                        if (showStopAction) {
+                          e.preventDefault()
+                          cancelGeneration()
+                        } else {
+                          shouldRemountOnClearRef.current = true
+                          handleSubmit(e)
+                          // On iOS Safari, forcing blur here can lead to a "dead" touch region
+                          // after the keyboard dismisses. Keep focus on mobile; desktop can blur.
+                          const isMobile =
+                            typeof navigator !== 'undefined' &&
+                            /iPhone|iPad|iPod|Android/i.test(
+                              navigator.userAgent,
+                            )
+                          if (!isMobile) {
+                            ownTextareaRef.current?.blur()
+                          }
+                        }
+                      }}
+                      className="group ml-2 flex h-10 w-10 items-center justify-center rounded-site-control bg-button-send-background text-button-send-foreground transition-colors hover:bg-button-send-background/80 disabled:opacity-50 md:h-8 md:w-8"
+                      style={{ WebkitTapHighlightColor: 'transparent' }}
+                      disabled={
+                        showStopAction
+                          ? false
+                          : isTranscribing || !hasSubmittableContent
+                      }
+                      aria-label={showStopAction ? 'Stop generation' : 'Send'}
+                    >
+                      {showStopAction ? (
+                        <div className="h-3.5 w-3.5 bg-button-send-foreground/80 transition-colors md:h-3 md:w-3" />
+                      ) : (
+                        <FiArrowUp className="h-6 w-6 text-button-send-foreground transition-colors md:h-5 md:w-5" />
+                      )}
+                    </button>
+                  )
+                })()}
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -75,13 +75,10 @@ export const CONSTANTS = {
   VERIFICATION_RETRY_DELAY_MS: 2000, // Base delay between retries (exponential backoff)
   MESSAGE_SEND_MAX_RETRIES: 6,
   MESSAGE_SEND_RETRY_DELAY_MS: 1000, // Base delay between retries (exponential backoff)
-  // Placeholder messages for empty chat input
-  INPUT_PLACEHOLDERS: [
-    "What's on your mind?",
-    'Ask me anything...',
-    'How can I help you today?',
-    'Your secrets are safe here...',
-  ],
+  // Placeholder for the input before a conversation has started
+  INPUT_PLACEHOLDER: 'How can I help you today?',
+  // Placeholder once the assistant has replied at least once
+  REPLY_PLACEHOLDER: 'Reply to Tin...',
   // Base document title used when no chat title is meaningful
   BASE_DOCUMENT_TITLE: 'Tinfoil Private Chat',
 } as const

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -77,7 +77,7 @@ export const CONSTANTS = {
   MESSAGE_SEND_RETRY_DELAY_MS: 1000, // Base delay between retries (exponential backoff)
   // Placeholder for the input before a conversation has started
   INPUT_PLACEHOLDER: 'How can I help you today?',
-  // Placeholder once the assistant has replied at least once
+  // Placeholder once a conversation has started
   REPLY_PLACEHOLDER: 'Reply to Tin...',
   // Base document title used when no chat title is meaningful
   BASE_DOCUMENT_TITLE: 'Tinfoil Private Chat',

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -42,6 +42,19 @@ const EFFORT_FLYOUT_WIDTH_PX = 240
 const EFFORT_FLYOUT_GAP_PX = 8
 const VIEWPORT_MARGIN_PX = 10
 
+// The top section grows to fill the available height so tall screens see
+// more models before the "Other models" fold. Row heights are estimated from
+// the Tailwind classes below (padding plus text line heights) rather than
+// measured, so the count is known before the first paint.
+const MIN_TOP_MODEL_COUNT = 3
+const MENU_PADDING_PX = 16
+const MENU_DIVIDER_HEIGHT_PX = 9
+const AUTO_MODEL_ROW_HEIGHT_PX = 40
+const MODEL_ROW_HEIGHT_PX = 56
+const EFFORT_ROW_HEIGHT_PX = 40
+const THINKING_ROW_HEIGHT_PX = 56
+const OTHER_MODELS_ROW_HEIGHT_PX = 40
+
 type ModelSelectorProps = {
   selectedModel: AIModel
   onSelect: (model: AIModel) => void
@@ -286,9 +299,22 @@ export function ModelSelector({
       (model.type === 'chat' || model.type === 'code') && model.chat === true,
   )
 
-  const TOP_MODEL_COUNT = 3
-  const topModels = displayModels.slice(0, TOP_MODEL_COUNT)
-  const otherModels = displayModels.slice(TOP_MODEL_COUNT)
+  const availableHeight = Number.parseInt(dynamicStyles.maxHeight, 10) || 0
+  const fixedHeight =
+    MENU_PADDING_PX +
+    autoModels.length * AUTO_MODEL_ROW_HEIGHT_PX +
+    (autoModels.length > 0 ? MENU_DIVIDER_HEIGHT_PX : 0) +
+    (showEffort || showThinkingToggle ? MENU_DIVIDER_HEIGHT_PX : 0) +
+    (showEffort ? EFFORT_ROW_HEIGHT_PX : 0) +
+    (showThinkingToggle ? THINKING_ROW_HEIGHT_PX : 0) +
+    MENU_DIVIDER_HEIGHT_PX +
+    OTHER_MODELS_ROW_HEIGHT_PX
+  const topModelCount = Math.max(
+    MIN_TOP_MODEL_COUNT,
+    Math.floor((availableHeight - fixedHeight) / MODEL_ROW_HEIGHT_PX),
+  )
+  const topModels = displayModels.slice(0, topModelCount)
+  const otherModels = displayModels.slice(topModelCount)
 
   const getModelIcon = (model: BaseModel) => {
     if (failedImages[model.modelName]) return '/icon.png'

--- a/tests/ui/smoke.test.ts
+++ b/tests/ui/smoke.test.ts
@@ -100,15 +100,10 @@ test.describe('Smoke Tests', () => {
     const textarea = page.locator('#chat-input')
     await expect(textarea).toBeVisible({ timeout: 10000 })
 
-    // Should have a valid placeholder (randomly selected from a list)
-    const placeholder = await textarea.getAttribute('placeholder')
-    const validPlaceholders = [
-      "What's on your mind?",
-      'Ask me anything...',
+    await expect(textarea).toHaveAttribute(
+      'placeholder',
       'How can I help you today?',
-      'Your secrets are safe here...',
-    ]
-    expect(validPlaceholders).toContain(placeholder)
+    )
 
     // Should be able to type in it
     await textarea.fill('Hello, this is a test message')


### PR DESCRIPTION
## Summary
- **Chat page:** once a conversation has started the composer collapses into a single row (`+` / textarea / mic / send). The context-usage ring and model selector move to a footer under the card, right-aligned, with the "AI can make mistakes" disclaimer left-aligned beside them.
- **Welcome screen:** greeting is centered with the "Your chats are private by design" note directly underneath, styled as a pill matching the persona suggestions. The input keeps its taller two-row layout with the model selector inside the card, and uses a single fixed placeholder ("How can I help you today?") instead of a random one.
- **Model picker:** the top section fills the available height, so tall screens see more models before the "Other models" fold (minimum of 3 remains for short viewports).

## Notes
- Placeholder strings moved into `CONSTANTS` (`INPUT_PLACEHOLDER`, `REPLY_PLACEHOLDER`); the random-placeholder state and its SSR-hydration workaround are removed.
- The `chat-input.tsx` diff is large due to re-indentation from the new compact-mode wrapper; `git diff -w` shows ~50 changed lines.