### PR TITLE
feat: rename the assistant to Al and drop bundled config fallbacks

### DIFF
--- a/src/components/chat/chat-announcer.tsx
+++ b/src/components/chat/chat-announcer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import type { Message } from './types'
 
-const RESPONDING_ANNOUNCEMENT = 'Tin is responding'
+const RESPONDING_ANNOUNCEMENT = 'Al is responding'
 
 type ChatAnnouncerProps = {
   messages: Message[]

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -524,6 +524,7 @@ export function ChatInterface({
   const [systemPrompt, setSystemPrompt] = useState<string>('')
   const [rules, setRules] = useState<string>('')
   const [isLoadingConfig, setIsLoadingConfig] = useState(true)
+  const [configLoadFailed, setConfigLoadFailed] = useState(false)
   const [logoAnimDone, setLogoAnimDone] = useState(false)
   const handleLogoAnimFinished = useCallback(() => {
     setLogoAnimDone(true)
@@ -802,7 +803,9 @@ export function ChatInterface({
     initializeRenderers()
   }, [])
 
-  // Load models and system prompt immediately in parallel.
+  // Load models and system prompt immediately in parallel. Cached values
+  // seed the first render, but the controlplane response is authoritative:
+  // a failed fetch blocks the app even when a cache exists.
   useEffect(() => {
     let cancelled = false
     const configStartedAt = startPerformanceTimer()
@@ -836,21 +839,25 @@ export function ChatInterface({
           getAIModels(),
         ])
 
-        if (!cancelled) {
-          setSystemPrompt(promptData.systemPrompt)
-          setRules(promptData.rules)
-          setModels(models)
+        if (cancelled) return
+        if (!promptData || !models) {
+          setConfigLoadFailed(true)
           setIsLoadingConfig(false)
-          recordConfigReady()
+          return
         }
+        setSystemPrompt(promptData.systemPrompt)
+        setRules(promptData.rules)
+        setModels(models)
+        setIsLoadingConfig(false)
+        recordConfigReady()
       } catch (error) {
         logError('Failed to load chat configuration', error, {
           component: 'ChatInterface',
           action: 'loadConfig',
         })
         if (!cancelled) {
+          setConfigLoadFailed(true)
           setIsLoadingConfig(false)
-          recordConfigReady()
         }
       }
     }
@@ -3548,7 +3555,7 @@ export function ChatInterface({
   }
 
   // Show error state if no models are available (configuration error)
-  if (!isLoadingConfig && models.length === 0) {
+  if (!isLoadingConfig && (configLoadFailed || models.length === 0)) {
     return (
       <div className="flex h-screen items-center justify-center bg-surface-chat-background px-4 font-aeonik">
         <div className="max-w-md text-center">

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -78,7 +78,7 @@ export const CONSTANTS = {
   // Placeholder for the input before a conversation has started
   INPUT_PLACEHOLDER: 'How can I help you today?',
   // Placeholder once a conversation has started
-  REPLY_PLACEHOLDER: 'Reply to Tin...',
+  REPLY_PLACEHOLDER: 'Reply to Al...',
   // Base document title used when no chat title is meaningful
   BASE_DOCUMENT_TITLE: 'Tinfoil Private Chat',
 } as const

--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -43,7 +43,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
     modelName: string
   }> => {
     try {
-      const models = await getAIModels()
+      const models = (await getAIModels()) ?? []
       const doclingModel = models.find(
         (model) => model.modelName === 'docling' || model.type === 'document',
       )
@@ -92,7 +92,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
     base64: string,
     mimeType: string,
   ): Promise<string> => {
-    const models = await getAIModels()
+    const models = (await getAIModels()) ?? []
     const fastTier: AutoTier = 'fast'
     const isMultimodalChat = (m: BaseModel) =>
       Boolean(m.multimodal && m.chat && m.type === 'chat')
@@ -254,7 +254,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
 
       // For audio files, transcribe via audio model
       if (isAudioFile(file)) {
-        const models = await getAIModels()
+        const models = (await getAIModels()) ?? []
         const audioModel = (
           models.find((m) => m.modelName === CONSTANTS.DEFAULT_AUDIO_MODEL) ||
           models.find((m) => m.type === 'audio')

--- a/src/components/chat/genui/config.ts
+++ b/src/components/chat/genui/config.ts
@@ -17,9 +17,9 @@
  * controlplane.
  *
  * Until the controlplane response arrives, `getGenUIConfig()` returns
- * `null`, which the prompt/tool builders treat as "use bundled defaults"
- * (i.e. all registered widgets enabled with the bundled header). This keeps
- * the first-render path working when the network is slow or offline.
+ * `null`, which the prompt/tool builders treat as "GenUI is off". The
+ * webapp blocks on the config fetch before chat becomes interactive, so
+ * this only covers the pre-fetch window.
  */
 
 export interface GenUIConfig {

--- a/src/components/chat/genui/enabled-widgets.ts
+++ b/src/components/chat/genui/enabled-widgets.ts
@@ -8,8 +8,8 @@
  * `/api/config/system-prompt` response).
  *
  * Semantics:
- *   - No controlplane config yet → expose every registered widget. Keeps
- *     the first-render path working before the network response arrives.
+ *   - No controlplane config → no widgets enabled. The allowlist is the
+ *     kill switch, so its absence fails closed.
  *   - Controlplane config present → intersect with the local registry.
  *     Widgets the controlplane lists but the webapp doesn't have are
  *     ignored (lets the controlplane reference future widget names without
@@ -23,7 +23,7 @@ import type { GenUIWidget } from './types'
 
 export function resolveEnabledWidgets(): GenUIWidget[] {
   const config = getGenUIConfig()
-  if (!config) return GENUI_WIDGETS
+  if (!config) return []
   const allowed = new Set(config.enabledWidgets)
   return GENUI_WIDGETS.filter((w) => allowed.has(w.name))
 }

--- a/src/components/chat/genui/system-prompt.ts
+++ b/src/components/chat/genui/system-prompt.ts
@@ -7,23 +7,11 @@
  *
  * The guidance header and the allowlist of enabled widgets come from the
  * controlplane via `getGenUIConfig()` so model-facing wording and on/off
- * gating can be tuned without a webapp release. When the controlplane
- * config hasn't been fetched yet, we fall back to a bundled header and
- * expose every registered widget.
+ * gating can be tuned without a webapp release. Without controlplane config
+ * no widgets are enabled and no hint is produced.
  */
 import { getGenUIConfig } from './config'
 import { resolveEnabledWidgets } from './enabled-widgets'
-
-const BUNDLED_GENUI_HEADER =
-  'You have optional render_* tools available. Default to a normal markdown ' +
-  'response. Only call a render_* tool when the user explicitly asks for ' +
-  'one of these UI elements, or when the content genuinely cannot be ' +
-  'expressed well in markdown (e.g. an interactive HTML page, a chart that ' +
-  'requires plotting, an embedded live preview). Do not use render_* tools ' +
-  'for ordinary informational answers, lists, tables, or summaries — write ' +
-  'those as regular prose and markdown. Prefer at most one render_* call ' +
-  'per response, and always pair it with a written answer rather than ' +
-  'replacing the answer with a widget.'
 
 /**
  * Returns the system-prompt hint block describing the enabled widgets, or
@@ -31,6 +19,9 @@ const BUNDLED_GENUI_HEADER =
  * provides a hint.
  */
 export function buildGenUIPromptHint(): string | null {
+  const config = getGenUIConfig()
+  if (!config) return null
+
   const enabled = resolveEnabledWidgets()
   if (enabled.length === 0) return null
 
@@ -39,6 +30,5 @@ export function buildGenUIPromptHint(): string | null {
     .map((w) => `- ${w.name}: ${w.promptHint}`)
   if (hints.length === 0) return null
 
-  const header = getGenUIConfig()?.header ?? BUNDLED_GENUI_HEADER
-  return `${header}\n${hints.join('\n')}`
+  return `${config.header}\n${hints.join('\n')}`
 }

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -250,7 +250,7 @@ const DefaultMessageComponent = ({
       className={`relative mx-auto flex w-full max-w-3xl flex-col ${isUser ? 'items-end' : 'items-start'} group mb-6`}
       data-message-role={message.role}
       role="article"
-      aria-label={isUser ? 'You said' : 'Tin said'}
+      aria-label={isUser ? 'You said' : 'Al said'}
       tabIndex={-1}
     >
       {/* Display the quoted reply preview above the user's message */}

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -2654,7 +2654,7 @@ ${encryptionKey.replace('key_', '')}
                               Generative UI
                             </div>
                             <div className="font-aeonik-fono text-xs text-content-muted">
-                              Let Tin render interactive widgets like charts and
+                              Let Al render interactive widgets like charts and
                               timelines. When off, no tool capabilities are sent
                               to the model.
                             </div>
@@ -2953,8 +2953,8 @@ ${encryptionKey.replace('key_', '')}
                           Personalize responses
                         </div>
                         <div className="font-aeonik-fono text-xs text-content-muted">
-                          Tailor Tin&apos;s replies using the details below.
-                          When off, none of these are sent to the model.
+                          Tailor Al&apos;s replies using the details below. When
+                          off, none of these are sent to the model.
                         </div>
                       </div>
                       <label className="relative inline-flex cursor-pointer items-center">
@@ -2986,7 +2986,7 @@ ${encryptionKey.replace('key_', '')}
                               Name
                             </div>
                             <div className="font-aeonik-fono text-xs text-content-muted">
-                              How should Tin call you?
+                              How should Al call you?
                             </div>
                           </div>
                           <input
@@ -3052,7 +3052,7 @@ ${encryptionKey.replace('key_', '')}
                               Conversational Traits
                             </div>
                             <div className="font-aeonik-fono text-xs text-content-muted">
-                              What traits should Tin have?
+                              What traits should Al have?
                             </div>
                           </div>
                           <div className="flex flex-wrap gap-1.5">
@@ -3090,7 +3090,7 @@ ${encryptionKey.replace('key_', '')}
                               Additional Context
                             </div>
                             <div className="font-aeonik-fono text-xs text-content-muted">
-                              Anything else Tin should know about you?
+                              Anything else Al should know about you?
                             </div>
                           </div>
                           <textarea
@@ -3098,7 +3098,7 @@ ${encryptionKey.replace('key_', '')}
                             onChange={(e) =>
                               handleContextChange(e.target.value)
                             }
-                            placeholder="Interests and other preferences you'd like Tin to know about you."
+                            placeholder="Interests and other preferences you'd like Al to know about you."
                             rows={3}
                             className={cn(
                               'w-full resize-none rounded-md border px-3 py-2 text-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-border-strong',

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -337,13 +337,14 @@ const isLocalDevelopment = (): boolean => {
   )
 }
 
-const CONFIG_CACHE_VERSION = 1
-const CONFIG_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+// The cache only seeds the first render while the controlplane request is in
+// flight. A successful response always overwrites it and a failed response
+// blocks the app, so entries never serve as an offline fallback.
+const CONFIG_CACHE_VERSION = 2
 const CONFIG_REQUEST_TIMEOUT_MS = 10_000
 
 type CachedConfig<T> = {
   version: number
-  cachedAt: number
   value: T
 }
 
@@ -365,13 +366,7 @@ function readCachedConfig<T>(
     const parsed = JSON.parse(localStorage.getItem(key) ?? '') as Partial<
       CachedConfig<unknown>
     >
-    if (
-      parsed.version !== CONFIG_CACHE_VERSION ||
-      typeof parsed.cachedAt !== 'number' ||
-      Date.now() - parsed.cachedAt < 0 ||
-      Date.now() - parsed.cachedAt > CONFIG_CACHE_MAX_AGE_MS ||
-      !validate(parsed.value)
-    ) {
+    if (parsed.version !== CONFIG_CACHE_VERSION || !validate(parsed.value)) {
       return null
     }
     return parsed.value
@@ -386,7 +381,6 @@ function writeCachedConfig<T>(key: string, value: T): void {
       key,
       JSON.stringify({
         version: CONFIG_CACHE_VERSION,
-        cachedAt: Date.now(),
         value,
       } satisfies CachedConfig<T>),
     )
@@ -453,10 +447,10 @@ export function getCachedSystemPromptAndRules(): SystemPromptAndRules | null {
   }
 }
 
-// Fetch models from the API
-export const getAIModels = async (): Promise<BaseModel[]> => {
+// Fetch models from the API. Returns null when the controlplane is
+// unreachable so callers can block rather than proceed without config.
+export const getAIModels = async (): Promise<BaseModel[] | null> => {
   const isLocalDev = isLocalDevelopment()
-  const cachedModels = getCachedAIModels()
 
   // In dev mode on localhost, return hardcoded models instead of fetching
   if (IS_DEV && isLocalDev) {
@@ -490,14 +484,15 @@ export const getAIModels = async (): Promise<BaseModel[]> => {
     logError('Failed to fetch AI models', error, {
       component: 'getAIModels',
     })
-    return cachedModels ?? []
+    return null
   }
 }
 
-// Fetch system prompt and rules from the API
+// Fetch system prompt and rules from the API. Returns null when the
+// controlplane is unreachable so callers can block rather than proceed
+// without config.
 export const getSystemPromptAndRules =
-  async (): Promise<SystemPromptAndRules> => {
-    const cachedPrompt = getCachedSystemPromptAndRules()
+  async (): Promise<SystemPromptAndRules | null> => {
     try {
       const url = `${API_BASE_URL}/api/config/system-prompt`
       const response = await fetchConfig(url)
@@ -522,16 +517,7 @@ export const getSystemPromptAndRules =
       logError('Failed to fetch system prompt', error, {
         component: 'getSystemPromptAndRules',
       })
-      if (!cachedPrompt) {
-        setGenUIConfig(null)
-      }
-      return (
-        cachedPrompt ?? {
-          systemPrompt:
-            'You are an intelligent and helpful assistant named Tin.',
-          rules: '',
-        }
-      )
+      return null
     }
   }
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -1,4 +1,7 @@
-import { setGenUIConfig } from '@/components/chat/genui/config'
+import {
+  setGenUIConfig,
+  type GenUIConfig,
+} from '@/components/chat/genui/config'
 import { API_BASE_URL, IS_DEV } from '@/config'
 import {
   CONFIG_CACHED_MODELS,
@@ -353,8 +356,8 @@ type SystemPromptAndRules = {
   rules: string
 }
 
-type CachedSystemPromptAndRules = SystemPromptAndRules & {
-  genUI?: unknown
+type SystemPromptResponse = SystemPromptAndRules & {
+  genUI: GenUIConfig
 }
 
 function readCachedConfig<T>(
@@ -404,15 +407,25 @@ function isBaseModelArray(value: unknown): value is BaseModel[] {
   )
 }
 
-function isSystemPromptAndRules(
-  value: unknown,
-): value is CachedSystemPromptAndRules {
+function isGenUIConfig(value: unknown): value is GenUIConfig {
+  const candidate = value as Record<string, unknown> | null
+  return (
+    typeof candidate === 'object' &&
+    candidate !== null &&
+    typeof candidate.header === 'string' &&
+    Array.isArray(candidate.enabledWidgets) &&
+    candidate.enabledWidgets.every((w) => typeof w === 'string')
+  )
+}
+
+function isSystemPromptResponse(value: unknown): value is SystemPromptResponse {
   const candidate = value as Record<string, unknown> | null
   return (
     typeof candidate === 'object' &&
     candidate !== null &&
     typeof candidate.systemPrompt === 'string' &&
-    typeof candidate.rules === 'string'
+    typeof candidate.rules === 'string' &&
+    isGenUIConfig(candidate.genUI)
   )
 }
 
@@ -437,10 +450,10 @@ export function getCachedAIModels(): BaseModel[] | null {
 export function getCachedSystemPromptAndRules(): SystemPromptAndRules | null {
   const cached = readCachedConfig(
     CONFIG_CACHED_SYSTEM_PROMPT,
-    isSystemPromptAndRules,
+    isSystemPromptResponse,
   )
   if (!cached) return null
-  applyGenUIConfigFromResponse(cached.genUI)
+  setGenUIConfig(cached.genUI)
   return {
     systemPrompt: cached.systemPrompt,
     rules: cached.rules,
@@ -501,18 +514,18 @@ export const getSystemPromptAndRules =
         throw new Error(`Failed to fetch system prompt: ${response.status}`)
       }
 
-      const data = await response.json()
-      const result: CachedSystemPromptAndRules = {
-        systemPrompt: data.systemPrompt,
-        rules: data.rules,
-        genUI: data?.genUI,
-      }
-      if (!isSystemPromptAndRules(result)) {
+      const data: unknown = await response.json()
+      if (!isSystemPromptResponse(data)) {
         throw new Error('System prompt response is malformed')
       }
-      applyGenUIConfigFromResponse(result.genUI)
+      const result: SystemPromptResponse = {
+        systemPrompt: data.systemPrompt,
+        rules: data.rules,
+        genUI: data.genUI,
+      }
+      setGenUIConfig(result.genUI)
       writeCachedConfig(CONFIG_CACHED_SYSTEM_PROMPT, result)
-      return result
+      return { systemPrompt: result.systemPrompt, rules: result.rules }
     } catch (error) {
       logError('Failed to fetch system prompt', error, {
         component: 'getSystemPromptAndRules',
@@ -520,29 +533,6 @@ export const getSystemPromptAndRules =
       return null
     }
   }
-
-/**
- * Validates the optional `genUI` block from the system-prompt response and
- * pushes it into the runtime config used by the GenUI prompt and tool
- * builders. Malformed or missing payloads clear the runtime config so the
- * bundled defaults take over, rather than leaving stale config from an
- * earlier successful fetch active.
- */
-export function applyGenUIConfigFromResponse(raw: unknown): void {
-  if (!raw || typeof raw !== 'object') {
-    setGenUIConfig(null)
-    return
-  }
-  const obj = raw as Record<string, unknown>
-  if (typeof obj.header !== 'string' || !Array.isArray(obj.enabledWidgets)) {
-    setGenUIConfig(null)
-    return
-  }
-  const enabledWidgets = obj.enabledWidgets.filter(
-    (w): w is string => typeof w === 'string',
-  )
-  setGenUIConfig({ header: obj.header, enabledWidgets })
-}
 
 // Fetch memory prompt from the API
 export const getMemoryPrompt = async (): Promise<string> => {

--- a/src/pages/share/[[...slug]].tsx
+++ b/src/pages/share/[[...slug]].tsx
@@ -121,7 +121,7 @@ export default function SharePage() {
           return
         }
 
-        const models = await getAIModels()
+        const models = (await getAIModels()) ?? []
         const chatModel = models.find((m) => m.type === 'chat') || models[0]
         if (!chatModel) {
           setErrorMessage('Failed to load model configuration')

--- a/src/services/memory/fact-extractor.ts
+++ b/src/services/memory/fact-extractor.ts
@@ -98,7 +98,7 @@ export async function extractFacts(params: {
     return { operations: [], processedCount: 0 }
   }
 
-  const models = await getAIModels()
+  const models = (await getAIModels()) ?? []
   // Structured outputs require a model that supports it - use gpt-oss-120b specifically
   const structuredModel =
     models.find((m) => m.modelName === 'gpt-oss-120b') || models[0]

--- a/tests/components/chat/genui/config.test.ts
+++ b/tests/components/chat/genui/config.test.ts
@@ -24,7 +24,7 @@ function filterAllowed<T extends { name: string }>(
   registry: readonly T[],
 ): readonly T[] {
   const config = getGenUIConfig()
-  if (!config) return registry
+  if (!config) return []
   const allowed = new Set(config.enabledWidgets)
   return registry.filter((w) => allowed.has(w.name))
 }
@@ -50,8 +50,8 @@ describe('GenUI runtime config', () => {
 })
 
 describe('widget allowlist filter', () => {
-  it('exposes every widget when no config is set', () => {
-    expect(filterAllowed(widgetFixture)).toHaveLength(widgetFixture.length)
+  it('exposes no widgets when no config is set', () => {
+    expect(filterAllowed(widgetFixture)).toHaveLength(0)
   })
 
   it('restricts widgets to the controlplane allowlist', () => {

--- a/tests/components/chat/genui/registry.test.ts
+++ b/tests/components/chat/genui/registry.test.ts
@@ -1,11 +1,28 @@
+import { setGenUIConfig } from '@/components/chat/genui/config'
 import {
   buildGenUIToolSchemas,
   GENUI_WIDGETS,
   GENUI_WIDGETS_BY_NAME,
 } from '@/components/chat/genui/registry'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+beforeEach(() => {
+  setGenUIConfig({
+    header: 'h',
+    enabledWidgets: GENUI_WIDGETS.map((w) => w.name),
+  })
+})
+
+afterEach(() => {
+  setGenUIConfig(null)
+})
 
 describe('GenUI registry', () => {
+  it('builds no tool schemas without controlplane config', () => {
+    setGenUIConfig(null)
+    expect(buildGenUIToolSchemas()).toHaveLength(0)
+  })
+
   it('has unique render_* tool names', () => {
     const names = GENUI_WIDGETS.map((w) => w.name)
     expect(names).toEqual(Array.from(new Set(names)))

--- a/tests/config/genui-config-reset.test.ts
+++ b/tests/config/genui-config-reset.test.ts
@@ -49,20 +49,13 @@ describe('applyGenUIConfigFromResponse', () => {
     })
   })
 
-  it('clears stale config when the system prompt request falls back', async () => {
-    setGenUIConfig({ header: 'stale', enabledWidgets: ['render_chart'] })
+  it('returns null when the system prompt request fails', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
 
-    const result = await getSystemPromptAndRules()
-
-    expect(result).toEqual({
-      systemPrompt: 'You are an intelligent and helpful assistant named Tin.',
-      rules: '',
-    })
-    expect(getGenUIConfig()).toBeNull()
+    await expect(getSystemPromptAndRules()).resolves.toBeNull()
   })
 
-  it('restores cached configuration while the network refreshes', async () => {
+  it('seeds the cache from a successful response without serving it as a fallback', async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({
@@ -88,17 +81,10 @@ describe('applyGenUIConfigFromResponse', () => {
       enabledWidgets: ['render_chart'],
     })
 
-    await expect(getSystemPromptAndRules()).resolves.toEqual({
-      systemPrompt: 'Cached prompt',
-      rules: 'Cached rules',
-    })
-    expect(getGenUIConfig()).toEqual({
-      header: 'cached',
-      enabledWidgets: ['render_chart'],
-    })
+    await expect(getSystemPromptAndRules()).resolves.toBeNull()
   })
 
-  it('restores a cached model list after a request failure', async () => {
+  it('returns null for models after a request failure even when cached', async () => {
     const model = {
       modelName: 'gpt-oss-120b',
       image: 'openai.png',
@@ -120,6 +106,6 @@ describe('applyGenUIConfigFromResponse', () => {
     const fetchedModels = await getAIModels()
     expect(fetchedModels).toContainEqual(model)
     expect(getCachedAIModels()).toEqual(fetchedModels)
-    await expect(getAIModels()).resolves.toEqual(fetchedModels)
+    await expect(getAIModels()).resolves.toBeNull()
   })
 })

--- a/tests/config/genui-config-reset.test.ts
+++ b/tests/config/genui-config-reset.test.ts
@@ -1,6 +1,5 @@
 import { getGenUIConfig, setGenUIConfig } from '@/components/chat/genui/config'
 import {
-  applyGenUIConfigFromResponse,
   getAIModels,
   getCachedAIModels,
   getCachedSystemPromptAndRules,
@@ -14,42 +13,77 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-describe('applyGenUIConfigFromResponse', () => {
-  it('applies a valid payload to the runtime config', () => {
-    applyGenUIConfigFromResponse({
-      header: 'use widgets sparingly',
-      enabledWidgets: ['render_stat_cards', 'render_chart'],
+const validResponse = {
+  systemPrompt: 'Server prompt',
+  rules: 'Server rules',
+  genUI: { header: 'use widgets sparingly', enabledWidgets: ['render_chart'] },
+}
+
+function okResponse(body: unknown) {
+  return { ok: true, json: vi.fn().mockResolvedValue(body) }
+}
+
+describe('getSystemPromptAndRules', () => {
+  it('applies the genUI block from a valid response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse(validResponse)))
+
+    await expect(getSystemPromptAndRules()).resolves.toEqual({
+      systemPrompt: 'Server prompt',
+      rules: 'Server rules',
     })
+    expect(getGenUIConfig()).toEqual(validResponse.genUI)
+  })
+
+  it('rejects a response without a genUI block', async () => {
+    setGenUIConfig({ header: 'stale', enabledWidgets: ['render_chart'] })
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          okResponse({ systemPrompt: 'p', rules: 'r', genUI: undefined }),
+        ),
+    )
+
+    await expect(getSystemPromptAndRules()).resolves.toBeNull()
     expect(getGenUIConfig()).toEqual({
-      header: 'use widgets sparingly',
-      enabledWidgets: ['render_stat_cards', 'render_chart'],
+      header: 'stale',
+      enabledWidgets: ['render_chart'],
     })
   })
 
-  it('clears stale config when the payload is missing entirely', () => {
-    setGenUIConfig({ header: 'stale', enabledWidgets: ['render_chart'] })
-    applyGenUIConfigFromResponse(undefined)
+  it('rejects a response with a malformed genUI block', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        okResponse({
+          systemPrompt: 'p',
+          rules: 'r',
+          genUI: { header: 42, enabledWidgets: 'oops' },
+        }),
+      ),
+    )
+
+    await expect(getSystemPromptAndRules()).resolves.toBeNull()
     expect(getGenUIConfig()).toBeNull()
   })
 
-  it('clears stale config when the payload is malformed', () => {
-    setGenUIConfig({ header: 'stale', enabledWidgets: ['render_chart'] })
-    applyGenUIConfigFromResponse({ header: 42, enabledWidgets: 'oops' })
-    expect(getGenUIConfig()).toBeNull()
+  it('rejects widget lists containing non-string entries', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        okResponse({
+          systemPrompt: 'p',
+          rules: 'r',
+          genUI: { header: 'h', enabledWidgets: ['render_chart', 7, null] },
+        }),
+      ),
+    )
+
+    await expect(getSystemPromptAndRules()).resolves.toBeNull()
   })
 
-  it('drops non-string widget names while keeping valid ones', () => {
-    applyGenUIConfigFromResponse({
-      header: 'h',
-      enabledWidgets: ['render_stat_cards', 7, null, 'render_chart'],
-    })
-    expect(getGenUIConfig()).toEqual({
-      header: 'h',
-      enabledWidgets: ['render_stat_cards', 'render_chart'],
-    })
-  })
-
-  it('returns null when the system prompt request fails', async () => {
+  it('returns null when the request fails', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
 
     await expect(getSystemPromptAndRules()).resolves.toBeNull()
@@ -58,14 +92,7 @@ describe('applyGenUIConfigFromResponse', () => {
   it('seeds the cache from a successful response without serving it as a fallback', async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: vi.fn().mockResolvedValue({
-          systemPrompt: 'Cached prompt',
-          rules: 'Cached rules',
-          genUI: { header: 'cached', enabledWidgets: ['render_chart'] },
-        }),
-      })
+      .mockResolvedValueOnce(okResponse(validResponse))
       .mockRejectedValueOnce(new Error('network down'))
     vi.stubGlobal('fetch', fetchMock)
 
@@ -73,18 +100,17 @@ describe('applyGenUIConfigFromResponse', () => {
     setGenUIConfig(null)
 
     expect(getCachedSystemPromptAndRules()).toEqual({
-      systemPrompt: 'Cached prompt',
-      rules: 'Cached rules',
+      systemPrompt: 'Server prompt',
+      rules: 'Server rules',
     })
-    expect(getGenUIConfig()).toEqual({
-      header: 'cached',
-      enabledWidgets: ['render_chart'],
-    })
+    expect(getGenUIConfig()).toEqual(validResponse.genUI)
 
     await expect(getSystemPromptAndRules()).resolves.toBeNull()
   })
+})
 
-  it('returns null for models after a request failure even when cached', async () => {
+describe('getAIModels', () => {
+  it('returns null after a request failure even when cached', async () => {
     const model = {
       modelName: 'gpt-oss-120b',
       image: 'openai.png',
@@ -96,10 +122,7 @@ describe('applyGenUIConfigFromResponse', () => {
     }
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: vi.fn().mockResolvedValue([model]),
-      })
+      .mockResolvedValueOnce(okResponse([model]))
       .mockRejectedValueOnce(new Error('network down'))
     vi.stubGlobal('fetch', fetchMock)
 


### PR DESCRIPTION
## Summary
- Renames the assistant from "Tin" to "Al" in all UI copy (placeholders, aria labels, settings).
- Removes the hardcoded fallback system prompt. The controlplane response is now authoritative: a failed fetch of models or system prompt shows the existing "Something went wrong" screen even when a localStorage cache exists. The cache remains solely as a warm-start seed for the first render and no longer has a TTL (cache version bumped to invalidate stale "Tin" entries).
- Removes the bundled GenUI header and the "no config = every widget enabled" default. Without a controlplane `genUI` block, no render tools are exposed and no hint is added; a response missing or malforming `genUI` is rejected like any other malformed config.

Depends on tinfoilsh/controlplane#661 for the prompt rename; the fallback removal is independent.

## Test plan
- [x] `vitest run` (2069 tests pass)
- [x] `tsc --noEmit`
- [ ] Manual: block `/api/config/system-prompt` in devtools with a warm cache and confirm the error screen appears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the assistant from "Tin" to "Al" in all UI copy and makes the controlplane response authoritative for models, system prompt, and GenUI config. A failed fetch previously fell back to a bundled prompt with every widget enabled; now it blocks chat with the existing error screen even when a stale localStorage cache exists.

**Behavior changes**
- `getAIModels()` and `getSystemPromptAndRules()` return `null` on failure and callers short-circuit to the error screen.
- The config cache only seeds the first render, no longer has a TTL, and is version-bumped to invalidate stale "Tin" entries.
- A response missing or malforming `genUI` is rejected; without a `genUI` block no render tools are exposed and no prompt hint is added.

**Rollout**
- The prompt rename pairs with `tinfoilsh/controlplane` #661; the fallback removal is independent.

<sup>Written for commit 6213bfa7058901aebdf3c430af73a83c4115a467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

