### PR TITLE
refactor: rely only on numeric model context window sizes

### DIFF
--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -136,7 +136,6 @@ export type BaseModel = {
   descriptionShort?: string
   details?: string
   parameters?: string
-  contextWindow?: string
   contextWindowTokens?: number
   recommendedUse?: string
   supportedLanguages?: string
@@ -215,7 +214,6 @@ export const getAutoModels = (models: BaseModel[]): BaseModel[] => {
       isAuto: true,
       tier,
       multimodal: members.some((m) => m.multimodal === true),
-      contextWindow: smallestMember.contextWindow,
       contextWindowTokens: resolveContextWindowTokens(smallestMember),
     })
   }

--- a/src/utils/token-estimation.ts
+++ b/src/utils/token-estimation.ts
@@ -9,11 +9,10 @@ import {
 // the remainder is headroom for the system prompt and the model's response.
 export const CONTEXT_WINDOW_USAGE_RATIO = 0.8
 
-export const DEFAULT_CONTEXT_WINDOW_TOKENS = 64000
+export const DEFAULT_CONTEXT_WINDOW_TOKENS = 128000
 
 export type ContextWindowConfig = {
   contextWindowTokens?: number
-  contextWindow?: string
 }
 
 // Roughly estimate token count based on character length (≈4 chars per token)
@@ -22,39 +21,10 @@ export function estimateTokenCount(text: string | undefined): number {
   return Math.ceil(text.length / 4)
 }
 
-// Any parsed window below this is treated as an unrecognized format (e.g. a
-// suffix this parser predates) rather than a real limit; zeroing the budget
-// would silently archive the whole conversation.
-const MIN_PLAUSIBLE_CONTEXT_WINDOW_TOKENS = 1000
-
-// Parse values like "64k tokens" → 64000 or "1M tokens" → 1000000
-export function parseContextWindowTokens(contextWindow?: string): number {
-  if (!contextWindow) return DEFAULT_CONTEXT_WINDOW_TOKENS
-  const match = contextWindow.match(/(\d+(?:\.\d+)?)\s*([km])?/i)
-  if (!match) return DEFAULT_CONTEXT_WINDOW_TOKENS
-  let tokens = parseFloat(match[1])
-  const suffix = match[2]?.toLowerCase()
-  if (suffix === 'k') tokens *= 1_000
-  if (suffix === 'm') tokens *= 1_000_000
-  tokens = Math.round(tokens)
-  if (tokens < MIN_PLAUSIBLE_CONTEXT_WINDOW_TOKENS) {
-    return DEFAULT_CONTEXT_WINDOW_TOKENS
-  }
-  return tokens
-}
-
 export function resolveContextWindowTokens(
   config: ContextWindowConfig | undefined,
 ): number {
-  const configuredTokens = config?.contextWindowTokens
-  if (
-    Number.isFinite(configuredTokens) &&
-    configuredTokens !== undefined &&
-    configuredTokens >= MIN_PLAUSIBLE_CONTEXT_WINDOW_TOKENS
-  ) {
-    return Math.round(configuredTokens)
-  }
-  return parseContextWindowTokens(config?.contextWindow)
+  return config?.contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS
 }
 
 export function getSmallestContextWindowTokens(

--- a/tests/components/chat/chat-messages-recovery.test.tsx
+++ b/tests/components/chat/chat-messages-recovery.test.tsx
@@ -79,7 +79,7 @@ const baseProps = {
   pendingRecoveries: [recovery],
   isDarkMode: false,
   chatId: 'chat-1',
-  models: [{ id: 'model-1', contextWindow: 1000 }] as any,
+  models: [{ id: 'model-1', contextWindowTokens: 1000 }] as any,
   selectedModel: 'model-1',
 }
 

--- a/tests/config/models-reasoning-history.test.ts
+++ b/tests/config/models-reasoning-history.test.ts
@@ -13,7 +13,6 @@ import { describe, expect, it } from 'vitest'
 const model = (
   modelName: string,
   policy?: ReasoningHistoryPolicy,
-  contextWindow?: string,
   contextWindowTokens?: number,
 ): BaseModel => ({
   modelName,
@@ -23,7 +22,6 @@ const model = (
   description: '',
   type: 'chat',
   chat: true,
-  contextWindow,
   contextWindowTokens,
   reasoningConfig: policy ? { reasoningHistoryPolicy: policy } : undefined,
 })
@@ -65,21 +63,9 @@ describe('getReasoningHistoryPolicy', () => {
   })
 
   it('uses the smallest Auto candidate context window', () => {
-    expect(
-      getResolvedModelContextWindowTokens({
-        model: model('large', undefined, '256k tokens'),
-        autoCandidates: [
-          model('large', undefined, '256k tokens'),
-          model('small', undefined, '128k tokens'),
-        ],
-      }),
-    ).toBe(128000)
-  })
-
-  it('prefers numeric context windows for Auto candidates', () => {
     const candidates = [
-      model('large', undefined, '1k tokens', 256000),
-      model('small', undefined, '999k tokens', 128000),
+      model('large', undefined, 256000),
+      model('small', undefined, 32000),
     ]
     candidates.forEach((candidate) => {
       candidate.attributes = ['smart']
@@ -90,7 +76,7 @@ describe('getReasoningHistoryPolicy', () => {
         model: candidates[0],
         autoCandidates: candidates,
       }),
-    ).toBe(128000)
-    expect(getAutoModels(candidates)[0].contextWindowTokens).toBe(128000)
+    ).toBe(32000)
+    expect(getAutoModels(candidates)[0].contextWindowTokens).toBe(32000)
   })
 })

--- a/tests/services/inference/chat-query-builder.test.ts
+++ b/tests/services/inference/chat-query-builder.test.ts
@@ -41,7 +41,6 @@ describe('ChatQueryBuilder', () => {
     const messages = ChatQueryBuilder.buildMessages({
       model: {
         ...model,
-        contextWindow: '256k tokens',
         contextWindowTokens: 1000,
       },
       systemPrompt: '',

--- a/tests/utils/token-estimation.test.ts
+++ b/tests/utils/token-estimation.test.ts
@@ -2,13 +2,13 @@ import type { Message } from '@/components/chat/types'
 import { REASONING_HISTORY_POLICIES } from '@/utils/reasoning-history'
 import {
   CONTEXT_WINDOW_USAGE_RATIO,
+  DEFAULT_CONTEXT_WINDOW_TOKENS,
   estimateMessageTokens,
   estimateTokenCount,
   findContextStartIndex,
   getContextTokenBudget,
   getHistoryTokenBudget,
   getSmallestContextWindowTokens,
-  parseContextWindowTokens,
   resolveContextWindowTokens,
   selectMessagesWithinBudget,
 } from '@/utils/token-estimation'
@@ -34,58 +34,29 @@ describe('estimateTokenCount', () => {
   })
 })
 
-describe('parseContextWindowTokens', () => {
-  it('parses "64k tokens" style values', () => {
-    expect(parseContextWindowTokens('64k tokens')).toBe(64000)
-    expect(parseContextWindowTokens('256K tokens')).toBe(256000)
-    expect(parseContextWindowTokens('32000')).toBe(32000)
-  })
-
-  it('parses "1M tokens" style values', () => {
-    expect(parseContextWindowTokens('1M tokens')).toBe(1000000)
-    expect(parseContextWindowTokens('1.5m tokens')).toBe(1500000)
-  })
-
-  it('falls back to a default for missing or malformed values', () => {
-    expect(parseContextWindowTokens(undefined)).toBe(64000)
-    expect(parseContextWindowTokens('unknown')).toBe(64000)
-  })
-
-  it('falls back to a default for implausibly small windows', () => {
-    expect(parseContextWindowTokens('1 tokens')).toBe(64000)
-    expect(parseContextWindowTokens('512')).toBe(64000)
-  })
-})
-
 describe('resolveContextWindowTokens', () => {
-  it('prefers numeric model metadata', () => {
-    expect(
-      resolveContextWindowTokens({
-        contextWindowTokens: 128000,
-        contextWindow: '1k tokens',
-      }),
-    ).toBe(128000)
-  })
-
-  it('falls back to legacy display metadata', () => {
-    expect(resolveContextWindowTokens({ contextWindow: '256k tokens' })).toBe(
+  it('uses the numeric model metadata', () => {
+    expect(resolveContextWindowTokens({ contextWindowTokens: 256000 })).toBe(
       256000,
     )
-    expect(
-      resolveContextWindowTokens({
-        contextWindowTokens: 0,
-        contextWindow: '32k tokens',
-      }),
-    ).toBe(32000)
   })
 
-  it('finds the smallest mixed-format context window', () => {
+  it('falls back to the default when the model reports no window', () => {
+    expect(resolveContextWindowTokens({})).toBe(DEFAULT_CONTEXT_WINDOW_TOKENS)
+    expect(resolveContextWindowTokens(undefined)).toBe(
+      DEFAULT_CONTEXT_WINDOW_TOKENS,
+    )
+  })
+
+  it('finds the smallest context window across candidates', () => {
     expect(
       getSmallestContextWindowTokens([
-        { contextWindowTokens: 256000, contextWindow: '1k tokens' },
-        { contextWindow: '128k tokens' },
+        { contextWindowTokens: 256000 },
+        { contextWindowTokens: 32000 },
+        {},
       ]),
-    ).toBe(128000)
+    ).toBe(32000)
+    expect(getSmallestContextWindowTokens([])).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary
- Drop the legacy human-readable `contextWindow` string from `BaseModel` and the `parseContextWindowTokens` string parser.
- `resolveContextWindowTokens` now reads `contextWindowTokens` directly, falling back to `DEFAULT_CONTEXT_WINDOW_TOKENS` when a model reports none.
- Raise the default from 64k to 128k tokens and remove the 1k "plausibility floor" that silently swapped small values for the default.
- Update test fixtures accordingly.

## Why
The controlplane is deprecating the `contextWindow` string in `models.json` (tinfoilsh/controlplane#662) and will remove it once clients no longer read it. The matching iOS change is tinfoilsh/tinfoil-ios#342.

## Test plan
- [x] `npx vitest run` (198 files, 2064 tests)
- [x] `npx tsc --noEmit`
- [x] `eslint` on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the legacy human-readable `contextWindow` string so context windows come only from numeric `contextWindowTokens`, matching the controlplane deprecation of that field. Models without a numeric window now fall back to a 128k default (up from 64k), and the 1k plausibility floor that silently replaced small values is removed.

**Refactors**
- Removes `parseContextWindowTokens` and its tests.
- Auto-model resolution now only uses the smallest member's numeric `contextWindowTokens`.

<sup>Written for commit 1860fc2cffbf5a4d04eb304517f8e0bef35b8486. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

