### PR TITLE
feat: read chat model settings from the server's chatConfig block

### DIFF
--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -99,7 +99,8 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
     // Prefer a fast multimodal model over larger reasoning-heavy ones
     const multimodalModel =
       models.find(
-        (m) => isMultimodalChat(m) && m.attributes?.includes(fastTier),
+        (m) =>
+          isMultimodalChat(m) && m.chatConfig?.attributes?.includes(fastTier),
       ) ?? models.find(isMultimodalChat)
     if (!multimodalModel) {
       throw new Error('No multimodal model available')

--- a/src/components/chat/hooks/use-reasoning-effort.ts
+++ b/src/components/chat/hooks/use-reasoning-effort.ts
@@ -119,13 +119,13 @@ export function useThinkingEnabled() {
 }
 
 export function isReasoningModel(model: BaseModel | undefined): boolean {
-  return !!model?.reasoningConfig
+  return !!model?.chatConfig?.reasoningConfig
 }
 
 export function supportsReasoningEffort(model: BaseModel | undefined): boolean {
-  return !!model?.reasoningConfig?.supportsEffort
+  return !!model?.chatConfig?.reasoningConfig?.supportsEffort
 }
 
 export function supportsThinkingToggle(model: BaseModel | undefined): boolean {
-  return !!model?.reasoningConfig?.supportsToggle
+  return !!model?.chatConfig?.reasoningConfig?.supportsToggle
 }

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -424,11 +424,11 @@ export function ModelSelector({
             </>
           )}
         </div>
-        {!model.isAuto && model.descriptionShort ? (
+        {!model.isAuto && model.chatConfig?.descriptionShort ? (
           <div className="flex min-w-0 flex-1 flex-col">
             <span className="font-medium">{model.name}</span>
             <span className="text-xs text-content-muted">
-              {model.descriptionShort}
+              {model.chatConfig.descriptionShort}
             </span>
           </div>
         ) : (

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -361,7 +361,7 @@ const isLocalDevelopment = (): boolean => {
 // The cache only seeds the first render while the controlplane request is in
 // flight. A successful response always overwrites it and a failed response
 // blocks the app, so entries never serve as an offline fallback.
-const CONFIG_CACHE_VERSION = 2
+const CONFIG_CACHE_VERSION = 3
 const CONFIG_REQUEST_TIMEOUT_MS = 10_000
 
 type CachedConfig<T> = {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -27,21 +27,23 @@ const DEV_MODELS: BaseModel[] = [
     name: 'Gemma 4 31B',
     nameShort: 'Gemma 4',
     description: 'Google Gemma 4 31B',
-    descriptionShort: 'Best for everyday tasks with images',
     type: 'chat',
     chat: true,
     multimodal: true,
-    reasoningConfig: {
-      supportsToggle: true,
-      defaultEnabled: true,
-      params: {
-        '/v1/chat/completions': {
-          enable: { chat_template_kwargs: { enable_thinking: true } },
-          disable: { chat_template_kwargs: { enable_thinking: false } },
-        },
-        '/v1/responses': {
-          enable: { chat_template_kwargs: { enable_thinking: true } },
-          disable: { chat_template_kwargs: { enable_thinking: false } },
+    chatConfig: {
+      descriptionShort: 'Best for everyday tasks with images',
+      reasoningConfig: {
+        supportsToggle: true,
+        defaultEnabled: true,
+        params: {
+          '/v1/chat/completions': {
+            enable: { chat_template_kwargs: { enable_thinking: true } },
+            disable: { chat_template_kwargs: { enable_thinking: false } },
+          },
+          '/v1/responses': {
+            enable: { chat_template_kwargs: { enable_thinking: true } },
+            disable: { chat_template_kwargs: { enable_thinking: false } },
+          },
         },
       },
     },
@@ -52,10 +54,12 @@ const DEV_MODELS: BaseModel[] = [
     name: 'Kimi K2.6',
     nameShort: 'Kimi K2.6',
     description: 'Moonshot Kimi K2.6',
-    descriptionShort: 'Best for coding and visual tasks',
     type: 'chat',
     chat: true,
     multimodal: true,
+    chatConfig: {
+      descriptionShort: 'Best for coding and visual tasks',
+    },
   },
   {
     modelName: 'gpt-oss-120b',
@@ -63,9 +67,11 @@ const DEV_MODELS: BaseModel[] = [
     name: 'GPT-OSS 120B',
     nameShort: 'GPT-OSS',
     description: 'OpenAI GPT-OSS 120B',
-    descriptionShort: 'Best for quick reasoning tasks',
     type: 'chat',
     chat: true,
+    chatConfig: {
+      descriptionShort: 'Best for quick reasoning tasks',
+    },
   },
 ]
 
@@ -125,6 +131,23 @@ export type ReasoningConfig = {
 
 export type AutoTier = 'smart' | 'fast'
 
+/**
+ * Settings the chat clients read for a model. Present only on chat models; the
+ * controlplane keeps everything a chat client needs under this block.
+ */
+export type ChatConfig = {
+  /**
+   * Token budget the chat archives history against. May be lower than the
+   * model's raw capability advertised to API consumers.
+   */
+  contextWindowTokens?: number
+  /** Open set of model tags, including Auto routing tiers ("smart", "fast"). */
+  attributes?: string[]
+  /** Short "Best for x" blurb shown under the name in the model picker. */
+  descriptionShort?: string
+  reasoningConfig?: ReasoningConfig
+}
+
 // Base model type with all possible properties
 export type BaseModel = {
   modelName: string
@@ -132,11 +155,8 @@ export type BaseModel = {
   name: string
   nameShort: string
   description: string
-  /** Short "Best for x" blurb shown under the name in the model picker. */
-  descriptionShort?: string
   details?: string
   parameters?: string
-  contextWindowTokens?: number
   recommendedUse?: string
   supportedLanguages?: string
   type: 'chat' | 'code' | 'embedding' | 'audio' | 'tts' | 'document' | 'title'
@@ -144,13 +164,11 @@ export type BaseModel = {
   paid?: boolean
   multimodal?: boolean
   toolCalling?: boolean
-  /** Open set of model tags, including Auto routing tiers ("smart", "fast"). */
-  attributes?: string[]
+  chatConfig?: ChatConfig
   /** True for the synthetic Auto picker entries; never a real backend model. */
   isAuto?: boolean
   /** Routing tier an Auto entry resolves; only set when isAuto is true. */
   tier?: AutoTier
-  reasoningConfig?: ReasoningConfig
   endpoint?: string
   /** Extra fields merged into the chat completion request body */
   requestParams?: Record<string, unknown>
@@ -181,8 +199,8 @@ const tierModels = (models: BaseModel[], tier: AutoTier): BaseModel[] =>
   models.filter(
     (m) =>
       isChatModel(m) &&
-      Array.isArray(m.attributes) &&
-      m.attributes.includes(tier),
+      Array.isArray(m.chatConfig?.attributes) &&
+      m.chatConfig.attributes.includes(tier),
   )
 
 /**
@@ -214,7 +232,9 @@ export const getAutoModels = (models: BaseModel[]): BaseModel[] => {
       isAuto: true,
       tier,
       multimodal: members.some((m) => m.multimodal === true),
-      contextWindowTokens: resolveContextWindowTokens(smallestMember),
+      chatConfig: {
+        contextWindowTokens: resolveContextWindowTokens(smallestMember),
+      },
     })
   }
   add('smart', AUTO_SMART_ID, 'Auto · Smart')
@@ -282,7 +302,7 @@ export const getReasoningHistoryPolicy = (
       getStrongerReasoningHistoryPolicy(
         strongest,
         normalizeReasoningHistoryPolicy(
-          candidate.reasoningConfig?.reasoningHistoryPolicy,
+          candidate.chatConfig?.reasoningConfig?.reasoningHistoryPolicy,
         ),
       ),
     REASONING_HISTORY_POLICIES.none,

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -93,8 +93,8 @@ function buildModelBodyParams(
   const out: Record<string, unknown> = {}
 
   if (isReasoningModel(model)) {
-    const endpointParams =
-      model.reasoningConfig?.params?.[CHAT_COMPLETIONS_ENDPOINT]
+    const reasoningConfig = model.chatConfig?.reasoningConfig
+    const endpointParams = reasoningConfig?.params?.[CHAT_COMPLETIONS_ENDPOINT]
     if (endpointParams) {
       const rawBlock = supportsThinkingToggle(model)
         ? opts.thinkingEnabled
@@ -106,7 +106,7 @@ function buildModelBodyParams(
           supportsReasoningEffort(model) && opts.reasoningEffort
             ? opts.reasoningEffort
             : 'medium'
-        const effort = model.reasoningConfig?.effortMap?.[uiEffort] ?? uiEffort
+        const effort = reasoningConfig?.effortMap?.[uiEffort] ?? uiEffort
         const block = substituteEffort(rawBlock, effort) as Record<
           string,
           unknown

--- a/src/utils/dev-simulator.ts
+++ b/src/utils/dev-simulator.ts
@@ -7,16 +7,18 @@ export const DEV_SIMULATOR_MODEL: BaseModel = {
   name: 'Dev Simulator',
   nameShort: 'Dev',
   description: 'Development model for testing streaming and thinking behaviors',
-  descriptionShort: 'Best for testing streaming behaviors',
   details:
     'Simulates various streaming patterns including thinking, content generation, and edge cases',
   parameters: 'Configurable via query patterns',
-  contextWindowTokens: 32000,
   recommendedUse: 'Testing and development only',
   type: 'chat',
   chat: true,
   multimodal: false,
   endpoint: '/api/dev/simulator',
+  chatConfig: {
+    contextWindowTokens: 32000,
+    descriptionShort: 'Best for testing streaming behaviors',
+  },
 }
 
 // Simulator response patterns

--- a/src/utils/token-estimation.ts
+++ b/src/utils/token-estimation.ts
@@ -11,8 +11,9 @@ export const CONTEXT_WINDOW_USAGE_RATIO = 0.8
 
 export const DEFAULT_CONTEXT_WINDOW_TOKENS = 128000
 
-export type ContextWindowConfig = {
-  contextWindowTokens?: number
+/** The slice of a model the context budget is derived from. */
+export type ContextWindowSource = {
+  chatConfig?: { contextWindowTokens?: number }
 }
 
 // Roughly estimate token count based on character length (≈4 chars per token)
@@ -22,16 +23,16 @@ export function estimateTokenCount(text: string | undefined): number {
 }
 
 export function resolveContextWindowTokens(
-  config: ContextWindowConfig | undefined,
+  model: ContextWindowSource | undefined,
 ): number {
-  return config?.contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS
+  return model?.chatConfig?.contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS
 }
 
 export function getSmallestContextWindowTokens(
-  configs: ContextWindowConfig[],
+  models: ContextWindowSource[],
 ): number | undefined {
-  if (configs.length === 0) return undefined
-  return Math.min(...configs.map(resolveContextWindowTokens))
+  if (models.length === 0) return undefined
+  return Math.min(...models.map(resolveContextWindowTokens))
 }
 
 export type TokenEstimationOptions = {

--- a/tests/components/chat/chat-messages-archive-boundary.test.tsx
+++ b/tests/components/chat/chat-messages-archive-boundary.test.tsx
@@ -29,7 +29,9 @@ vi.mock('@/components/chat/WelcomeScreen', () => ({
   WelcomeScreen: () => null,
 }))
 
-const models = [{ id: 'model-1', contextWindowTokens: 1000 }] as any
+const models = [
+  { id: 'model-1', chatConfig: { contextWindowTokens: 1000 } },
+] as any
 
 function message(
   role: Message['role'],

--- a/tests/components/chat/chat-messages-recovery.test.tsx
+++ b/tests/components/chat/chat-messages-recovery.test.tsx
@@ -79,7 +79,7 @@ const baseProps = {
   pendingRecoveries: [recovery],
   isDarkMode: false,
   chatId: 'chat-1',
-  models: [{ id: 'model-1', contextWindowTokens: 1000 }] as any,
+  models: [{ id: 'model-1', chatConfig: { contextWindowTokens: 1000 } }] as any,
   selectedModel: 'model-1',
 }
 

--- a/tests/components/chat/chat-messages-scroll-spacer.test.tsx
+++ b/tests/components/chat/chat-messages-scroll-spacer.test.tsx
@@ -25,7 +25,9 @@ vi.mock('@/components/chat/PrintableChat', () => ({
   PrintableChat: () => null,
 }))
 
-const models = [{ id: 'model-1', contextWindowTokens: 1000 }] as any
+const models = [
+  { id: 'model-1', chatConfig: { contextWindowTokens: 1000 } },
+] as any
 
 function message(role: Message['role'], turnId: string): Message {
   return {

--- a/tests/components/chat/genui/retry.test.ts
+++ b/tests/components/chat/genui/retry.test.ts
@@ -39,7 +39,7 @@ vi.mock('@/utils/error-handling', () => ({ logError: logErrorMock }))
 
 const model = {
   modelName: 'gpt-oss-120b',
-  contextWindowTokens: 64000,
+  chatConfig: { contextWindowTokens: 64000 },
 } as BaseModel
 
 function message(role: Message['role'], content: string): Message {

--- a/tests/components/chat/model-management.test.ts
+++ b/tests/components/chat/model-management.test.ts
@@ -33,7 +33,7 @@ const mockModels: BaseModel[] = [mockModelA, mockModelB]
 const mockFastModel: BaseModel = {
   ...mockModelB,
   modelName: 'model-fast',
-  attributes: ['fast'],
+  chatConfig: { attributes: ['fast'] },
 }
 
 const modelsWithFastTier: BaseModel[] = [mockModelA, mockFastModel]

--- a/tests/config/models-reasoning-history.test.ts
+++ b/tests/config/models-reasoning-history.test.ts
@@ -22,8 +22,10 @@ const model = (
   description: '',
   type: 'chat',
   chat: true,
-  contextWindowTokens,
-  reasoningConfig: policy ? { reasoningHistoryPolicy: policy } : undefined,
+  chatConfig: {
+    contextWindowTokens,
+    reasoningConfig: policy ? { reasoningHistoryPolicy: policy } : undefined,
+  },
 })
 
 describe('getReasoningHistoryPolicy', () => {
@@ -53,8 +55,8 @@ describe('getReasoningHistoryPolicy', () => {
 
   it('falls back safely for unknown future policies', () => {
     const futureModel = model('future')
-    futureModel.reasoningConfig = {
-      reasoningHistoryPolicy: 'future-policy' as never,
+    futureModel.chatConfig = {
+      reasoningConfig: { reasoningHistoryPolicy: 'future-policy' as never },
     }
 
     expect(getReasoningHistoryPolicy({ model: futureModel })).toBe(
@@ -68,7 +70,7 @@ describe('getReasoningHistoryPolicy', () => {
       model('small', undefined, 32000),
     ]
     candidates.forEach((candidate) => {
-      candidate.attributes = ['smart']
+      candidate.chatConfig = { ...candidate.chatConfig, attributes: ['smart'] }
     })
 
     expect(
@@ -77,6 +79,8 @@ describe('getReasoningHistoryPolicy', () => {
         autoCandidates: candidates,
       }),
     ).toBe(32000)
-    expect(getAutoModels(candidates)[0].contextWindowTokens).toBe(32000)
+    expect(getAutoModels(candidates)[0].chatConfig?.contextWindowTokens).toBe(
+      32000,
+    )
   })
 })

--- a/tests/services/inference/chat-query-builder.test.ts
+++ b/tests/services/inference/chat-query-builder.test.ts
@@ -24,15 +24,19 @@ const preservedHistoryModel: BaseModel = {
   ...model,
   modelName: 'kimi-k3',
   name: 'Kimi K3',
-  reasoningConfig: { reasoningHistoryPolicy: REASONING_HISTORY_POLICIES.all },
+  chatConfig: {
+    reasoningConfig: { reasoningHistoryPolicy: REASONING_HISTORY_POLICIES.all },
+  },
 }
 
 const toolCallHistoryModel: BaseModel = {
   ...model,
   modelName: 'gemma4-31b',
   name: 'Gemma 4',
-  reasoningConfig: {
-    reasoningHistoryPolicy: REASONING_HISTORY_POLICIES.toolCallOnly,
+  chatConfig: {
+    reasoningConfig: {
+      reasoningHistoryPolicy: REASONING_HISTORY_POLICIES.toolCallOnly,
+    },
   },
 }
 
@@ -41,7 +45,7 @@ describe('ChatQueryBuilder', () => {
     const messages = ChatQueryBuilder.buildMessages({
       model: {
         ...model,
-        contextWindowTokens: 1000,
+        chatConfig: { contextWindowTokens: 1000 },
       },
       systemPrompt: '',
       rules: '',

--- a/tests/services/inference/inference-client-structured.test.ts
+++ b/tests/services/inference/inference-client-structured.test.ts
@@ -58,11 +58,13 @@ describe('sendStructuredCompletion', () => {
         temperature: 0.25,
         response_format: { type: 'text' },
       },
-      reasoningConfig: {
-        supportsEffort: true,
-        params: {
-          '/v1/chat/completions': {
-            enable: { reasoning_effort: '$EFFORT' },
+      chatConfig: {
+        reasoningConfig: {
+          supportsEffort: true,
+          params: {
+            '/v1/chat/completions': {
+              enable: { reasoning_effort: '$EFFORT' },
+            },
           },
         },
       },

--- a/tests/utils/token-estimation.test.ts
+++ b/tests/utils/token-estimation.test.ts
@@ -35,10 +35,12 @@ describe('estimateTokenCount', () => {
 })
 
 describe('resolveContextWindowTokens', () => {
-  it('uses the numeric model metadata', () => {
-    expect(resolveContextWindowTokens({ contextWindowTokens: 256000 })).toBe(
-      256000,
-    )
+  it('uses the chat config budget', () => {
+    expect(
+      resolveContextWindowTokens({
+        chatConfig: { contextWindowTokens: 256000 },
+      }),
+    ).toBe(256000)
   })
 
   it('falls back to the default when the model reports no window', () => {
@@ -51,8 +53,8 @@ describe('resolveContextWindowTokens', () => {
   it('finds the smallest context window across candidates', () => {
     expect(
       getSmallestContextWindowTokens([
-        { contextWindowTokens: 256000 },
-        { contextWindowTokens: 32000 },
+        { chatConfig: { contextWindowTokens: 256000 } },
+        { chatConfig: { contextWindowTokens: 32000 } },
         {},
       ]),
     ).toBe(32000)


### PR DESCRIPTION
## Summary
- `BaseModel` gains a `chatConfig?: ChatConfig` block and drops the top-level `contextWindowTokens`, `attributes`, `descriptionShort` and `reasoningConfig` fields.
- Every reader moves to `chatConfig`: history budgeting (`resolveContextWindowTokens`), Auto tier membership, the model picker subtitle, the reasoning capability helpers, and the request-body builder.
- Synthetic Auto entries carry their smallest-member budget under `chatConfig.contextWindowTokens`.
- Dev fixtures (`DEV_MODELS`, `DEV_SIMULATOR_MODEL`) and test fixtures updated to the new shape.

## Why
The controlplane now groups everything a chat client needs under `chatConfig` (tinfoilsh/controlplane#663). `chatConfig.contextWindowTokens` is the chat budget and may be lower than the model's raw capability advertised at the top level; the webapp should only ever read the budget.

## Compatibility
No top-level fallback. Until #663 is deployed the webapp will use the 128k default for context and lose Auto tiers / reasoning controls / picker subtitles. Deploy the controlplane change first.

## Stacked on
#570 (numeric-only context window).

## Test plan
- [x] `npx vitest run` (198 files, 2064 tests)
- [x] `npx tsc --noEmit`
- [x] `eslint` on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reads chat model settings from the server's `chatConfig` block so the webapp uses the chat budget instead of the model's raw top-level capability. Also discards cached model lists from before the new shape to avoid stale configs.

`BaseModel` drops its top-level `contextWindowTokens`, `attributes`, `descriptionShort`, and `reasoningConfig` fields in favor of a nested `chatConfig` block. History budgeting, Auto tier routing, multimodal upload model selection, the model picker subtitle, reasoning capability helpers, and the request-body builder all read from `chatConfig` now. Synthetic Auto entries carry their smallest-member budget under `chatConfig.contextWindowTokens`. Dev and test fixtures updated to the new shape.

**Migration**
- Deploy the controlplane change (`tinfoilsh/controlplane`#663) first.
- Until it ships, the webapp uses the 128k default and loses Auto tiers, reasoning controls, and picker subtitles.
- Cached model lists from before the new shape are discarded on load.

<sup>Written for commit 2467424790e8f6e7a3d979787cad2ade2cbf9ad1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

