### PR TITLE
fix: stop chat search from getting stuck on "Building search index"

### DIFF
--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -2452,7 +2452,16 @@ export function ChatSidebar({
                         pinnedChatIds={pinnedChatIds}
                         onTogglePin={onToggleFavorite}
                         emptyState={
-                          isSearchActive ? (
+                          isSearchActive && chatSearch.failed ? (
+                            <div className="rounded-lg border border-border-subtle bg-surface-sidebar p-4 text-center">
+                              <p className="text-sm text-content-muted">
+                                Search is unavailable right now
+                              </p>
+                              <p className="mt-1 text-balance text-xs text-content-muted">
+                                Please try again in a moment
+                              </p>
+                            </div>
+                          ) : isSearchActive ? (
                             <div className="rounded-lg border border-border-subtle bg-surface-sidebar p-4 text-center">
                               <p className="text-sm text-content-muted">
                                 No matching chats

--- a/src/hooks/use-chat-search.ts
+++ b/src/hooks/use-chat-search.ts
@@ -18,6 +18,12 @@ export interface ChatSearchState {
   /** True while the enclave rebuilds the index; results may be partial. */
   isIndexing: boolean
   /**
+   * True when the current term's search threw or the index rebuild it
+   * was waiting on did not complete, so an empty result set must not
+   * be presented as "no matches".
+   */
+  failed: boolean
+  /**
    * False when server-side search cannot run (no key loaded, enclave
    * without a search backend). Callers should fall back to filtering
    * locally loaded chats by title.
@@ -42,6 +48,7 @@ export function useChatSearch(
   const [results, setResults] = useState<SearchResultChat[]>([])
   const [isSearching, setIsSearching] = useState(false)
   const [isIndexing, setIsIndexing] = useState(false)
+  const [failed, setFailed] = useState(false)
   const [available, setAvailable] = useState(true)
   const [refreshNonce, setRefreshNonce] = useState(0)
 
@@ -50,6 +57,7 @@ export function useChatSearch(
       setResults([])
       setIsSearching(false)
       setIsIndexing(false)
+      setFailed(false)
       return
     }
     // Set on cleanup so completions from a superseded term (or an
@@ -57,6 +65,7 @@ export function useChatSearch(
     // state or schedule a refresh.
     let cancelled = false
     setIsSearching(true)
+    setFailed(false)
     const run = async () => {
       try {
         const outcome = await searchSyncedChats(trimmed, SEARCH_RESULT_LIMIT)
@@ -81,6 +90,9 @@ export function useChatSearch(
               setRefreshNonce((n) => n + 1)
             } else {
               setIsIndexing(false)
+              // 'skipped' means a recent rebuild already failed and we
+              // are inside its cooldown, so the index is still broken.
+              setFailed(true)
             }
           })
         }
@@ -96,6 +108,7 @@ export function useChatSearch(
         // flag, so reset it here or the "building index" indicator
         // stays up until the user edits the term.
         setIsIndexing(false)
+        setFailed(true)
       }
     }
     const timer = setTimeout(() => void run(), SEARCH_DEBOUNCE_MS)
@@ -105,5 +118,5 @@ export function useChatSearch(
     }
   }, [trimmed, active, includeProjectChats, refreshNonce])
 
-  return { results, isSearching, isIndexing, available }
+  return { results, isSearching, isIndexing, failed, available }
 }

--- a/src/hooks/use-chat-search.ts
+++ b/src/hooks/use-chat-search.ts
@@ -92,6 +92,10 @@ export function useChatSearch(
         })
         setResults([])
         setIsSearching(false)
+        // A failed run has no settle callback to clear the indexing
+        // flag, so reset it here or the "building index" indicator
+        // stays up until the user edits the term.
+        setIsIndexing(false)
       }
     }
     const timer = setTimeout(() => void run(), SEARCH_DEBOUNCE_MS)

--- a/tests/hooks/use-chat-search.test.ts
+++ b/tests/hooks/use-chat-search.test.ts
@@ -1,0 +1,74 @@
+import { useChatSearch } from '@/hooks/use-chat-search'
+import type { ChatSearchOutcome } from '@/services/cloud/chat-search'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const searchSyncedChats = vi.fn()
+const resolveSearchResultChats = vi.fn()
+
+vi.mock('@/services/cloud/chat-search', () => ({
+  searchSyncedChats: (...args: unknown[]) => searchSyncedChats(...args),
+  resolveSearchResultChats: (...args: unknown[]) =>
+    resolveSearchResultChats(...args),
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+}))
+
+function indexingOutcome(): ChatSearchOutcome {
+  return {
+    results: [],
+    totalIndexed: 0,
+    indexing: true,
+    available: true,
+    reindexSettled: new Promise(() => {}),
+  }
+}
+
+async function flushDebounce() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(400)
+  })
+}
+
+describe('useChatSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    searchSyncedChats.mockReset()
+    resolveSearchResultChats.mockReset()
+    resolveSearchResultChats.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('clears the indexing flag when a later search run fails', async () => {
+    searchSyncedChats.mockResolvedValueOnce(indexingOutcome())
+    const { result, rerender } = renderHook(
+      ({ term }) => useChatSearch(term, true),
+      { initialProps: { term: 'duc' } },
+    )
+    await flushDebounce()
+    expect(result.current.isIndexing).toBe(true)
+
+    searchSyncedChats.mockRejectedValueOnce(new Error('enclave timeout'))
+    rerender({ term: 'duck' })
+    await flushDebounce()
+
+    expect(result.current.isSearching).toBe(false)
+    expect(result.current.isIndexing).toBe(false)
+    expect(result.current.results).toEqual([])
+  })
+
+  it('clears the indexing flag when resolving hits fails after needs_reindex', async () => {
+    searchSyncedChats.mockResolvedValueOnce(indexingOutcome())
+    resolveSearchResultChats.mockRejectedValueOnce(new Error('pull failed'))
+    const { result } = renderHook(() => useChatSearch('duck', true))
+    await flushDebounce()
+
+    expect(result.current.isSearching).toBe(false)
+    expect(result.current.isIndexing).toBe(false)
+  })
+})

--- a/tests/hooks/use-chat-search.test.ts
+++ b/tests/hooks/use-chat-search.test.ts
@@ -16,13 +16,25 @@ vi.mock('@/utils/error-handling', () => ({
   logError: vi.fn(),
 }))
 
-function indexingOutcome(): ChatSearchOutcome {
+function indexingOutcome(
+  reindexSettled: ChatSearchOutcome['reindexSettled'] = new Promise(() => {}),
+): ChatSearchOutcome {
   return {
     results: [],
     totalIndexed: 0,
     indexing: true,
     available: true,
-    reindexSettled: new Promise(() => {}),
+    reindexSettled,
+  }
+}
+
+function readyOutcome(): ChatSearchOutcome {
+  return {
+    results: [],
+    totalIndexed: 3,
+    indexing: false,
+    available: true,
+    reindexSettled: null,
   }
 }
 
@@ -59,6 +71,7 @@ describe('useChatSearch', () => {
 
     expect(result.current.isSearching).toBe(false)
     expect(result.current.isIndexing).toBe(false)
+    expect(result.current.failed).toBe(true)
     expect(result.current.results).toEqual([])
   })
 
@@ -70,5 +83,46 @@ describe('useChatSearch', () => {
 
     expect(result.current.isSearching).toBe(false)
     expect(result.current.isIndexing).toBe(false)
+    expect(result.current.failed).toBe(true)
+  })
+
+  it('marks the search failed when the rebuild it waited on does not complete', async () => {
+    searchSyncedChats.mockResolvedValueOnce(
+      indexingOutcome(Promise.resolve('failed')),
+    )
+    const { result } = renderHook(() => useChatSearch('duck', true))
+    await flushDebounce()
+
+    expect(result.current.isIndexing).toBe(false)
+    expect(result.current.failed).toBe(true)
+  })
+
+  it('re-queries after a completed rebuild and clears the failed flag on success', async () => {
+    searchSyncedChats
+      .mockResolvedValueOnce(indexingOutcome(Promise.resolve('completed')))
+      .mockResolvedValueOnce(readyOutcome())
+    const { result } = renderHook(() => useChatSearch('duck', true))
+    await flushDebounce()
+    await flushDebounce()
+
+    expect(searchSyncedChats).toHaveBeenCalledTimes(2)
+    expect(result.current.isIndexing).toBe(false)
+    expect(result.current.failed).toBe(false)
+  })
+
+  it('clears a previous failure when the term changes and the new run succeeds', async () => {
+    searchSyncedChats
+      .mockRejectedValueOnce(new Error('enclave timeout'))
+      .mockResolvedValueOnce(readyOutcome())
+    const { result, rerender } = renderHook(
+      ({ term }) => useChatSearch(term, true),
+      { initialProps: { term: 'duc' } },
+    )
+    await flushDebounce()
+    expect(result.current.failed).toBe(true)
+
+    rerender({ term: 'duck' })
+    await flushDebounce()
+    expect(result.current.failed).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- A user reported chat search permanently showing "Building search index..." with no results. The `useChatSearch` hook set `isIndexing` when the enclave reported `needs_reindex`, but the error path never cleared it, so any subsequent failed request (enclave timeout, auth/network error, or a failure resolving hit titles) stranded the spinner until the term changed.
- Reset `isIndexing` on the failure path, and add a `failed` flag so a thrown search or a rebuild that settles `failed`/`timeout`/`skipped` renders "Search is unavailable right now" instead of the misleading "No matching chats".
- Add hook tests covering the stranding paths (both fail on the old code) plus the failed-settle, completed-refresh, and recovery-on-retype transitions.

## Notes
- This does not fix the underlying reason a search request fails. Investigation in confidential-sync found a separate enclave-side loop where a rebuild completes but `published_source_revision` stays behind `source_revision` if a chat write lands during the run, triggering a full re-rebuild on every re-query; and a permanent CAS rejection when the key sent by the client is not the registered primary. Both will be tracked as follow-ups in confidential-sync/controlplane.

## Test plan
- [x] `npx vitest run tests/hooks/use-chat-search.test.ts` (5 passing; the two stranding tests fail against the previous hook)
- [x] `npx vitest run tests/components/chat` (477 passing)
- [x] `tsc --noEmit`, eslint clean
- [ ] Manual: search while offline / with enclave unreachable and confirm the empty state reads "Search is unavailable right now" rather than a spinner

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat search getting stuck on "Building search index" when a request fails after the index rebuild starts. The hook now resets `isIndexing` on the error path and tracks a `failed` state, so the sidebar shows "Search is unavailable right now" instead of a permanent spinner or "No matching chats".

**Details**

- Thrown searches and rebuilds settled as `failed`, `timeout`, or `skipped` set `failed`; the next successful run clears it.
- Adds hook tests covering the stranded-spinner paths (they fail against the old code), rebuild completion, and recovery on term change.
- Underlying enclave-side rebuild failures are not fixed here; they'll be tracked as separate follow-ups.

<sup>Written for commit 5d34d93ee21585ac2a036a1d6e9f2d6132445d94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

