### PR TITLE
Fix mobile model selector layout

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -706,7 +706,7 @@ export function ChatInput({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="relative">
+      <div className="relative order-2 md:order-none">
         {mobileHeader}
         <div
           className={cn(
@@ -1445,11 +1445,11 @@ export function ChatInput({
       </div>
 
       {hasMessages && (
-        <div className="flex items-center justify-between gap-4 px-3 md:px-6">
-          <p className="text-xs text-content-muted">
+        <div className="contents md:flex md:items-center md:justify-between md:gap-4 md:px-6">
+          <p className="order-3 px-3 text-xs text-content-muted md:order-none md:px-0">
             AI can make mistakes. Verify important information.
           </p>
-          <div className="flex items-center gap-2">
+          <div className="order-1 flex items-center gap-2 self-end px-3 md:order-none md:self-auto md:px-0">
             {contextUsage && (
               <ContextUsageIndicator
                 usage={contextUsage}

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -706,7 +706,12 @@ export function ChatInput({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="relative order-2 md:order-none">
+      {hasMessages && modelSelectorButton && (
+        <div className="flex items-center self-end px-3 md:hidden">
+          {modelSelectorButton}
+        </div>
+      )}
+      <div className="relative">
         {mobileHeader}
         <div
           className={cn(
@@ -1445,11 +1450,11 @@ export function ChatInput({
       </div>
 
       {hasMessages && (
-        <div className="contents md:flex md:items-center md:justify-between md:gap-4 md:px-6">
-          <p className="order-3 px-3 text-xs text-content-muted md:order-none md:px-0">
+        <div className="flex items-center justify-between gap-4 px-3 md:px-6">
+          <p className="text-xs text-content-muted">
             AI can make mistakes. Verify important information.
           </p>
-          <div className="order-1 flex items-center gap-2 self-end px-3 md:order-none md:self-auto md:px-0">
+          <div className="hidden items-center gap-2 md:flex">
             {contextUsage && (
               <ContextUsageIndicator
                 usage={contextUsage}

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -259,16 +259,21 @@ export function useChatState({
       const triggerSelector = '[data-model-selector]'
       const menuSelector = '[data-model-menu]'
 
-      const getSelectorElements = () => ({
-        trigger: document.querySelector<HTMLElement>(triggerSelector),
-        menu: document.querySelector<HTMLElement>(menuSelector),
-      })
+      const getSelectorElements = () => [
+        ...document.querySelectorAll<HTMLElement>(triggerSelector),
+        ...document.querySelectorAll<HTMLElement>(menuSelector),
+      ]
+      const getVisibleTrigger = () =>
+        [...document.querySelectorAll<HTMLElement>(triggerSelector)].find(
+          (element) => element.getClientRects().length > 0,
+        )
 
       const isOutsideSelector = (target: EventTarget | null) => {
         if (!(target instanceof Node)) return false
-        const { trigger, menu } = getSelectorElements()
+        const selectorElements = getSelectorElements()
         return (
-          trigger && menu && !trigger.contains(target) && !menu.contains(target)
+          selectorElements.length > 0 &&
+          selectorElements.every((element) => !element.contains(target))
         )
       }
 
@@ -288,7 +293,7 @@ export function useChatState({
         if (event.key === 'Escape') {
           event.preventDefault()
           setExpandedLabel(null)
-          getSelectorElements().trigger?.focus()
+          getVisibleTrigger()?.focus()
         }
       }
 

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -327,7 +327,9 @@ export function ModelSelector({
 
   const focusTrigger = () => {
     requestAnimationFrame(() => {
-      document.querySelector<HTMLElement>('[data-model-selector]')?.focus()
+      menuRef.current?.parentElement
+        ?.querySelector<HTMLElement>('[data-model-selector]')
+        ?.focus()
     })
   }
 


### PR DESCRIPTION
## Summary
- move the model selector above the chat input on mobile
- give the disclaimer full width below the input
- preserve the existing desktop layout

## Testing
- `npx eslint src/components/chat/chat-input.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mobile chat input layout so the model selector sits above the input and the disclaimer spans full width, while keeping the desktop layout unchanged. Also updates model selector focus and click-outside handling to account for the selector now appearing in both mobile and desktop.

<sup>Written for commit 3436c968d62aaa4ea07a7edb326d9d72c28a2052. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

