### PR TITLE
Fix cloud history pagination for imported chats

### DIFF
--- a/src/components/chat/document-content.ts
+++ b/src/components/chat/document-content.ts
@@ -7,7 +7,7 @@ export function getDocumentTextContent(
   if (content.trim()) return content
 
   const pageContent = pages
-    ?.map((page) => page.text)
+    ?.map((page) => (typeof page?.text === 'string' ? page.text : ''))
     .filter((text) => text.trim())
     .join('\n\n---\n\n')
 

--- a/src/services/chat-export/export-archive.ts
+++ b/src/services/chat-export/export-archive.ts
@@ -1,5 +1,6 @@
 import { strToU8, zipSync } from 'fflate'
 
+import { getDocumentTextContent } from '@/components/chat/document-content'
 import type { Attachment, Chat } from '@/components/chat/types'
 
 /**
@@ -185,13 +186,16 @@ export async function buildChatExport(
           exportedAttachments.push(exported)
         } else {
           attachmentCount++
+          const textContent =
+            getDocumentTextContent(att.textContent ?? '', att.pages) ??
+            undefined
           exportedAttachments.push({
             id: att.id,
             type: 'document',
             fileName: att.fileName,
             mimeType: att.mimeType,
             fileSize: att.fileSize,
-            textContent: att.textContent,
+            textContent,
           })
         }
       }

--- a/src/services/cloud/chat-codec.ts
+++ b/src/services/cloud/chat-codec.ts
@@ -91,7 +91,8 @@ function isUsableRemoteAttachment(value: unknown): value is StoredAttachment {
   }
   return (
     hasNonEmptyString(attachment, 'id') &&
-    hasNonEmptyString(attachment, 'encryptionKey')
+    (hasNonEmptyString(attachment, 'encryptionKey') ||
+      hasNonEmptyString(attachment, 'key'))
   )
 }
 

--- a/src/services/cloud/chat-codec.ts
+++ b/src/services/cloud/chat-codec.ts
@@ -12,7 +12,7 @@ import { ensureValidISODate } from '@/utils/chat-timestamps'
 import { logInfo } from '@/utils/error-handling'
 import type { ChatSyncMetadata, StoredChat } from '../storage/indexed-db'
 import { observe } from './edit-clock'
-import { RemoteChatPlaintextSchema } from './schemas'
+import { RemoteChatPlaintextSchema, type RemoteChatMessage } from './schemas'
 
 export interface RemoteChatData {
   id: string
@@ -48,20 +48,62 @@ export class RemoteChatDecodeError extends Error {
   }
 }
 
-function removePayloadlessDocuments(
-  messages: StoredChat['messages'],
+type StoredMessage = StoredChat['messages'][number]
+type StoredAttachment = NonNullable<StoredMessage['attachments']>[number]
+
+function hasNonEmptyString(
+  value: Record<string, unknown>,
+  field: string,
+): boolean {
+  return typeof value[field] === 'string' && value[field].trim().length > 0
+}
+
+function hasReadablePages(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.some(
+      (page) =>
+        page !== null &&
+        typeof page === 'object' &&
+        (hasNonEmptyString(page as Record<string, unknown>, 'text') ||
+          hasNonEmptyString(page as Record<string, unknown>, 'image')),
+    )
+  )
+}
+
+function isUsableRemoteAttachment(value: unknown): value is StoredAttachment {
+  if (value === null || typeof value !== 'object') return false
+  const attachment = value as Record<string, unknown>
+  if (
+    (attachment.type !== 'image' && attachment.type !== 'document') ||
+    typeof attachment.id !== 'string' ||
+    typeof attachment.fileName !== 'string'
+  ) {
+    return false
+  }
+  if (hasNonEmptyString(attachment, 'base64')) return true
+  if (hasNonEmptyString(attachment, 'thumbnailBase64')) return true
+  if (attachment.type === 'document') {
+    return (
+      hasNonEmptyString(attachment, 'textContent') ||
+      hasReadablePages(attachment.pages)
+    )
+  }
+  return (
+    hasNonEmptyString(attachment, 'id') &&
+    hasNonEmptyString(attachment, 'encryptionKey')
+  )
+}
+
+function sanitizeRemoteMessages(
+  messages: RemoteChatMessage[],
 ): StoredChat['messages'] {
-  return messages.map((message) => ({
-    ...message,
-    attachments: message.attachments?.filter(
-      (attachment) =>
-        attachment.type !== 'document' ||
-        typeof attachment.base64 === 'string' ||
-        typeof attachment.thumbnailBase64 === 'string' ||
-        typeof attachment.textContent === 'string' ||
-        Array.isArray(attachment.pages),
-    ),
-  }))
+  return messages.map((message) => {
+    const attachments = Array.isArray(message.attachments)
+      ? message.attachments.filter(isUsableRemoteAttachment)
+      : undefined
+    return { ...message, attachments } as StoredMessage
+  })
 }
 
 /**
@@ -127,9 +169,7 @@ export async function processRemoteChat(
     })
   }
   const decrypted = validation.data
-  const messages = removePayloadlessDocuments(
-    decrypted.messages as StoredChat['messages'],
-  )
+  const messages = sanitizeRemoteMessages(decrypted.messages)
 
   // Advance the local logical clock past any remote edit clock so a
   // later local edit is guaranteed to outrank what we just observed.

--- a/src/services/cloud/chat-codec.ts
+++ b/src/services/cloud/chat-codec.ts
@@ -21,7 +21,7 @@ export interface RemoteChatData {
    * unsealing. v2 is the only format the codec accepts.
    */
   plaintext?: string | null
-  createdAt?: string
+  createdAt?: string | null
   updatedAt?: string | null
   formatVersion?: number
   syncVersion?: number
@@ -48,6 +48,22 @@ export class RemoteChatDecodeError extends Error {
   }
 }
 
+function removePayloadlessDocuments(
+  messages: StoredChat['messages'],
+): StoredChat['messages'] {
+  return messages.map((message) => ({
+    ...message,
+    attachments: message.attachments?.filter(
+      (attachment) =>
+        attachment.type !== 'document' ||
+        typeof attachment.base64 === 'string' ||
+        typeof attachment.thumbnailBase64 === 'string' ||
+        typeof attachment.textContent === 'string' ||
+        Array.isArray(attachment.pages),
+    ),
+  }))
+}
+
 /**
  * Decode a plaintext v2 row coming back from the enclave into a
  * `StoredChat`. Failure modes:
@@ -65,7 +81,10 @@ export async function processRemoteChat(
     ? (projectId ?? undefined)
     : localChat?.projectId
 
-  const safeCreatedAt = ensureValidISODate(remote.createdAt, remote.id)
+  const safeCreatedAt = ensureValidISODate(
+    remote.createdAt ?? remote.updatedAt,
+    remote.id,
+  )
   const safeUpdatedAt = ensureValidISODate(
     remote.updatedAt ?? remote.createdAt,
     remote.id,
@@ -108,6 +127,9 @@ export async function processRemoteChat(
     })
   }
   const decrypted = validation.data
+  const messages = removePayloadlessDocuments(
+    decrypted.messages as StoredChat['messages'],
+  )
 
   // Advance the local logical clock past any remote edit clock so a
   // later local edit is guaranteed to outrank what we just observed.
@@ -118,10 +140,10 @@ export async function processRemoteChat(
     title: decrypted.title ?? DEFAULT_CHAT_TITLE,
     // MessageSchema validates the fields the app depends on and
     // passes the rest through, so the runtime shape is a Message.
-    messages: decrypted.messages as StoredChat['messages'],
+    messages,
     id: remote.id,
     createdAt: ensureValidISODate(
-      decrypted.createdAt ?? remote.createdAt,
+      decrypted.createdAt ?? remote.createdAt ?? remote.updatedAt,
       remote.id,
     ),
     updatedAt: ensureValidISODate(

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -15,6 +15,7 @@ import {
   type RemoteChatData,
 } from './chat-codec'
 import { cloudStorage } from './cloud-storage'
+import { reportChatSyncRecovered } from './sync-health'
 import { shouldIngestRemoteChat } from './sync-predicates'
 
 export interface RemoteChatEntry {
@@ -129,6 +130,7 @@ export async function ingestRemoteChats(
       if (applied.applied) {
         result.savedIds.push(decoded.chat.id)
         result.downloaded++
+        reportChatSyncRecovered(decoded.chat.id)
       }
     } catch (error) {
       logError('Failed to ingest remote chat', error, {

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -43,6 +43,7 @@ export interface IngestOptions {
 export interface IngestFailure {
   chatId: string
   error: unknown
+  stage: 'decode' | 'storage'
 }
 
 export interface IngestResult {
@@ -81,6 +82,7 @@ export async function ingestRemoteChats(
       continue
     }
 
+    let stage: IngestFailure['stage'] = 'decode'
     try {
       let fetchedProjectMetadata:
         { projectIdSet: boolean; projectId?: string | null } | undefined
@@ -113,6 +115,7 @@ export async function ingestRemoteChats(
       }
       const decoded = await processRemoteChat(codecInput, codecOptions)
       if (!isCurrent()) break
+      stage = 'storage'
       const applied = await indexedDBStorage.applyRemoteChatIfFresh({
         chat: decoded.chat,
         syncVersion: decoded.chat.syncVersion ?? 0,
@@ -133,7 +136,7 @@ export async function ingestRemoteChats(
         action: 'ingestRemoteChats',
         metadata: { chatId: remoteChat.id },
       })
-      result.errors.push({ chatId: remoteChat.id, error })
+      result.errors.push({ chatId: remoteChat.id, error, stage })
     }
   }
 

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -53,7 +53,6 @@ import { streamingTracker } from './streaming-tracker'
 import {
   reportChatSynced,
   reportChatSyncFailed,
-  reportChatSyncRecovered,
   reportKeyActionRequired,
   reportSyncPaused,
 } from './sync-health'
@@ -976,9 +975,6 @@ export class CloudSyncService {
       userId,
     })
     this.ensureCurrentAccount(generation, userId)
-    for (const chatId of ingest.savedIds) {
-      reportChatSyncRecovered(chatId)
-    }
     const storageFailure = ingest.errors.find(
       (failure) => failure.stage === 'storage',
     )
@@ -1063,14 +1059,18 @@ export class CloudSyncService {
         }
         try {
           const entry = metadata.get(result.id)!
-          const decoded = await processRemoteChat({
-            id: result.id,
-            plaintext: result.content,
-            syncVersion: result.syncVersion,
-            formatVersion: 2,
-            updatedAt: entry.updatedAt,
-            projectId: entry.projectId ?? undefined,
-          })
+          const decoded = await processRemoteChat(
+            {
+              id: result.id,
+              plaintext: result.content,
+              syncVersion: result.syncVersion,
+              formatVersion: 2,
+              updatedAt: entry.updatedAt,
+            },
+            {
+              projectId: entry.projectId,
+            },
+          )
           chats.push(decoded.chat)
         } catch (error) {
           logError('Failed to decode paginated remote chat', error, {

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -53,6 +53,7 @@ import { streamingTracker } from './streaming-tracker'
 import {
   reportChatSynced,
   reportChatSyncFailed,
+  reportChatSyncRecovered,
   reportKeyActionRequired,
   reportSyncPaused,
 } from './sync-health'
@@ -975,6 +976,9 @@ export class CloudSyncService {
       userId,
     })
     this.ensureCurrentAccount(generation, userId)
+    for (const chatId of ingest.savedIds) {
+      reportChatSyncRecovered(chatId)
+    }
     const storageFailure = ingest.errors.find(
       (failure) => failure.stage === 'storage',
     )
@@ -1043,6 +1047,7 @@ export class CloudSyncService {
       const entries = remote.conversations.filter(
         (entry) => !deletedChatsTracker.isDeleted(entry.id),
       )
+      const metadata = new Map(entries.map((entry) => [entry.id, entry]))
       const pulled = await cloudStorage.downloadChats(
         entries.map((entry) => entry.id),
       )
@@ -1057,11 +1062,14 @@ export class CloudSyncService {
           )
         }
         try {
+          const entry = metadata.get(result.id)!
           const decoded = await processRemoteChat({
             id: result.id,
             plaintext: result.content,
             syncVersion: result.syncVersion,
             formatVersion: 2,
+            updatedAt: entry.updatedAt,
+            projectId: entry.projectId ?? undefined,
           })
           chats.push(decoded.chat)
         } catch (error) {

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -117,9 +117,12 @@ export interface UnavailableRemoteChat {
 interface ChatHydrationResult {
   saved: number
   unavailable: UnavailableRemoteChat[]
+  skippedIds: string[]
 }
 
-export interface ChatPageResult extends ChatHydrationResult {
+export interface ChatPageResult {
+  saved: number
+  unavailable: UnavailableRemoteChat[]
   hasMore: boolean
   nextToken?: string
 }
@@ -940,7 +943,8 @@ export class CloudSyncService {
     generation: number,
     userId: string,
   ): Promise<ChatHydrationResult> {
-    if (entries.length === 0) return { saved: 0, unavailable: [] }
+    if (entries.length === 0)
+      return { saved: 0, unavailable: [], skippedIds: [] }
     const pulled = await cloudStorage.downloadChats(
       entries.map((entry) => entry.id),
     )
@@ -971,16 +975,29 @@ export class CloudSyncService {
       userId,
     })
     this.ensureCurrentAccount(generation, userId)
-    if (ingest.errors.length > 0) {
-      const [failure] = ingest.errors
+    const storageFailure = ingest.errors.find(
+      (failure) => failure.stage === 'storage',
+    )
+    if (storageFailure) {
       throw new RemoteChatPageIncompleteError(
-        failure.chatId,
+        storageFailure.chatId,
         'storage',
-        failure.error,
+        storageFailure.error,
       )
     }
+    const skippedIds = ingest.errors.map((failure) => failure.chatId)
+    for (const chatId of skippedIds) {
+      reportChatSyncFailed(chatId, "This chat couldn't be read")
+    }
+    if (skippedIds.length > 0) {
+      logWarning('Skipped invalid chats while loading cloud history', {
+        component: 'CloudSync',
+        action: 'hydrateChats',
+        metadata: { chatIds: skippedIds },
+      })
+    }
     if (unavailable.length > 0) this.reportUnavailableChats(unavailable)
-    return { saved: ingest.downloaded, unavailable }
+    return { saved: ingest.downloaded, unavailable, skippedIds }
   }
 
   /**
@@ -1131,7 +1148,10 @@ export class CloudSyncService {
       }
     }
     const hydrated = await this.hydrateChats(missingOrStale, generation, userId)
-    const unavailableIds = new Set(hydrated.unavailable.map((row) => row.id))
+    const unavailableIds = new Set([
+      ...hydrated.unavailable.map((row) => row.id),
+      ...hydrated.skippedIds,
+    ])
     for (const entry of prefix) {
       if (unavailableIds.has(entry.id)) continue
       const local = await indexedDBStorage.getChat(entry.id)
@@ -1187,7 +1207,8 @@ export class CloudSyncService {
     return {
       hasMore: remote.hasMore,
       nextToken: remote.nextContinuationToken,
-      ...hydrated,
+      saved: hydrated.saved,
+      unavailable: hydrated.unavailable,
     }
   }
 

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -35,6 +35,8 @@ const MessageSchema = z
   })
   .passthrough()
 
+export type RemoteChatMessage = z.infer<typeof MessageSchema>
+
 export const PendingRecoveryEnvelopeSchema = z
   .object({
     v: z.literal(1),

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -98,8 +98,8 @@ export const RemoteChatPlaintextSchema = z
         }
       })
       .optional(),
-    createdAt: z.union([z.string(), z.number()]).optional(),
-    updatedAt: z.union([z.string(), z.number()]).optional(),
+    createdAt: z.union([z.string(), z.number()]).nullish(),
+    updatedAt: z.union([z.string(), z.number()]).nullish(),
     model: z.string().optional(),
     webSearchEnabled: z.boolean().optional(),
     isLocalOnly: z.boolean().optional(),

--- a/src/services/cloud/sync-health.ts
+++ b/src/services/cloud/sync-health.ts
@@ -162,6 +162,13 @@ export function reportChatSyncFailed(chatId: string, message: string): void {
   })
 }
 
+export function reportChatSyncRecovered(chatId: string): void {
+  if (!(chatId in snapshot.failedChats)) return
+  const failedChats = { ...snapshot.failedChats }
+  delete failedChats[chatId]
+  publish({ ...snapshot, failedChats })
+}
+
 /**
  * Clears a chat's failure entry (successful upload or deletion). A
  * successful write also proves the account is not blocked, so it

--- a/src/utils/chat-timestamps.ts
+++ b/src/utils/chat-timestamps.ts
@@ -22,7 +22,7 @@ export function getConversationTimestampFromId(
 }
 
 export function ensureValidISODate(
-  value: string | number | Date | undefined,
+  value: string | number | Date | null | undefined,
   conversationId?: string,
 ): string {
   if (value !== undefined && value !== null) {

--- a/tests/components/chat/document-content.test.ts
+++ b/tests/components/chat/document-content.test.ts
@@ -18,4 +18,13 @@ describe('getDocumentTextContent', () => {
   it('rejects processing results without readable content', () => {
     expect(getDocumentTextContent('   ', [])).toBeNull()
   })
+
+  it('ignores malformed page entries from restored chats', () => {
+    expect(
+      getDocumentTextContent('', [
+        {} as never,
+        { page: 2, text: 'Readable', image: '', is_scanned: false },
+      ]),
+    ).toBe('Readable')
+  })
 })

--- a/tests/services/chat-export/export-archive.test.ts
+++ b/tests/services/chat-export/export-archive.test.ts
@@ -74,6 +74,47 @@ describe('buildChatExport', () => {
     expect(att.textContent).toBe('the contents')
   })
 
+  it('exports page-backed documents with inline text', async () => {
+    const chats = [
+      chat({
+        messages: [
+          {
+            role: 'user',
+            content: 'read this',
+            timestamp: new Date('2023-11-14T22:13:21.000Z'),
+            attachments: [
+              {
+                id: 'doc-1',
+                type: 'document',
+                fileName: 'scan.pdf',
+                pages: [
+                  {
+                    page: 1,
+                    text: 'first page',
+                    image: 'page-one',
+                    is_scanned: true,
+                  },
+                  {
+                    page: 2,
+                    text: 'second page',
+                    image: 'page-two',
+                    is_scanned: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    ]
+
+    const result = await buildChatExport(chats, async () => null)
+    const parsed = JSON.parse(result.data as string)
+    const att = parsed[0].chat_messages[0].attachments[0]
+
+    expect(att.textContent).toBe('first page\n\n---\n\nsecond page')
+  })
+
   it('produces a zip with attachments, manifest, and no key leakage', async () => {
     const imageBytes = new Uint8Array([1, 2, 3, 4, 5])
     const chats = [

--- a/tests/services/cloud/chat-codec.test.ts
+++ b/tests/services/cloud/chat-codec.test.ts
@@ -148,6 +148,52 @@ describe('Chat Codec - processRemoteChat', () => {
       expect(result.chat.messages[0].attachments).toEqual([])
     })
 
+    it('sanitizes malformed and empty imported attachments', async () => {
+      const result = await processRemoteChat({
+        ...baseRemoteChat,
+        plaintext: basePlaintext({
+          messages: [
+            {
+              role: 'user',
+              content: 'Malformed collection',
+              attachments: { invalid: true },
+            },
+            {
+              role: 'user',
+              content: 'Mixed entries',
+              attachments: [
+                null,
+                {},
+                {
+                  id: 'empty-text',
+                  type: 'document',
+                  fileName: 'empty.txt',
+                  textContent: '   ',
+                },
+                {
+                  id: 'empty-pages',
+                  type: 'document',
+                  fileName: 'empty.pdf',
+                  pages: [],
+                },
+                {
+                  id: 'valid-document',
+                  type: 'document',
+                  fileName: 'notes.txt',
+                  textContent: 'notes',
+                },
+              ],
+            },
+          ],
+        }),
+      })
+
+      expect(result.chat.messages[0].attachments).toBeUndefined()
+      expect(result.chat.messages[1].attachments).toEqual([
+        expect.objectContaining({ id: 'valid-document' }),
+      ])
+    })
+
     it('accepts null imported timestamps using remote metadata', async () => {
       const result = await processRemoteChat({
         ...baseRemoteChat,

--- a/tests/services/cloud/chat-codec.test.ts
+++ b/tests/services/cloud/chat-codec.test.ts
@@ -182,6 +182,12 @@ describe('Chat Codec - processRemoteChat', () => {
                   fileName: 'notes.txt',
                   textContent: 'notes',
                 },
+                {
+                  id: 'legacy-image',
+                  type: 'image',
+                  fileName: 'legacy.png',
+                  key: 'legacy-key',
+                },
               ],
             },
           ],
@@ -191,6 +197,7 @@ describe('Chat Codec - processRemoteChat', () => {
       expect(result.chat.messages[0].attachments).toBeUndefined()
       expect(result.chat.messages[1].attachments).toEqual([
         expect.objectContaining({ id: 'valid-document' }),
+        expect.objectContaining({ id: 'legacy-image', key: 'legacy-key' }),
       ])
     })
 

--- a/tests/services/cloud/chat-codec.test.ts
+++ b/tests/services/cloud/chat-codec.test.ts
@@ -124,6 +124,40 @@ describe('Chat Codec - processRemoteChat', () => {
 
       expect(result.chat.id).toBe('remote-chat-1')
     })
+
+    it('drops imported documents that have no readable payload', async () => {
+      const result = await processRemoteChat({
+        ...baseRemoteChat,
+        plaintext: basePlaintext({
+          messages: [
+            {
+              role: 'user',
+              content: 'Read this',
+              attachments: [
+                {
+                  id: '',
+                  type: 'document',
+                  fileName: 'missing.pdf',
+                },
+              ],
+            },
+          ],
+        }),
+      })
+
+      expect(result.chat.messages[0].attachments).toEqual([])
+    })
+
+    it('accepts null imported timestamps using remote metadata', async () => {
+      const result = await processRemoteChat({
+        ...baseRemoteChat,
+        createdAt: null,
+        plaintext: basePlaintext({ createdAt: null, updatedAt: null }),
+      })
+
+      expect(result.chat.createdAt).toBe('2024-01-02T00:00:00.000Z')
+      expect(result.chat.updatedAt).toBe('2024-01-02T00:00:00.000Z')
+    })
   })
 
   describe('No content handling', () => {

--- a/tests/services/cloud/chat-ingestion.test.ts
+++ b/tests/services/cloud/chat-ingestion.test.ts
@@ -7,12 +7,14 @@ const {
   processRemoteChat,
   emit,
   fetchRawChatContent,
+  reportChatSyncRecovered,
 } = vi.hoisted(() => ({
   getChat: vi.fn(),
   applyRemoteChatIfFresh: vi.fn(),
   processRemoteChat: vi.fn(),
   emit: vi.fn(),
   fetchRawChatContent: vi.fn(),
+  reportChatSyncRecovered: vi.fn(),
 }))
 
 vi.mock('@/services/storage/indexed-db', () => ({
@@ -23,6 +25,7 @@ vi.mock('@/services/storage/chat-events', () => ({ chatEvents: { emit } }))
 vi.mock('@/services/cloud/cloud-storage', () => ({
   cloudStorage: { fetchRawChatContent },
 }))
+vi.mock('@/services/cloud/sync-health', () => ({ reportChatSyncRecovered }))
 
 describe('ingestRemoteChats', () => {
   beforeEach(() => {
@@ -51,6 +54,7 @@ describe('ingestRemoteChats', () => {
       }),
     )
     expect(emit).toHaveBeenCalledWith({ reason: 'sync', ids: ['chat-1'] })
+    expect(reportChatSyncRecovered).toHaveBeenCalledWith('chat-1')
   })
 
   it('falls back when an entry has undefined project metadata', async () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -30,7 +30,6 @@ const {
   clearRevisionCheckpoint,
   reportKeyActionRequired,
   reportChatSyncFailed,
-  reportChatSyncRecovered,
 } = vi.hoisted(() => ({
   drainChatRevisionSync: vi.fn(),
   isAuthenticated: vi.fn(),
@@ -50,7 +49,6 @@ const {
   clearRevisionCheckpoint: vi.fn(),
   reportKeyActionRequired: vi.fn(),
   reportChatSyncFailed: vi.fn(),
-  reportChatSyncRecovered: vi.fn(),
 }))
 
 vi.mock('@/services/cloud/chat-revision-sync', () => ({
@@ -101,7 +99,7 @@ vi.mock('@/services/cloud/streaming-tracker', () => ({
 vi.mock('@/services/cloud/sync-health', () => ({
   reportChatSynced: vi.fn(),
   reportChatSyncFailed,
-  reportChatSyncRecovered,
+  reportChatSyncRecovered: vi.fn(),
   reportKeyActionRequired,
   reportSyncPaused: vi.fn(),
 }))
@@ -1030,14 +1028,16 @@ describe('CloudSyncService revision coordinator routing', () => {
 
     await new CloudSyncService().loadChatsWithPagination({ limit: 10 })
 
-    expect(processRemoteChat).toHaveBeenCalledWith({
-      id: 'imported-chat',
-      plaintext: '{}',
-      syncVersion: 1,
-      formatVersion: 2,
-      updatedAt: '2026-01-02T00:00:00Z',
-      projectId: 'project-1',
-    })
+    expect(processRemoteChat).toHaveBeenCalledWith(
+      {
+        id: 'imported-chat',
+        plaintext: '{}',
+        syncVersion: 1,
+        formatVersion: 2,
+        updatedAt: '2026-01-02T00:00:00Z',
+      },
+      { projectId: 'project-1' },
+    )
   })
 
   it('continues decryption recovery after an individual eviction fails', async () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -29,6 +29,7 @@ const {
   deleteStoredChat,
   clearRevisionCheckpoint,
   reportKeyActionRequired,
+  reportChatSyncFailed,
 } = vi.hoisted(() => ({
   drainChatRevisionSync: vi.fn(),
   isAuthenticated: vi.fn(),
@@ -47,6 +48,7 @@ const {
   deleteStoredChat: vi.fn(),
   clearRevisionCheckpoint: vi.fn(),
   reportKeyActionRequired: vi.fn(),
+  reportChatSyncFailed: vi.fn(),
 }))
 
 vi.mock('@/services/cloud/chat-revision-sync', () => ({
@@ -96,7 +98,7 @@ vi.mock('@/services/cloud/streaming-tracker', () => ({
 }))
 vi.mock('@/services/cloud/sync-health', () => ({
   reportChatSynced: vi.fn(),
-  reportChatSyncFailed: vi.fn(),
+  reportChatSyncFailed,
   reportKeyActionRequired,
   reportSyncPaused: vi.fn(),
 }))
@@ -849,6 +851,85 @@ describe('CloudSyncService revision coordinator routing', () => {
       localChats.set(chat.id, chat)
       return { applied: true }
     })
+
+    await expect(
+      new CloudSyncService().initializeChatPaginationCursor(),
+    ).resolves.toEqual({ hasMore: true, nextToken: 'page-2' })
+  })
+
+  it('keeps paginating after an invalid chat fails to decode', async () => {
+    listChats.mockResolvedValue({
+      conversations: [
+        {
+          id: 'invalid-chat',
+          syncVersion: 2,
+          updatedAt: '2026-01-02T00:00:00Z',
+        },
+        {
+          id: 'readable-chat',
+          syncVersion: 3,
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ],
+      hasMore: true,
+      nextContinuationToken: 'page-3',
+    })
+    downloadChats.mockResolvedValue([
+      { status: 'ok', id: 'invalid-chat', syncVersion: 2, content: 'invalid' },
+      { status: 'ok', id: 'readable-chat', syncVersion: 3, content: '{}' },
+    ])
+    processRemoteChat
+      .mockRejectedValueOnce(new Error('invalid chat'))
+      .mockResolvedValueOnce({
+        chat: { id: 'readable-chat', syncVersion: 3, messages: [] },
+      })
+    getChat.mockResolvedValue(undefined)
+
+    await expect(
+      new CloudSyncService().fetchAndStorePage({
+        limit: 20,
+        continuationToken: 'page-2',
+      }),
+    ).resolves.toEqual({
+      hasMore: true,
+      nextToken: 'page-3',
+      saved: 1,
+      unavailable: [],
+    })
+    expect(reportChatSyncFailed).toHaveBeenCalledWith(
+      'invalid-chat',
+      "This chat couldn't be read",
+    )
+  })
+
+  it('does not block the pagination boundary on an invalid chat', async () => {
+    listChats
+      .mockResolvedValueOnce({
+        conversations: [
+          {
+            id: 'invalid-chat',
+            syncVersion: 2,
+            updatedAt: '2026-01-02T00:00:00Z',
+          },
+        ],
+        hasMore: true,
+        nextContinuationToken: 'page-2',
+      })
+      .mockResolvedValueOnce({
+        conversations: [
+          {
+            id: 'uncached-chat',
+            syncVersion: 3,
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+        hasMore: false,
+      })
+    getChat.mockResolvedValue(undefined)
+    downloadChats.mockResolvedValue([
+      { status: 'ok', id: 'invalid-chat', syncVersion: 2, content: 'invalid' },
+    ])
+    processRemoteChat.mockRejectedValue(new Error('invalid chat'))
 
     await expect(
       new CloudSyncService().initializeChatPaginationCursor(),

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -30,6 +30,7 @@ const {
   clearRevisionCheckpoint,
   reportKeyActionRequired,
   reportChatSyncFailed,
+  reportChatSyncRecovered,
 } = vi.hoisted(() => ({
   drainChatRevisionSync: vi.fn(),
   isAuthenticated: vi.fn(),
@@ -49,6 +50,7 @@ const {
   clearRevisionCheckpoint: vi.fn(),
   reportKeyActionRequired: vi.fn(),
   reportChatSyncFailed: vi.fn(),
+  reportChatSyncRecovered: vi.fn(),
 }))
 
 vi.mock('@/services/cloud/chat-revision-sync', () => ({
@@ -99,6 +101,7 @@ vi.mock('@/services/cloud/streaming-tracker', () => ({
 vi.mock('@/services/cloud/sync-health', () => ({
   reportChatSynced: vi.fn(),
   reportChatSyncFailed,
+  reportChatSyncRecovered,
   reportKeyActionRequired,
   reportSyncPaused: vi.fn(),
 }))
@@ -1004,6 +1007,37 @@ describe('CloudSyncService revision coordinator routing', () => {
       }),
     ).rejects.toThrow('Remote chat page is incomplete')
     expect(getAllChats).not.toHaveBeenCalled()
+  })
+
+  it('passes list metadata into chats decoded for export', async () => {
+    listChats.mockResolvedValue({
+      conversations: [
+        {
+          id: 'imported-chat',
+          syncVersion: 1,
+          updatedAt: '2026-01-02T00:00:00Z',
+          projectId: 'project-1',
+        },
+      ],
+      hasMore: false,
+    })
+    downloadChats.mockResolvedValue([
+      { status: 'ok', id: 'imported-chat', syncVersion: 1, content: '{}' },
+    ])
+    processRemoteChat.mockResolvedValueOnce({
+      chat: { id: 'imported-chat', syncVersion: 1, messages: [] },
+    })
+
+    await new CloudSyncService().loadChatsWithPagination({ limit: 10 })
+
+    expect(processRemoteChat).toHaveBeenCalledWith({
+      id: 'imported-chat',
+      plaintext: '{}',
+      syncVersion: 1,
+      formatVersion: 2,
+      updatedAt: '2026-01-02T00:00:00Z',
+      projectId: 'project-1',
+    })
   })
 
   it('continues decryption recovery after an individual eviction fails', async () => {

--- a/tests/services/cloud/sync-health.test.ts
+++ b/tests/services/cloud/sync-health.test.ts
@@ -2,6 +2,7 @@ import {
   getSyncHealthSnapshot,
   reportChatSynced,
   reportChatSyncFailed,
+  reportChatSyncRecovered,
   reportKeyActionRequired,
   reportKeyHealthy,
   reportSyncPaused,
@@ -69,6 +70,19 @@ describe('sync-health store', () => {
 
     reportChatSynced('chat-2')
     expect(syncHealthNeedsAttention(getSyncHealthSnapshot())).toBe(false)
+  })
+
+  it('clears a recovered chat without lifting the account gate', () => {
+    reportChatSyncFailed('chat-1', 'nope')
+    reportKeyActionRequired('account-blocked')
+
+    reportChatSyncRecovered('chat-1')
+
+    expect(getSyncHealthSnapshot().failedChats).toEqual({})
+    expect(getSyncHealthSnapshot().gate).toMatchObject({
+      kind: 'action-required',
+      reason: 'account-blocked',
+    })
   })
 
   it('only escalates a paused gate after the attention window', () => {


### PR DESCRIPTION
- Continue loading cloud history past chats that cannot be decoded while retaining retries for storage failures.
- Recover chats with incomplete document data and preserve page-backed document text in exports.
- Clear stale per-chat sync warnings after successful ingestion.