### PR TITLE
chore: prepare release v1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinfoil-chat",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinfoil-chat",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@apple/mapkit-loader": "^0.2.1",
         "@braintree/sanitize-url": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil-chat",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "dev": "concurrently \"npm run dev:backend\" \"npm run dev:frontend\"",
     "dev:frontend": "next dev",


### PR DESCRIPTION
## Summary
- update package versions for v1.0.4
- prepare the matching release tag

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `tinfoil-chat` to v1.0.4 in `package.json` and `package-lock.json` and prepares the matching release tag.

<sup>Written for commit b7f3f7703e0fbae46cf0ff3f1990fafe3c13adb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

