### PR TITLE
Replace Auto Smart/Fast with one Auto model and an intelligence slider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-progress": "^1.1.1",
         "@radix-ui/react-select": "^2.1.4",
+        "@radix-ui/react-slider": "^1.4.7",
         "@radix-ui/react-slot": "^1.1.1",
         "@radix-ui/react-tabs": "^1.1.2",
         "@radix-ui/react-toast": "^1.2.7",
@@ -2554,6 +2555,249 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+      "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/number": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+      "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+      "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-progress": "^1.1.1",
     "@radix-ui/react-select": "^2.1.4",
+    "@radix-ui/react-slider": "^1.4.7",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.7",

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -1,7 +1,6 @@
 import { Favicon } from '@/components/ui/favicon'
 import { Modal, ModalTitle } from '@/components/ui/modal'
 import {
-  DEFAULT_AUTO_INTELLIGENCE_LEVEL,
   getSelectedModelLabel,
   type AutoIntelligenceLevelId,
   type BaseModel,
@@ -210,8 +209,8 @@ interface WelcomeScreenProps {
   setReasoningEffort?: (effort: ReasoningEffort) => void
   thinkingEnabled?: boolean
   setThinkingEnabled?: (enabled: boolean) => void
-  autoIntelligence?: AutoIntelligenceLevelId
-  setAutoIntelligence?: (level: AutoIntelligenceLevelId) => void
+  autoIntelligence: AutoIntelligenceLevelId
+  setAutoIntelligence: (level: AutoIntelligenceLevelId) => void
   codeExecutionEnabled?: boolean
   onCodeExecutionToggle?: () => void
   isTemporaryMode?: boolean
@@ -452,7 +451,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                           data-model-selector
                           aria-haspopup="menu"
                           aria-expanded={expandedLabel === 'model'}
-                          aria-label={`Current model ${getSelectedModelLabel(selectedModel, models, autoIntelligence ?? DEFAULT_AUTO_INTELLIGENCE_LEVEL) ?? ''}`}
+                          aria-label={`Current model ${getSelectedModelLabel(selectedModel, models, autoIntelligence) ?? ''}`}
                           onClick={(e) => {
                             e.preventDefault()
                             e.stopPropagation()
@@ -466,8 +465,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                             const label = getSelectedModelLabel(
                               selectedModel,
                               models,
-                              autoIntelligence ??
-                                DEFAULT_AUTO_INTELLIGENCE_LEVEL,
+                              autoIntelligence,
                             )
                             if (!label) return null
                             return (

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -1,6 +1,11 @@
 import { Favicon } from '@/components/ui/favicon'
 import { Modal, ModalTitle } from '@/components/ui/modal'
-import { findSelectableModel, type BaseModel } from '@/config/models'
+import {
+  DEFAULT_AUTO_INTELLIGENCE_LEVEL,
+  getSelectedModelLabel,
+  type AutoIntelligenceLevelId,
+  type BaseModel,
+} from '@/config/models'
 import { USER_PREFS_NICKNAME } from '@/constants/storage-keys'
 import { useUser } from '@clerk/nextjs'
 import { motion } from 'framer-motion'
@@ -205,6 +210,8 @@ interface WelcomeScreenProps {
   setReasoningEffort?: (effort: ReasoningEffort) => void
   thinkingEnabled?: boolean
   setThinkingEnabled?: (enabled: boolean) => void
+  autoIntelligence?: AutoIntelligenceLevelId
+  setAutoIntelligence?: (level: AutoIntelligenceLevelId) => void
   codeExecutionEnabled?: boolean
   onCodeExecutionToggle?: () => void
   isTemporaryMode?: boolean
@@ -240,6 +247,8 @@ export const WelcomeScreen = memo(function WelcomeScreen({
   setReasoningEffort,
   thinkingEnabled,
   setThinkingEnabled,
+  autoIntelligence,
+  setAutoIntelligence,
   codeExecutionEnabled,
   onCodeExecutionToggle,
   isTemporaryMode,
@@ -443,7 +452,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                           data-model-selector
                           aria-haspopup="menu"
                           aria-expanded={expandedLabel === 'model'}
-                          aria-label={`Current model ${findSelectableModel(selectedModel, models)?.name ?? ''}`}
+                          aria-label={`Current model ${getSelectedModelLabel(selectedModel, models, autoIntelligence ?? DEFAULT_AUTO_INTELLIGENCE_LEVEL) ?? ''}`}
                           onClick={(e) => {
                             e.preventDefault()
                             e.stopPropagation()
@@ -454,15 +463,17 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                           className="flex items-center gap-1 py-1.5 text-content-secondary transition-colors hover:text-content-primary"
                         >
                           {(() => {
-                            const model = findSelectableModel(
+                            const label = getSelectedModelLabel(
                               selectedModel,
                               models,
+                              autoIntelligence ??
+                                DEFAULT_AUTO_INTELLIGENCE_LEVEL,
                             )
-                            if (!model) return null
+                            if (!label) return null
                             return (
                               <>
                                 <span className="text-xs font-medium">
-                                  {model.name}
+                                  {label}
                                 </span>
                                 <svg
                                   className={`h-3 w-3 transition-transform ${expandedLabel === 'model' ? 'rotate-180' : ''}`}
@@ -494,6 +505,8 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                             onEffortChange={setReasoningEffort}
                             thinkingEnabled={thinkingEnabled}
                             onThinkingEnabledChange={setThinkingEnabled}
+                            autoIntelligence={autoIntelligence}
+                            onAutoIntelligenceChange={setAutoIntelligence}
                           />
                         )}
                       </div>

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1,10 +1,12 @@
 import {
+  DEFAULT_AUTO_INTELLIGENCE_LEVEL,
   findSelectableModel,
   getAIModels,
   getCachedAIModels,
   getCachedSystemPromptAndRules,
   getReasoningHistoryPolicy,
   getResolvedModelContextWindowTokens,
+  getSelectedModelLabel,
   getSystemPromptAndRules,
   resolveModelSelection,
   type BaseModel,
@@ -156,6 +158,7 @@ import {
   resolveWebSearchEnabled,
   upsertChatById,
 } from './hooks/chat-operations'
+import { useAutoIntelligence } from './hooks/use-auto-intelligence'
 import { useChatState } from './hooks/use-chat-state'
 import { useCustomSystemPrompt } from './hooks/use-custom-system-prompt'
 import { useMessageQueue } from './hooks/use-message-queue'
@@ -692,6 +695,7 @@ export function ChatInterface({
   // (not per-model) and only surfaced for models whose reasoningConfig opts in.
   const { reasoningEffort, setReasoningEffort } = useReasoningEffort()
   const { thinkingEnabled, setThinkingEnabled } = useThinkingEnabled()
+  const { autoIntelligence, setAutoIntelligence } = useAutoIntelligence()
 
   // Detect platform for keyboard shortcut display
   const isMac = useMemo(() => {
@@ -1020,6 +1024,7 @@ export function ChatInterface({
     scrollToBottom: scrollUserMessageToTop,
     reasoningEffort,
     thinkingEnabled,
+    autoIntelligence,
     initialChatId,
     isLocalChatUrl,
     initialNewChatIsLocalOnly,
@@ -1387,6 +1392,7 @@ export function ChatInterface({
     selectedModel,
     reasoningEffort,
     thinkingEnabled,
+    autoIntelligence,
     webSearchEnabled: effectiveWebSearchEnabled,
     piiCheckEnabled,
   })
@@ -4299,6 +4305,8 @@ export function ChatInterface({
                       setReasoningEffort={setReasoningEffort}
                       thinkingEnabled={thinkingEnabled}
                       setThinkingEnabled={setThinkingEnabled}
+                      autoIntelligence={autoIntelligence}
+                      setAutoIntelligence={setAutoIntelligence}
                       codeExecutionEnabled={
                         canEnableCodeExecution ? codeExecutionEnabled : false
                       }
@@ -4433,7 +4441,7 @@ export function ChatInterface({
                                 data-model-selector
                                 aria-haspopup="menu"
                                 aria-expanded={expandedLabel === 'model'}
-                                aria-label={`Current model ${findSelectableModel(selectedModel, models)?.name ?? ''}`}
+                                aria-label={`Current model ${getSelectedModelLabel(selectedModel, models, autoIntelligence ?? DEFAULT_AUTO_INTELLIGENCE_LEVEL) ?? ''}`}
                                 onClick={(e) => {
                                   e.preventDefault()
                                   e.stopPropagation()
@@ -4442,15 +4450,17 @@ export function ChatInterface({
                                 className="flex items-center gap-1 py-1.5 text-content-secondary transition-colors hover:text-content-primary"
                               >
                                 {(() => {
-                                  const model = findSelectableModel(
+                                  const label = getSelectedModelLabel(
                                     selectedModel,
                                     models,
+                                    autoIntelligence ??
+                                      DEFAULT_AUTO_INTELLIGENCE_LEVEL,
                                   )
-                                  if (!model) return null
+                                  if (!label) return null
                                   return (
                                     <>
                                       <span className="text-xs font-medium">
-                                        {model.name}
+                                        {label}
                                       </span>
                                       <svg
                                         className={`h-3 w-3 transition-transform ${expandedLabel === 'model' ? 'rotate-180' : ''}`}
@@ -4481,6 +4491,8 @@ export function ChatInterface({
                                   onEffortChange={setReasoningEffort}
                                   thinkingEnabled={thinkingEnabled}
                                   onThinkingEnabledChange={setThinkingEnabled}
+                                  autoIntelligence={autoIntelligence}
+                                  onAutoIntelligenceChange={setAutoIntelligence}
                                 />
                               )}
                             </div>

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1,5 +1,4 @@
 import {
-  DEFAULT_AUTO_INTELLIGENCE_LEVEL,
   findSelectableModel,
   getAIModels,
   getCachedAIModels,
@@ -4441,7 +4440,7 @@ export function ChatInterface({
                                 data-model-selector
                                 aria-haspopup="menu"
                                 aria-expanded={expandedLabel === 'model'}
-                                aria-label={`Current model ${getSelectedModelLabel(selectedModel, models, autoIntelligence ?? DEFAULT_AUTO_INTELLIGENCE_LEVEL) ?? ''}`}
+                                aria-label={`Current model ${getSelectedModelLabel(selectedModel, models, autoIntelligence) ?? ''}`}
                                 onClick={(e) => {
                                   e.preventDefault()
                                   e.stopPropagation()
@@ -4453,8 +4452,7 @@ export function ChatInterface({
                                   const label = getSelectedModelLabel(
                                     selectedModel,
                                     models,
-                                    autoIntelligence ??
-                                      DEFAULT_AUTO_INTELLIGENCE_LEVEL,
+                                    autoIntelligence,
                                   )
                                   if (!label) return null
                                   return (

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -1,4 +1,8 @@
-import { findSelectableModel, type BaseModel } from '@/config/models'
+import {
+  findSelectableModel,
+  type AutoIntelligenceLevelId,
+  type BaseModel,
+} from '@/config/models'
 import { useChatPrint } from '@/hooks/use-chat-print'
 import {
   REASONING_HISTORY_POLICIES,
@@ -78,6 +82,8 @@ type ChatMessagesProps = {
   setReasoningEffort?: (effort: ReasoningEffort) => void
   thinkingEnabled?: boolean
   setThinkingEnabled?: (enabled: boolean) => void
+  autoIntelligence?: AutoIntelligenceLevelId
+  setAutoIntelligence?: (level: AutoIntelligenceLevelId) => void
   codeExecutionEnabled?: boolean
   onCodeExecutionToggle?: () => void
   isTemporaryMode?: boolean
@@ -313,6 +319,8 @@ export function ChatMessages({
   setReasoningEffort,
   thinkingEnabled,
   setThinkingEnabled,
+  autoIntelligence,
+  setAutoIntelligence,
   codeExecutionEnabled,
   onCodeExecutionToggle,
   isTemporaryMode,
@@ -528,6 +536,8 @@ export function ChatMessages({
             setReasoningEffort={setReasoningEffort}
             thinkingEnabled={thinkingEnabled}
             setThinkingEnabled={setThinkingEnabled}
+            autoIntelligence={autoIntelligence}
+            setAutoIntelligence={setAutoIntelligence}
             codeExecutionEnabled={codeExecutionEnabled}
             onCodeExecutionToggle={onCodeExecutionToggle}
             isTemporaryMode={isTemporaryMode}

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -82,8 +82,8 @@ type ChatMessagesProps = {
   setReasoningEffort?: (effort: ReasoningEffort) => void
   thinkingEnabled?: boolean
   setThinkingEnabled?: (enabled: boolean) => void
-  autoIntelligence?: AutoIntelligenceLevelId
-  setAutoIntelligence?: (level: AutoIntelligenceLevelId) => void
+  autoIntelligence: AutoIntelligenceLevelId
+  setAutoIntelligence: (level: AutoIntelligenceLevelId) => void
   codeExecutionEnabled?: boolean
   onCodeExecutionToggle?: () => void
   isTemporaryMode?: boolean

--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -1,4 +1,4 @@
-import { getAIModels, type AutoTier, type BaseModel } from '@/config/models'
+import { getAIModels, type BaseModel } from '@/config/models'
 import {
   getSecureFetch,
   getSessionToken,
@@ -93,7 +93,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
     mimeType: string,
   ): Promise<string> => {
     const models = (await getAIModels()) ?? []
-    const fastTier: AutoTier = 'fast'
+    const fastTier = 'fast'
     const isMultimodalChat = (m: BaseModel) =>
       Boolean(m.multimodal && m.chat && m.type === 'chat')
     // Prefer a fast multimodal model over larger reasoning-heavy ones

--- a/src/components/chat/genui/retry.ts
+++ b/src/components/chat/genui/retry.ts
@@ -1,6 +1,6 @@
 import type { ReasoningEffort } from '@/components/chat/hooks/use-reasoning-effort'
 import type { Chat, Message } from '@/components/chat/types'
-import type { BaseModel } from '@/config/models'
+import type { AutoIntelligenceLevelId, BaseModel } from '@/config/models'
 import {
   StructuredCompletionError,
   sendStructuredCompletion,
@@ -109,6 +109,7 @@ export async function regenerateToolCallArguments({
   autoCandidates,
   reasoningEffort,
   thinkingEnabled,
+  autoIntelligence,
 }: {
   toolName: string
   originalArguments?: string
@@ -117,6 +118,7 @@ export async function regenerateToolCallArguments({
   autoCandidates?: BaseModel[]
   reasoningEffort?: ReasoningEffort
   thinkingEnabled?: boolean
+  autoIntelligence?: AutoIntelligenceLevelId
 }): Promise<string> {
   if (!isGenUIToolName(toolName)) {
     throw new ArtifactRetryError('unavailable_target')
@@ -167,6 +169,7 @@ export async function regenerateToolCallArguments({
       jsonSchema,
       reasoningEffort,
       thinkingEnabled,
+      autoIntelligence,
     })
   } catch (error) {
     const retryError = mapStructuredError(error)

--- a/src/components/chat/hooks/use-auto-intelligence.ts
+++ b/src/components/chat/hooks/use-auto-intelligence.ts
@@ -30,15 +30,26 @@ export function useAutoIntelligence() {
         setAutoIntelligenceState(event.detail)
       }
     }
+    // Other tabs write the same key; a null key means storage was cleared.
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== null && event.key !== SETTINGS_AUTO_INTELLIGENCE) return
+      setAutoIntelligenceState(
+        isAutoIntelligenceLevelId(event.newValue)
+          ? event.newValue
+          : DEFAULT_AUTO_INTELLIGENCE_LEVEL,
+      )
+    }
     window.addEventListener(
       AUTO_INTELLIGENCE_CHANGED_EVENT,
       handleChanged as EventListener,
     )
+    window.addEventListener('storage', handleStorage)
     return () => {
       window.removeEventListener(
         AUTO_INTELLIGENCE_CHANGED_EVENT,
         handleChanged as EventListener,
       )
+      window.removeEventListener('storage', handleStorage)
     }
   }, [])
 

--- a/src/components/chat/hooks/use-auto-intelligence.ts
+++ b/src/components/chat/hooks/use-auto-intelligence.ts
@@ -1,0 +1,54 @@
+import {
+  DEFAULT_AUTO_INTELLIGENCE_LEVEL,
+  isAutoIntelligenceLevelId,
+  type AutoIntelligenceLevelId,
+} from '@/config/models'
+import { SETTINGS_AUTO_INTELLIGENCE } from '@/constants/storage-keys'
+import { useCallback, useEffect, useState } from 'react'
+
+const AUTO_INTELLIGENCE_CHANGED_EVENT = 'autoIntelligenceChanged'
+
+/**
+ * Tracks the Auto intelligence slider position. Persisted device-locally, like
+ * the selected model, and broadcast so every mounted picker stays in sync.
+ * Reads storage in the lazy initializer so the first render already reflects
+ * the saved level and an early submit does not send the default.
+ */
+export function useAutoIntelligence() {
+  const [autoIntelligence, setAutoIntelligenceState] =
+    useState<AutoIntelligenceLevelId>(() => {
+      if (typeof window === 'undefined') return DEFAULT_AUTO_INTELLIGENCE_LEVEL
+      const saved = window.localStorage.getItem(SETTINGS_AUTO_INTELLIGENCE)
+      return isAutoIntelligenceLevelId(saved)
+        ? saved
+        : DEFAULT_AUTO_INTELLIGENCE_LEVEL
+    })
+
+  useEffect(() => {
+    const handleChanged = (event: CustomEvent<AutoIntelligenceLevelId>) => {
+      if (isAutoIntelligenceLevelId(event.detail)) {
+        setAutoIntelligenceState(event.detail)
+      }
+    }
+    window.addEventListener(
+      AUTO_INTELLIGENCE_CHANGED_EVENT,
+      handleChanged as EventListener,
+    )
+    return () => {
+      window.removeEventListener(
+        AUTO_INTELLIGENCE_CHANGED_EVENT,
+        handleChanged as EventListener,
+      )
+    }
+  }, [])
+
+  const setAutoIntelligence = useCallback((level: AutoIntelligenceLevelId) => {
+    setAutoIntelligenceState(level)
+    localStorage.setItem(SETTINGS_AUTO_INTELLIGENCE, level)
+    window.dispatchEvent(
+      new CustomEvent(AUTO_INTELLIGENCE_CHANGED_EVENT, { detail: level }),
+    )
+  }, [])
+
+  return { autoIntelligence, setAutoIntelligence }
+}

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -18,6 +18,7 @@
  *   this hook are derived for the currently-viewed chat
  */
 import { useProject } from '@/components/project'
+import type { AutoIntelligenceLevelId } from '@/config/models'
 import {
   getKnownModelDisplayName,
   resolveModelSelection,
@@ -106,6 +107,7 @@ interface UseChatMessagingProps {
   scrollToBottom?: () => void
   reasoningEffort?: ReasoningEffort
   thinkingEnabled?: boolean
+  autoIntelligence?: AutoIntelligenceLevelId
   webSearchAvailable?: boolean
   codeExecutionEnabled?: boolean
   piiCheckEnabled?: boolean
@@ -208,6 +210,7 @@ export function useChatMessaging({
   scrollToBottom,
   reasoningEffort,
   thinkingEnabled,
+  autoIntelligence,
   webSearchAvailable,
   codeExecutionEnabled,
   piiCheckEnabled,
@@ -1235,6 +1238,7 @@ export function useChatMessaging({
           signal: controller.signal,
           reasoningEffort,
           thinkingEnabled,
+          autoIntelligence,
           webSearchEnabled: chatWebSearchEnabled,
           codeExecutionEnabled,
           piiCheckEnabled,
@@ -1672,6 +1676,7 @@ export function useChatMessaging({
       scrollToBottom,
       reasoningEffort,
       thinkingEnabled,
+      autoIntelligence,
       isProjectMode,
       activeProject,
       webSearchAvailable,
@@ -1842,6 +1847,7 @@ export function useChatMessaging({
           autoCandidates,
           reasoningEffort,
           thinkingEnabled,
+          autoIntelligence,
         })
       } catch (error) {
         const retryError =
@@ -1925,6 +1931,7 @@ export function useChatMessaging({
       models,
       reasoningEffort,
       thinkingEnabled,
+      autoIntelligence,
       storeHistory,
       setChats,
       setCurrentChat,

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -1,3 +1,4 @@
+import type { AutoIntelligenceLevelId } from '@/config/models'
 import { isModelNameAvailable, type BaseModel } from '@/config/models'
 import { useExecSnapshot } from '@/services/exec-snapshot/use-exec-snapshot'
 import { logWarning } from '@/utils/error-handling'
@@ -94,6 +95,7 @@ export function useChatState({
   scrollToBottom,
   reasoningEffort,
   thinkingEnabled,
+  autoIntelligence,
   initialChatId,
   isLocalChatUrl = false,
   initialNewChatIsLocalOnly = false,
@@ -110,6 +112,7 @@ export function useChatState({
   scrollToBottom?: () => void
   reasoningEffort?: ReasoningEffort
   thinkingEnabled?: boolean
+  autoIntelligence?: AutoIntelligenceLevelId
   initialChatId?: string | null
   isLocalChatUrl?: boolean
   initialNewChatIsLocalOnly?: boolean
@@ -244,6 +247,7 @@ export function useChatState({
     scrollToBottom,
     reasoningEffort,
     thinkingEnabled,
+    autoIntelligence,
     webSearchAvailable,
     // code-exec requires encryptionKey for snapshots
     codeExecutionEnabled:

--- a/src/components/chat/hooks/use-sidebar-chat.ts
+++ b/src/components/chat/hooks/use-sidebar-chat.ts
@@ -10,6 +10,7 @@
  * in-memory messages. This keeps parsing, thinking mode, web search, and
  * citation processing identical to the main chat view.
  */
+import type { AutoIntelligenceLevelId } from '@/config/models'
 import {
   getKnownModelDisplayName,
   resolveModelSelection,
@@ -30,6 +31,7 @@ interface UseSidebarChatProps {
   selectedModel: AIModel
   reasoningEffort?: ReasoningEffort
   thinkingEnabled?: boolean
+  autoIntelligence?: AutoIntelligenceLevelId
   webSearchEnabled?: boolean
   piiCheckEnabled?: boolean
 }
@@ -85,6 +87,7 @@ export function useSidebarChat({
   selectedModel,
   reasoningEffort,
   thinkingEnabled,
+  autoIntelligence,
   webSearchEnabled,
   piiCheckEnabled,
 }: UseSidebarChatProps): UseSidebarChatReturn {
@@ -198,6 +201,7 @@ export function useSidebarChat({
             signal: controller.signal,
             reasoningEffort,
             thinkingEnabled,
+            autoIntelligence,
             webSearchEnabled,
             piiCheckEnabled,
           })
@@ -285,6 +289,7 @@ export function useSidebarChat({
       rules,
       reasoningEffort,
       thinkingEnabled,
+      autoIntelligence,
       webSearchEnabled,
       piiCheckEnabled,
     ],

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -1,6 +1,11 @@
+import { SteppedSlider } from '@/components/ui/stepped-slider'
 import {
-  getAutoModels,
+  AUTO_INTELLIGENCE_LEVELS,
+  getAutoIntelligenceLevel,
+  getAutoModel,
+  isAutoModelId,
   resolveModelSelection,
+  type AutoIntelligenceLevelId,
   type BaseModel,
 } from '@/config/models'
 import {
@@ -37,6 +42,9 @@ const EFFORT_OPTIONS: {
 const EFFORT_EXPLAINER =
   'Higher effort means more thorough responses, but takes longer.'
 
+const INTELLIGENCE_EXPLAINER =
+  'Higher intelligence picks a more capable model and thinks longer.'
+
 const MOBILE_BREAKPOINT_PX = 768
 const EFFORT_FLYOUT_WIDTH_PX = 240
 const EFFORT_FLYOUT_GAP_PX = 8
@@ -50,6 +58,7 @@ const MIN_TOP_MODEL_COUNT = 3
 const MENU_PADDING_PX = 16
 const MENU_DIVIDER_HEIGHT_PX = 9
 const AUTO_MODEL_ROW_HEIGHT_PX = 40
+const INTELLIGENCE_SLIDER_HEIGHT_PX = 84
 const MODEL_ROW_HEIGHT_PX = 56
 const EFFORT_ROW_HEIGHT_PX = 40
 const THINKING_ROW_HEIGHT_PX = 56
@@ -65,6 +74,8 @@ type ModelSelectorProps = {
   onEffortChange?: (effort: ReasoningEffort) => void
   thinkingEnabled?: boolean
   onThinkingEnabledChange?: (enabled: boolean) => void
+  autoIntelligence?: AutoIntelligenceLevelId
+  onAutoIntelligenceChange?: (level: AutoIntelligenceLevelId) => void
 }
 
 export function ModelSelector({
@@ -77,6 +88,8 @@ export function ModelSelector({
   onEffortChange,
   thinkingEnabled,
   onThinkingEnabledChange,
+  autoIntelligence,
+  onAutoIntelligenceChange,
 }: ModelSelectorProps) {
   const [failedImages, setFailedImages] = useState<Record<string, boolean>>({})
   const [loadedImages, setLoadedImages] = useState<Record<string, boolean>>({})
@@ -275,13 +288,21 @@ export function ModelSelector({
     }
   }, [showEffortOptions, isMobileLayout, recalcEffortFlyout])
 
-  const autoModels = getAutoModels(models)
+  const autoModel = getAutoModel(models)
+  const isAutoSelected = isAutoModelId(selectedModel)
+  const showIntelligenceSlider =
+    isAutoSelected &&
+    autoModel !== undefined &&
+    autoIntelligence !== undefined &&
+    onAutoIntelligenceChange !== undefined
 
   // Reasoning controls live at the bottom of the menu and reflect the
-  // currently selected model (for Auto entries, the representative model the
-  // selection resolves to). They only render when the parent wires the
-  // reasoning props and the model exposes the matching capability.
-  const resolvedModel = resolveModelSelection(selectedModel, models).model
+  // currently selected model. They only render when the parent wires the
+  // reasoning props and the model exposes the matching capability. Auto hides
+  // them: the router chooses the effort from the intelligence level.
+  const resolvedModel = isAutoSelected
+    ? undefined
+    : resolveModelSelection(selectedModel, models).model
   const showEffort =
     supportsReasoningEffort(resolvedModel) &&
     reasoningEffort !== undefined &&
@@ -302,8 +323,8 @@ export function ModelSelector({
   const availableHeight = Number.parseInt(dynamicStyles.maxHeight, 10) || 0
   const fixedHeight =
     MENU_PADDING_PX +
-    autoModels.length * AUTO_MODEL_ROW_HEIGHT_PX +
-    (autoModels.length > 0 ? MENU_DIVIDER_HEIGHT_PX : 0) +
+    (autoModel ? AUTO_MODEL_ROW_HEIGHT_PX + MENU_DIVIDER_HEIGHT_PX : 0) +
+    (showIntelligenceSlider ? INTELLIGENCE_SLIDER_HEIGHT_PX : 0) +
     (showEffort || showThinkingToggle ? MENU_DIVIDER_HEIGHT_PX : 0) +
     (showEffort ? EFFORT_ROW_HEIGHT_PX : 0) +
     (showThinkingToggle ? THINKING_ROW_HEIGHT_PX : 0) +
@@ -391,7 +412,9 @@ export function ModelSelector({
   )
 
   const renderModelItem = (model: BaseModel) => {
-    const isSelected = model.modelName === selectedModel
+    const isSelected = model.isAuto
+      ? isAutoSelected
+      : model.modelName === selectedModel
     return (
       <button
         type="button"
@@ -477,9 +500,37 @@ export function ModelSelector({
           if (showEffortOptions && !isMobileLayout) recalcEffortFlyout()
         }}
       >
-        {autoModels.map((model) => renderModelItem(model))}
+        {autoModel && renderModelItem(autoModel)}
 
-        {autoModels.length > 0 && (
+        {showIntelligenceSlider && (
+          <div
+            className="px-3 pb-2 pt-1"
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+            onTouchMove={(e) => e.stopPropagation()}
+            onTouchEnd={(e) => e.stopPropagation()}
+          >
+            <div className="mb-2 flex items-center justify-between text-xs">
+              <span className="font-medium text-content-secondary">
+                Intelligence
+              </span>
+              <span className="text-content-muted">
+                {getAutoIntelligenceLevel(autoIntelligence).label}
+              </span>
+            </div>
+            <SteppedSlider
+              steps={AUTO_INTELLIGENCE_LEVELS}
+              value={autoIntelligence}
+              onValueChange={onAutoIntelligenceChange}
+              aria-label="Auto intelligence"
+            />
+            <p className="mt-2 text-xs text-content-muted">
+              {INTELLIGENCE_EXPLAINER}
+            </p>
+          </div>
+        )}
+
+        {autoModel && (
           <div className="mx-3 my-1 border-t border-border-subtle" />
         )}
 

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -503,13 +503,7 @@ export function ModelSelector({
         {autoModel && renderModelItem(autoModel)}
 
         {showIntelligenceSlider && (
-          <div
-            className="px-3 pb-2 pt-1"
-            onMouseDown={(e) => e.stopPropagation()}
-            onTouchStart={(e) => e.stopPropagation()}
-            onTouchMove={(e) => e.stopPropagation()}
-            onTouchEnd={(e) => e.stopPropagation()}
-          >
+          <div className="px-3 pb-2 pt-1">
             <div className="mb-2 flex items-center justify-between text-xs">
               <span className="font-medium text-content-secondary">
                 Intelligence

--- a/src/components/ui/stepped-slider.tsx
+++ b/src/components/ui/stepped-slider.tsx
@@ -47,7 +47,6 @@ export function SteppedSlider<T extends string>({
         const step = steps[next]
         if (step && step.id !== value) onValueChange(step.id)
       }}
-      aria-label={ariaLabel}
     >
       <SliderPrimitive.Track className="relative h-8 w-full grow overflow-hidden rounded-full bg-content-muted/25">
         <SliderPrimitive.Range className="absolute h-full rounded-full bg-brand-accent-light" />
@@ -69,6 +68,7 @@ export function SteppedSlider<T extends string>({
       </SliderPrimitive.Track>
       <SliderPrimitive.Thumb
         className="block h-7 w-7 rounded-full bg-white shadow-md ring-offset-surface-chat transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-light focus-visible:ring-offset-2"
+        aria-label={ariaLabel}
         aria-valuetext={steps[index]?.label}
       />
     </SliderPrimitive.Root>

--- a/src/components/ui/stepped-slider.tsx
+++ b/src/components/ui/stepped-slider.tsx
@@ -1,0 +1,76 @@
+import * as SliderPrimitive from '@radix-ui/react-slider'
+
+import { cn } from './utils'
+
+export type SteppedSliderStep<T extends string> = {
+  id: T
+  label: string
+}
+
+type SteppedSliderProps<T extends string> = {
+  steps: readonly SteppedSliderStep<T>[]
+  value: T
+  onValueChange: (value: T) => void
+  'aria-label': string
+  className?: string
+}
+
+/**
+ * A discrete slider with one stop per step. The track is as tall as a switch
+ * so the fill reads as a level indicator; a dot marks each stop and the thumb
+ * covers the current one.
+ */
+export function SteppedSlider<T extends string>({
+  steps,
+  value,
+  onValueChange,
+  'aria-label': ariaLabel,
+  className,
+}: SteppedSliderProps<T>) {
+  const index = Math.max(
+    0,
+    steps.findIndex((step) => step.id === value),
+  )
+  const lastIndex = steps.length - 1
+
+  return (
+    <SliderPrimitive.Root
+      className={cn(
+        'relative flex h-8 w-full touch-none select-none items-center',
+        className,
+      )}
+      min={0}
+      max={lastIndex}
+      step={1}
+      value={[index]}
+      onValueChange={([next]) => {
+        const step = steps[next]
+        if (step && step.id !== value) onValueChange(step.id)
+      }}
+      aria-label={ariaLabel}
+    >
+      <SliderPrimitive.Track className="relative h-8 w-full grow overflow-hidden rounded-full bg-content-muted/25">
+        <SliderPrimitive.Range className="absolute h-full rounded-full bg-brand-accent-light" />
+        <div
+          className="pointer-events-none absolute inset-y-0 flex items-center justify-between"
+          style={{ left: '1rem', right: '1rem' }}
+          aria-hidden="true"
+        >
+          {steps.map((step, i) => (
+            <span
+              key={step.id}
+              className={cn(
+                'h-1.5 w-1.5 rounded-full',
+                i <= index ? 'bg-white/60' : 'bg-content-muted/70',
+              )}
+            />
+          ))}
+        </div>
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        className="block h-7 w-7 rounded-full bg-white shadow-md ring-offset-surface-chat transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-light focus-visible:ring-offset-2"
+        aria-valuetext={steps[index]?.label}
+      />
+    </SliderPrimitive.Root>
+  )
+}

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -198,15 +198,16 @@ export const AUTO_MODEL_OPTIONS_FIELD = 'auto_model_options'
 const LEGACY_AUTO_MODEL_IDS = ['auto-smart', 'auto-fast'] as const
 
 /**
- * The five positions of the Auto intelligence slider. Each maps to a level on
- * the router's normalized 0-100 scale, where 100 is the most capable model and
+ * The positions of the Auto intelligence slider. Each maps to a level on the
+ * router's normalized 0-100 scale, where 100 is the most capable model and
  * effort currently in the catalog.
  */
 export const AUTO_INTELLIGENCE_LEVELS = [
-  { id: 'low', label: 'Low', value: 0 },
-  { id: 'medium', label: 'Med', value: 25 },
-  { id: 'high', label: 'High', value: 50 },
-  { id: 'extra', label: 'Extra', value: 75 },
+  { id: 'instant', label: 'Instant', value: 0 },
+  { id: 'low', label: 'Low', value: 20 },
+  { id: 'medium', label: 'Med', value: 40 },
+  { id: 'high', label: 'High', value: 60 },
+  { id: 'extra', label: 'Extra', value: 80 },
   { id: 'max', label: 'Max', value: 100 },
 ] as const
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -78,9 +78,16 @@ const DEV_MODELS: BaseModel[] = [
 const modelDisplayNames = new Map<string, string>()
 
 const rememberModelDisplayNames = (models: BaseModel[]): BaseModel[] => {
-  const autoModel = getAutoModel(models)
-  for (const model of autoModel ? [...models, autoModel] : models) {
+  for (const model of models) {
     modelDisplayNames.set(model.modelName, model.name)
+  }
+  // Synced chats may still carry a legacy Auto tier id; every Auto id shows
+  // the same label.
+  const autoModel = getAutoModel(models)
+  if (autoModel) {
+    for (const id of [AUTO_MODEL_ID, ...LEGACY_AUTO_MODEL_IDS]) {
+      modelDisplayNames.set(id, autoModel.name)
+    }
   }
   return models
 }

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -78,7 +78,8 @@ const DEV_MODELS: BaseModel[] = [
 const modelDisplayNames = new Map<string, string>()
 
 const rememberModelDisplayNames = (models: BaseModel[]): BaseModel[] => {
-  for (const model of [...models, ...getAutoModels(models)]) {
+  const autoModel = getAutoModel(models)
+  for (const model of autoModel ? [...models, autoModel] : models) {
     modelDisplayNames.set(model.modelName, model.name)
   }
   return models
@@ -129,8 +130,6 @@ export type ReasoningConfig = {
   reasoningHistoryPolicy?: ReasoningHistoryPolicy
 }
 
-export type AutoTier = 'smart' | 'fast'
-
 /**
  * Settings the chat clients read for a model. Present only on chat models; the
  * controlplane keeps everything a chat client needs under this block.
@@ -141,7 +140,7 @@ export type ChatConfig = {
    * model's raw capability advertised to API consumers.
    */
   contextWindowTokens?: number
-  /** Open set of model tags, including Auto routing tiers ("smart", "fast"). */
+  /** Open set of model tags (e.g. "smart", "fast") shown as picker hints. */
   attributes?: string[]
   /** Short "Best for x" blurb shown under the name in the model picker. */
   descriptionShort?: string
@@ -165,117 +164,150 @@ export type BaseModel = {
   multimodal?: boolean
   toolCalling?: boolean
   chatConfig?: ChatConfig
-  /** True for the synthetic Auto picker entries; never a real backend model. */
+  /** True for the synthetic Auto picker entry; never a real backend model. */
   isAuto?: boolean
-  /** Routing tier an Auto entry resolves; only set when isAuto is true. */
-  tier?: AutoTier
   endpoint?: string
   /** Extra fields merged into the chat completion request body */
   requestParams?: Record<string, unknown>
 }
 
-/** Selectable picker ids for the two Auto routing options. */
-export const AUTO_SMART_ID = 'auto-smart'
-export const AUTO_FAST_ID = 'auto-fast'
+/**
+ * Picker id and wire value for Auto. The router treats `model: "auto"` as a
+ * sentinel and picks a concrete model and reasoning effort from the requested
+ * intelligence level.
+ */
+export const AUTO_MODEL_ID = 'auto'
 
 /**
- * Wire value placed in the request `model` field when an Auto option is
- * selected. The router treats this as a sentinel and reads the candidate list
- * from the `auto_model_options` body blob.
+ * Router-only body field. Carries `{ intelligence: <0-100> }` so the router
+ * knows how capable a model the user asked for.
  */
-export const AUTO_REQUEST_MODEL = 'auto'
-
-/** Router-only body field carrying the ordered Auto candidate list. */
 export const AUTO_MODEL_OPTIONS_FIELD = 'auto_model_options'
 
-const isAutoId = (modelName: string): boolean =>
-  modelName === AUTO_SMART_ID || modelName === AUTO_FAST_ID
+/**
+ * Picker ids from the previous two-tier Auto design. Still present in saved
+ * settings and synced chats; both map onto the single Auto entry.
+ */
+const LEGACY_AUTO_MODEL_IDS = ['auto-smart', 'auto-fast'] as const
+
+/**
+ * The five positions of the Auto intelligence slider. Each maps to a level on
+ * the router's normalized 0-100 scale, where 100 is the most capable model and
+ * effort currently in the catalog.
+ */
+export const AUTO_INTELLIGENCE_LEVELS = [
+  { id: 'low', label: 'Low', value: 0 },
+  { id: 'medium', label: 'Med', value: 25 },
+  { id: 'high', label: 'High', value: 50 },
+  { id: 'extra', label: 'Extra', value: 75 },
+  { id: 'max', label: 'Max', value: 100 },
+] as const
+
+export type AutoIntelligenceLevel = (typeof AUTO_INTELLIGENCE_LEVELS)[number]
+export type AutoIntelligenceLevelId = AutoIntelligenceLevel['id']
+
+export const DEFAULT_AUTO_INTELLIGENCE_LEVEL: AutoIntelligenceLevelId = 'high'
+
+export const isAutoIntelligenceLevelId = (
+  value: unknown,
+): value is AutoIntelligenceLevelId =>
+  AUTO_INTELLIGENCE_LEVELS.some((level) => level.id === value)
+
+export const getAutoIntelligenceLevel = (
+  id: AutoIntelligenceLevelId,
+): AutoIntelligenceLevel =>
+  AUTO_INTELLIGENCE_LEVELS.find((level) => level.id === id) ??
+  AUTO_INTELLIGENCE_LEVELS[0]
+
+/** Collapsed picker label for Auto at the given level, e.g. "Auto · High". */
+export const getAutoDisplayName = (level: AutoIntelligenceLevelId): string =>
+  `Auto · ${getAutoIntelligenceLevel(level).label}`
+
+/**
+ * Label for the collapsed model picker trigger: "Auto · <level>" when Auto is
+ * selected, otherwise the model's name.
+ */
+export const getSelectedModelLabel = (
+  selectedModel: string,
+  models: BaseModel[],
+  autoIntelligence: AutoIntelligenceLevelId,
+): string | undefined => {
+  const model = findSelectableModel(selectedModel, models)
+  if (!model) return undefined
+  return model.isAuto ? getAutoDisplayName(autoIntelligence) : model.name
+}
+
+export const isAutoModelId = (modelName: string): boolean =>
+  modelName === AUTO_MODEL_ID ||
+  (LEGACY_AUTO_MODEL_IDS as readonly string[]).includes(modelName)
 
 const isChatModel = (m: BaseModel): boolean =>
   (m.type === 'chat' || m.type === 'code') && m.chat === true
 
-/** Real chat models belonging to the given Auto tier, in priority order. */
-const tierModels = (models: BaseModel[], tier: AutoTier): BaseModel[] =>
-  models.filter(
-    (m) =>
-      isChatModel(m) &&
-      Array.isArray(m.chatConfig?.attributes) &&
-      m.chatConfig.attributes.includes(tier),
+/**
+ * Real chat models the router may pick for Auto. The router only routes
+ * across models with published intelligence scores, which today are the chat
+ * models; the picker mirrors that so its Auto entry is offered exactly when
+ * the router can serve it.
+ */
+const autoCandidateModels = (models: BaseModel[]): BaseModel[] =>
+  models.filter(isChatModel)
+
+/**
+ * Builds the synthetic Auto picker entry when at least one chat model exists.
+ * Display-only and never sent to a backend; the request path resolves it via
+ * resolveModelSelection.
+ */
+export const getAutoModel = (models: BaseModel[]): BaseModel | undefined => {
+  const members = autoCandidateModels(models)
+  if (members.length === 0) return undefined
+  const smallestMember = members.reduce((smallest, member) =>
+    resolveContextWindowTokens(member) < resolveContextWindowTokens(smallest)
+      ? member
+      : smallest,
   )
-
-/**
- * Builds the synthetic Auto picker entries, one per tier that has at least one
- * member. These are display-only and are never sent to a backend; selection is
- * resolved to a concrete model list via resolveModelSelection.
- */
-export const getAutoModels = (models: BaseModel[]): BaseModel[] => {
-  const entries: BaseModel[] = []
-  const add = (tier: AutoTier, modelName: string, name: string): void => {
-    const members = tierModels(models, tier)
-    if (members.length === 0) return
-    const smallestMember = members.reduce((smallest, member) =>
-      resolveContextWindowTokens(member) < resolveContextWindowTokens(smallest)
-        ? member
-        : smallest,
-    )
-    entries.push({
-      modelName,
-      image: '',
-      name,
-      nameShort: name,
-      description:
-        tier === 'smart'
-          ? 'Automatically routes to the best available high-capability model'
-          : 'Automatically routes to the best available fast model',
-      type: 'chat',
-      chat: true,
-      isAuto: true,
-      tier,
-      multimodal: members.some((m) => m.multimodal === true),
-      chatConfig: {
-        contextWindowTokens: resolveContextWindowTokens(smallestMember),
-      },
-    })
+  return {
+    modelName: AUTO_MODEL_ID,
+    image: '',
+    name: 'Auto',
+    nameShort: 'Auto',
+    description:
+      'Automatically routes to the best model for the chosen intelligence level',
+    type: 'chat',
+    chat: true,
+    isAuto: true,
+    multimodal: members.some((m) => m.multimodal === true),
+    chatConfig: {
+      contextWindowTokens: resolveContextWindowTokens(smallestMember),
+    },
   }
-  add('smart', AUTO_SMART_ID, 'Auto · Smart')
-  add('fast', AUTO_FAST_ID, 'Auto · Fast')
-  return entries
 }
 
 /**
- * Default picker selection: Auto · Fast when its tier has members, otherwise
- * the first chat-capable model (e.g. local dev where models carry no tier
- * attributes). The model list also contains non-chat types (embedding, audio,
- * title, ...) which must never become the chat default. Empty string when no
- * chat models are available.
+ * Default picker selection: Auto when any chat model exists, otherwise empty.
+ * The model list also contains non-chat types (embedding, audio, title, ...)
+ * which must never become the chat default.
  */
-export const getDefaultModelId = (models: BaseModel[]): string => {
-  if (tierModels(models, 'fast').length > 0) return AUTO_FAST_ID
-  return models.find(isChatModel)?.modelName ?? ''
-}
+export const getDefaultModelId = (models: BaseModel[]): string =>
+  getAutoModel(models) ? AUTO_MODEL_ID : ''
 
 export const isModelNameAvailable = (
   modelName: string,
   models: BaseModel[],
 ): boolean => {
-  if (isAutoId(modelName)) {
-    const tier: AutoTier = modelName === AUTO_SMART_ID ? 'smart' : 'fast'
-    return tierModels(models, tier).length > 0
-  }
+  if (isAutoModelId(modelName)) return getAutoModel(models) !== undefined
   return models.some((m) => m.modelName === modelName)
 }
 
 /**
- * Resolves a selected picker id to a concrete model for display: the matching
- * Auto entry when an Auto id is selected, otherwise the real model.
+ * Resolves a selected picker id to a concrete model for display: the Auto
+ * entry for Auto (including legacy tier ids), otherwise the real model.
  */
 export const findSelectableModel = (
   modelName: string,
   models: BaseModel[],
 ): BaseModel | undefined => {
-  if (isAutoId(modelName)) {
-    return getAutoModels(models).find((m) => m.modelName === modelName)
-  }
+  if (isAutoModelId(modelName)) return getAutoModel(models)
   return models.find((m) => m.modelName === modelName)
 }
 
@@ -283,8 +315,10 @@ export type ResolvedModelSelection = {
   /** Representative model used to build the request body and the UI. */
   model: BaseModel | undefined
   /**
-   * Ordered Auto candidates (only set when an Auto option is selected). The
-   * first entry is the representative model.
+   * Every model the router may pick when Auto is selected (unset for a real
+   * model). The router makes the actual choice; the client uses this pool only
+   * for worst-case budgeting (smallest context window, strongest reasoning
+   * history policy). The first entry is the representative model.
    */
   autoCandidates?: BaseModel[]
 }
@@ -316,25 +350,22 @@ export const getResolvedModelContextWindowTokens = (
 }
 
 /**
- * Resolves the selected picker id (real model or Auto sentinel) into the model
- * used to build the request plus, for Auto, the ordered candidate list. For
- * Auto each preferred capability (multimodal / tool calling) narrows the tier
- * pool only when at least one member satisfies it, so a satisfied preference is
- * never silently dropped. When no tier member supports a preference at all the
- * incapable models are kept, which keeps the request routable (degraded)
- * rather than mis-routing past a capable candidate.
+ * Resolves the selected picker id (real model or Auto) into the model used to
+ * build the request plus, for Auto, the pool of models the router may choose
+ * from. Each preferred capability (multimodal / tool calling) narrows the pool
+ * only when at least one member satisfies it, so the client's budgeting
+ * reflects the models the router will realistically land on.
  */
 export const resolveModelSelection = (
   selectedModel: string,
   models: BaseModel[],
   opts?: { preferMultimodal?: boolean; preferToolCalling?: boolean },
 ): ResolvedModelSelection => {
-  if (!isAutoId(selectedModel)) {
+  if (!isAutoModelId(selectedModel)) {
     return { model: models.find((m) => m.modelName === selectedModel) }
   }
 
-  const tier: AutoTier = selectedModel === AUTO_SMART_ID ? 'smart' : 'fast'
-  let candidates = tierModels(models, tier)
+  let candidates = autoCandidateModels(models)
 
   if (opts?.preferMultimodal) {
     const capable = candidates.filter((m) => m.multimodal === true)

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -38,6 +38,7 @@ export const SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED =
 export const SETTINGS_HAS_SEEN_CLOUD_SYNC_MODAL =
   'tinfoil-settings-has-seen-cloud-sync-modal'
 export const SETTINGS_SELECTED_MODEL = 'tinfoil-settings-selected-model'
+export const SETTINGS_AUTO_INTELLIGENCE = 'tinfoil-settings-auto-intelligence'
 export const SETTINGS_REASONING_EFFORT = 'tinfoil-settings-reasoning-effort'
 export const SETTINGS_THINKING_ENABLED = 'tinfoil-settings-thinking-enabled'
 export const SETTINGS_WEB_SEARCH_ENABLED = 'tinfoil-settings-web-search-enabled'

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -11,6 +11,7 @@ import type { Message } from '@/components/chat/types'
 import {
   AUTO_MODEL_ID,
   AUTO_MODEL_OPTIONS_FIELD,
+  DEFAULT_AUTO_INTELLIGENCE_LEVEL,
   getAutoIntelligenceLevel,
   type AutoIntelligenceLevelId,
   type BaseModel,
@@ -256,13 +257,11 @@ export function isRetryableError(error: unknown): boolean {
  */
 function applyAutoRouting(
   requestBody: Record<string, unknown>,
-  autoIntelligence: AutoIntelligenceLevelId | undefined,
+  autoIntelligence: AutoIntelligenceLevelId = DEFAULT_AUTO_INTELLIGENCE_LEVEL,
 ): void {
   requestBody.model = AUTO_MODEL_ID
-  if (autoIntelligence !== undefined) {
-    requestBody[AUTO_MODEL_OPTIONS_FIELD] = {
-      intelligence: getAutoIntelligenceLevel(autoIntelligence).value,
-    }
+  requestBody[AUTO_MODEL_OPTIONS_FIELD] = {
+    intelligence: getAutoIntelligenceLevel(autoIntelligence).value,
   }
 }
 

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -8,8 +8,13 @@ import {
   type ReasoningEffort,
 } from '@/components/chat/hooks/use-reasoning-effort'
 import type { Message } from '@/components/chat/types'
-import type { BaseModel } from '@/config/models'
-import { AUTO_MODEL_OPTIONS_FIELD, AUTO_REQUEST_MODEL } from '@/config/models'
+import {
+  AUTO_MODEL_ID,
+  AUTO_MODEL_OPTIONS_FIELD,
+  getAutoIntelligenceLevel,
+  type AutoIntelligenceLevelId,
+  type BaseModel,
+} from '@/config/models'
 import { shouldRetryTestFail } from '@/utils/dev-simulator'
 import { logError, logInfo } from '@/utils/error-handling'
 import {
@@ -243,15 +248,36 @@ export function isRetryableError(error: unknown): boolean {
   return false
 }
 
+/**
+ * Hands model selection to the router: `model` becomes the "auto" sentinel and
+ * the requested intelligence level rides in the router-only options blob. The
+ * router picks a concrete model and reasoning effort and injects that model's
+ * own reasoning params, so no per-model params are sent from here.
+ */
+function applyAutoRouting(
+  requestBody: Record<string, unknown>,
+  autoIntelligence: AutoIntelligenceLevelId | undefined,
+): void {
+  requestBody.model = AUTO_MODEL_ID
+  if (autoIntelligence !== undefined) {
+    requestBody[AUTO_MODEL_OPTIONS_FIELD] = {
+      intelligence: getAutoIntelligenceLevel(autoIntelligence).value,
+    }
+  }
+}
+
 export interface SendChatStreamParams {
   model: BaseModel
   /**
-   * Ordered Auto candidates. When provided (an Auto option is selected), the
-   * request `model` is set to the router's "auto" sentinel and each
-   * candidate's params travel in the `auto_model_options` blob. `model` is the
-   * representative (first) candidate, used to build the shared message body.
+   * Models the router may pick from. When provided (Auto is selected), the
+   * request `model` is set to the router's "auto" sentinel and the requested
+   * intelligence level travels in the `auto_model_options` blob. `model` is
+   * the representative (first) candidate, used to build the shared message
+   * body; the router applies the chosen model's reasoning params itself.
    */
   autoCandidates?: BaseModel[]
+  /** Slider position sent with Auto requests. */
+  autoIntelligence?: AutoIntelligenceLevelId
   systemPrompt: string
   rules?: string
   onRetry?: (attempt: number, maxRetries: number, error?: string) => void
@@ -284,6 +310,7 @@ export async function sendChatStream(
   const {
     model,
     autoCandidates,
+    autoIntelligence,
     systemPrompt,
     rules,
     onRetry,
@@ -492,19 +519,14 @@ export async function sendChatStream(
         requestBody.tool_choice = 'auto'
       }
 
-      const modelParamOpts = { thinkingEnabled, reasoningEffort }
       if (autoCandidates && autoCandidates.length > 0) {
-        // Auto: defer the model choice to the router. Each candidate carries
-        // its own model-specific param block so whichever one the router picks
-        // gets exactly the right reasoning/requestParams applied.
-        requestBody.model = AUTO_REQUEST_MODEL
-        requestBody[AUTO_MODEL_OPTIONS_FIELD] = autoCandidates.map((c) => ({
-          model: c.modelName,
-          params: buildModelBodyParams(c, modelParamOpts),
-        }))
+        applyAutoRouting(requestBody, autoIntelligence)
       } else {
         // Single model: merge its params straight into the body.
-        const params = buildModelBodyParams(model, modelParamOpts)
+        const params = buildModelBodyParams(model, {
+          thinkingEnabled,
+          reasoningEffort,
+        })
         for (const [key, value] of Object.entries(params)) {
           requestBody[key] = value
         }
@@ -708,6 +730,7 @@ function toTerminalChatError(err: unknown, retries?: number): ChatError {
 export interface StructuredCompletionParams {
   model: BaseModel
   autoCandidates?: BaseModel[]
+  autoIntelligence?: AutoIntelligenceLevelId
   messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>
   jsonSchema: Record<string, unknown>
   signal?: AbortSignal
@@ -752,6 +775,7 @@ export async function sendStructuredCompletion<T>(
   const {
     model,
     autoCandidates,
+    autoIntelligence,
     messages,
     jsonSchema,
     signal,
@@ -764,15 +788,13 @@ export async function sendStructuredCompletion<T>(
     messages,
     stream: false,
   }
-  const modelParamOpts = { thinkingEnabled, reasoningEffort }
   if (autoCandidates && autoCandidates.length > 0) {
-    requestBody.model = AUTO_REQUEST_MODEL
-    requestBody[AUTO_MODEL_OPTIONS_FIELD] = autoCandidates.map((candidate) => ({
-      model: candidate.modelName,
-      params: buildModelBodyParams(candidate, modelParamOpts),
-    }))
+    applyAutoRouting(requestBody, autoIntelligence)
   } else {
-    Object.assign(requestBody, buildModelBodyParams(model, modelParamOpts))
+    Object.assign(
+      requestBody,
+      buildModelBodyParams(model, { thinkingEnabled, reasoningEffort }),
+    )
   }
   requestBody.response_format = {
     type: 'json_schema',

--- a/tests/components/chat/model-management.test.ts
+++ b/tests/components/chat/model-management.test.ts
@@ -3,7 +3,7 @@ import {
   useModelManagement,
 } from '@/components/chat/hooks/use-model-management'
 import type { Chat } from '@/components/chat/types'
-import type { BaseModel } from '@/config/models'
+import { AUTO_MODEL_ID, type BaseModel } from '@/config/models'
 import { SETTINGS_SELECTED_MODEL } from '@/constants/storage-keys'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -29,14 +29,6 @@ const mockModelB: BaseModel = {
 }
 
 const mockModels: BaseModel[] = [mockModelA, mockModelB]
-
-const mockFastModel: BaseModel = {
-  ...mockModelB,
-  modelName: 'model-fast',
-  chatConfig: { attributes: ['fast'] },
-}
-
-const modelsWithFastTier: BaseModel[] = [mockModelA, mockFastModel]
 
 vi.mock('@/utils/error-handling', () => ({
   logWarning: vi.fn(),
@@ -71,40 +63,48 @@ describe('resolveChatModel', () => {
   it('ignores a saved device model that is no longer available', () => {
     expect(
       resolveChatModel(makeChat(undefined), mockModels, 'removed-model'),
-    ).toBe('model-a')
+    ).toBe(AUTO_MODEL_ID)
   })
 
-  it('falls back to the first model when the chat has no model', () => {
-    expect(resolveChatModel(makeChat(undefined), mockModels)).toBe('model-a')
-  })
-
-  it('falls back to the first model when the chat model is unavailable', () => {
-    expect(resolveChatModel(makeChat('removed-model'), mockModels)).toBe(
-      'model-a',
+  it('falls back to Auto when the chat has no model', () => {
+    expect(resolveChatModel(makeChat(undefined), mockModels)).toBe(
+      AUTO_MODEL_ID,
     )
   })
 
-  it('falls back to the first model when there is no chat', () => {
-    expect(resolveChatModel(undefined, mockModels)).toBe('model-a')
+  it('falls back to Auto when the chat model is unavailable', () => {
+    expect(resolveChatModel(makeChat('removed-model'), mockModels)).toBe(
+      AUTO_MODEL_ID,
+    )
+  })
+
+  it('falls back to Auto when there is no chat', () => {
+    expect(resolveChatModel(undefined, mockModels)).toBe(AUTO_MODEL_ID)
   })
 
   it('returns an empty string when no models are available', () => {
     expect(resolveChatModel(makeChat('model-a'), [])).toBe('')
   })
 
-  it('falls back to auto-fast when available', () => {
-    expect(resolveChatModel(undefined, modelsWithFastTier)).toBe('auto-fast')
+  it('keeps a chat pinned to a legacy Auto tier id', () => {
+    expect(resolveChatModel(makeChat('auto-fast'), mockModels)).toBe(
+      'auto-fast',
+    )
+    expect(resolveChatModel(makeChat('auto-smart'), mockModels)).toBe(
+      'auto-smart',
+    )
   })
 
-  it('skips non-chat models when falling back to the default', () => {
+  it('does not offer Auto when only non-chat models exist', () => {
     const embeddingModel: BaseModel = {
       ...mockModelA,
       modelName: 'model-embedding',
       type: 'embedding',
       chat: undefined,
     }
+    expect(resolveChatModel(undefined, [embeddingModel])).toBe('')
     expect(resolveChatModel(undefined, [embeddingModel, mockModelB])).toBe(
-      'model-b',
+      AUTO_MODEL_ID,
     )
   })
 })
@@ -158,7 +158,7 @@ describe('useModelManagement', () => {
       expect(result.current.selectedModel).toBe('model-b')
     })
 
-    it('should fall back to first model when no saved model exists', async () => {
+    it('should fall back to Auto when no saved model exists', async () => {
       const { result } = renderHook(() =>
         useModelManagement({
           models: mockModels,
@@ -170,12 +170,12 @@ describe('useModelManagement', () => {
         expect(result.current.hasValidatedModel).toBe(true)
       })
 
-      expect(result.current.selectedModel).toBe('model-a')
+      expect(result.current.selectedModel).toBe(AUTO_MODEL_ID)
     })
   })
 
   describe('invalid saved model handling', () => {
-    it('should fall back to first model when saved model does not exist', async () => {
+    it('should fall back to Auto when saved model does not exist', async () => {
       localStorage.setItem(SETTINGS_SELECTED_MODEL, 'non-existent-model')
 
       const { result } = renderHook(() =>
@@ -189,10 +189,10 @@ describe('useModelManagement', () => {
         expect(result.current.hasValidatedModel).toBe(true)
       })
 
-      expect(result.current.selectedModel).toBe('model-a')
+      expect(result.current.selectedModel).toBe(AUTO_MODEL_ID)
     })
 
-    it('should fall back to first model when saved model is empty', async () => {
+    it('should fall back to Auto when saved model is empty', async () => {
       localStorage.setItem(SETTINGS_SELECTED_MODEL, '')
 
       const { result } = renderHook(() =>
@@ -206,7 +206,7 @@ describe('useModelManagement', () => {
         expect(result.current.hasValidatedModel).toBe(true)
       })
 
-      expect(result.current.selectedModel).toBe('model-a')
+      expect(result.current.selectedModel).toBe(AUTO_MODEL_ID)
     })
   })
 
@@ -320,16 +320,18 @@ describe('useModelManagement', () => {
         expect(result.current.hasValidatedModel).toBe(true)
       })
 
-      expect(result.current.selectedModel).toBe('model-a')
+      expect(result.current.selectedModel).toBe(AUTO_MODEL_ID)
       expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBeNull()
     })
   })
 
-  describe('auto-fast default', () => {
-    it('defaults to auto-fast when the fast tier has members', async () => {
+  describe('Auto selection', () => {
+    it('keeps a saved Auto selection', async () => {
+      localStorage.setItem(SETTINGS_SELECTED_MODEL, AUTO_MODEL_ID)
+
       const { result } = renderHook(() =>
         useModelManagement({
-          models: modelsWithFastTier,
+          models: mockModels,
           isClient: true,
         }),
       )
@@ -338,15 +340,16 @@ describe('useModelManagement', () => {
         expect(result.current.hasValidatedModel).toBe(true)
       })
 
-      expect(result.current.selectedModel).toBe('auto-fast')
+      expect(result.current.selectedModel).toBe(AUTO_MODEL_ID)
+      expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBe(AUTO_MODEL_ID)
     })
 
-    it('keeps a saved auto selection when its tier is still available', async () => {
+    it('treats a saved legacy Auto tier id as still available', async () => {
       localStorage.setItem(SETTINGS_SELECTED_MODEL, 'auto-fast')
 
       const { result } = renderHook(() =>
         useModelManagement({
-          models: modelsWithFastTier,
+          models: mockModels,
           isClient: true,
         }),
       )
@@ -356,7 +359,6 @@ describe('useModelManagement', () => {
       })
 
       expect(result.current.selectedModel).toBe('auto-fast')
-      expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBe('auto-fast')
     })
   })
 })

--- a/tests/components/chat/use-auto-intelligence.test.tsx
+++ b/tests/components/chat/use-auto-intelligence.test.tsx
@@ -1,0 +1,40 @@
+import { useAutoIntelligence } from '@/components/chat/hooks/use-auto-intelligence'
+import { SETTINGS_AUTO_INTELLIGENCE } from '@/constants/storage-keys'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('useAutoIntelligence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('starts at the default level when nothing is saved', () => {
+    const { result } = renderHook(() => useAutoIntelligence())
+    expect(result.current.autoIntelligence).toBe('high')
+  })
+
+  it('reads a saved level on first render and ignores garbage', () => {
+    localStorage.setItem(SETTINGS_AUTO_INTELLIGENCE, 'max')
+    expect(
+      renderHook(() => useAutoIntelligence()).result.current.autoIntelligence,
+    ).toBe('max')
+
+    localStorage.setItem(SETTINGS_AUTO_INTELLIGENCE, 'smart')
+    expect(
+      renderHook(() => useAutoIntelligence()).result.current.autoIntelligence,
+    ).toBe('high')
+  })
+
+  it('persists changes and syncs every mounted instance', () => {
+    const first = renderHook(() => useAutoIntelligence())
+    const second = renderHook(() => useAutoIntelligence())
+
+    act(() => {
+      first.result.current.setAutoIntelligence('low')
+    })
+
+    expect(localStorage.getItem(SETTINGS_AUTO_INTELLIGENCE)).toBe('low')
+    expect(first.result.current.autoIntelligence).toBe('low')
+    expect(second.result.current.autoIntelligence).toBe('low')
+  })
+})

--- a/tests/components/chat/use-auto-intelligence.test.tsx
+++ b/tests/components/chat/use-auto-intelligence.test.tsx
@@ -37,4 +37,30 @@ describe('useAutoIntelligence', () => {
     expect(first.result.current.autoIntelligence).toBe('low')
     expect(second.result.current.autoIntelligence).toBe('low')
   })
+
+  it('follows changes made in another tab and resets when storage is cleared', () => {
+    const { result } = renderHook(() => useAutoIntelligence())
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: SETTINGS_AUTO_INTELLIGENCE,
+          newValue: 'max',
+        }),
+      )
+    })
+    expect(result.current.autoIntelligence).toBe('max')
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: 'unrelated', newValue: 'low' }),
+      )
+    })
+    expect(result.current.autoIntelligence).toBe('max')
+
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: null }))
+    })
+    expect(result.current.autoIntelligence).toBe('high')
+  })
 })

--- a/tests/config/models-auto.test.ts
+++ b/tests/config/models-auto.test.ts
@@ -1,0 +1,128 @@
+import {
+  AUTO_INTELLIGENCE_LEVELS,
+  AUTO_MODEL_ID,
+  findSelectableModel,
+  getAutoDisplayName,
+  getAutoModel,
+  getDefaultModelId,
+  getSelectedModelLabel,
+  isAutoIntelligenceLevelId,
+  isAutoModelId,
+  isModelNameAvailable,
+  resolveModelSelection,
+  type BaseModel,
+} from '@/config/models'
+import { describe, expect, it } from 'vitest'
+
+const chat = (
+  modelName: string,
+  extra: Partial<BaseModel> = {},
+): BaseModel => ({
+  modelName,
+  image: '',
+  name: modelName.toUpperCase(),
+  nameShort: modelName,
+  description: '',
+  type: 'chat',
+  chat: true,
+  ...extra,
+})
+
+const textModel = chat('text-only')
+const visionModel = chat('vision', { multimodal: true, toolCalling: true })
+const embedding: BaseModel = {
+  ...chat('embed'),
+  type: 'embedding',
+  chat: undefined,
+}
+
+describe('Auto intelligence levels', () => {
+  it('spans the router scale from 0 to 100 in ascending order', () => {
+    const values = AUTO_INTELLIGENCE_LEVELS.map((level) => level.value)
+    expect(values[0]).toBe(0)
+    expect(values[values.length - 1]).toBe(100)
+    expect([...values].sort((a, b) => a - b)).toEqual(values)
+  })
+
+  it('produces the collapsed picker labels', () => {
+    expect(
+      AUTO_INTELLIGENCE_LEVELS.map((l) => getAutoDisplayName(l.id)),
+    ).toEqual([
+      'Auto · Low',
+      'Auto · Med',
+      'Auto · High',
+      'Auto · Extra',
+      'Auto · Max',
+    ])
+  })
+
+  it('validates persisted level ids', () => {
+    expect(isAutoIntelligenceLevelId('max')).toBe(true)
+    expect(isAutoIntelligenceLevelId('smart')).toBe(false)
+    expect(isAutoIntelligenceLevelId(null)).toBe(false)
+  })
+})
+
+describe('Auto picker entry', () => {
+  it('exists only when a chat model does', () => {
+    expect(getAutoModel([embedding])).toBeUndefined()
+    expect(getAutoModel([embedding, textModel])?.modelName).toBe(AUTO_MODEL_ID)
+    expect(getDefaultModelId([embedding])).toBe('')
+    expect(getDefaultModelId([textModel])).toBe(AUTO_MODEL_ID)
+  })
+
+  it('is multimodal when any candidate is', () => {
+    expect(getAutoModel([textModel])?.multimodal).toBe(false)
+    expect(getAutoModel([textModel, visionModel])?.multimodal).toBe(true)
+  })
+
+  it('accepts the legacy tier ids as Auto', () => {
+    for (const id of ['auto', 'auto-smart', 'auto-fast']) {
+      expect(isAutoModelId(id)).toBe(true)
+      expect(isModelNameAvailable(id, [textModel])).toBe(true)
+      expect(findSelectableModel(id, [textModel])?.isAuto).toBe(true)
+    }
+    expect(isAutoModelId('text-only')).toBe(false)
+  })
+
+  it('labels the collapsed trigger with the level for Auto and the name otherwise', () => {
+    const models = [textModel]
+    expect(getSelectedModelLabel(AUTO_MODEL_ID, models, 'max')).toBe(
+      'Auto · Max',
+    )
+    expect(getSelectedModelLabel('auto-fast', models, 'low')).toBe('Auto · Low')
+    expect(getSelectedModelLabel('text-only', models, 'max')).toBe('TEXT-ONLY')
+    expect(getSelectedModelLabel('missing', models, 'max')).toBeUndefined()
+  })
+})
+
+describe('resolveModelSelection for Auto', () => {
+  it('returns every chat model as the candidate pool', () => {
+    const { model, autoCandidates } = resolveModelSelection(AUTO_MODEL_ID, [
+      embedding,
+      textModel,
+      visionModel,
+    ])
+    expect(model).toBe(textModel)
+    expect(autoCandidates).toEqual([textModel, visionModel])
+  })
+
+  it('narrows to capable models only when at least one satisfies the preference', () => {
+    const models = [textModel, visionModel]
+    expect(
+      resolveModelSelection(AUTO_MODEL_ID, models, { preferMultimodal: true })
+        .autoCandidates,
+    ).toEqual([visionModel])
+    expect(
+      resolveModelSelection(AUTO_MODEL_ID, [textModel], {
+        preferMultimodal: true,
+      }).autoCandidates,
+    ).toEqual([textModel])
+  })
+
+  it('resolves a real model without a candidate pool', () => {
+    const selection = resolveModelSelection('vision', [textModel, visionModel])
+    expect(selection.model).toBe(visionModel)
+    expect(selection.autoCandidates).toBeUndefined()
+  })
+})

--- a/tests/config/models-auto.test.ts
+++ b/tests/config/models-auto.test.ts
@@ -48,6 +48,7 @@ describe('Auto intelligence levels', () => {
     expect(
       AUTO_INTELLIGENCE_LEVELS.map((l) => getAutoDisplayName(l.id)),
     ).toEqual([
+      'Auto · Instant',
       'Auto · Low',
       'Auto · Med',
       'Auto · High',

--- a/tests/config/models-reasoning-history.test.ts
+++ b/tests/config/models-reasoning-history.test.ts
@@ -1,5 +1,5 @@
 import {
-  getAutoModels,
+  getAutoModel,
   getReasoningHistoryPolicy,
   getResolvedModelContextWindowTokens,
   type BaseModel,
@@ -69,9 +69,6 @@ describe('getReasoningHistoryPolicy', () => {
       model('large', undefined, 256000),
       model('small', undefined, 32000),
     ]
-    candidates.forEach((candidate) => {
-      candidate.chatConfig = { ...candidate.chatConfig, attributes: ['smart'] }
-    })
 
     expect(
       getResolvedModelContextWindowTokens({
@@ -79,7 +76,7 @@ describe('getReasoningHistoryPolicy', () => {
         autoCandidates: candidates,
       }),
     ).toBe(32000)
-    expect(getAutoModels(candidates)[0].chatConfig?.contextWindowTokens).toBe(
+    expect(getAutoModel(candidates)?.chatConfig?.contextWindowTokens).toBe(
       32000,
     )
   })

--- a/tests/services/inference/inference-client-structured.test.ts
+++ b/tests/services/inference/inference-client-structured.test.ts
@@ -51,7 +51,7 @@ describe('sendStructuredCompletion', () => {
     createMock.mockReset()
   })
 
-  it('preserves Auto candidate params and protects response_format', async () => {
+  it('routes Auto by intelligence level and leaves per-model params to the router', async () => {
     const candidate = {
       modelName: 'candidate-a',
       requestParams: {
@@ -74,6 +74,7 @@ describe('sendStructuredCompletion', () => {
     await sendStructuredCompletion({
       model: candidate,
       autoCandidates: [candidate],
+      autoIntelligence: 'extra',
       messages: [{ role: 'user', content: 'repair' }],
       jsonSchema: schema,
       reasoningEffort: 'high',
@@ -82,12 +83,9 @@ describe('sendStructuredCompletion', () => {
 
     const body = createMock.mock.calls[0][0]
     expect(body.model).toBe('auto')
-    expect(body.auto_model_options).toEqual([
-      {
-        model: 'candidate-a',
-        params: { temperature: 0.25, reasoning_effort: 'high' },
-      },
-    ])
+    expect(body.auto_model_options).toEqual({ intelligence: 75 })
+    expect(body).not.toHaveProperty('reasoning_effort')
+    expect(body).not.toHaveProperty('temperature')
     expect(body.response_format).toEqual({
       type: 'json_schema',
       json_schema: { name: 'response', schema },

--- a/tests/services/inference/inference-client-structured.test.ts
+++ b/tests/services/inference/inference-client-structured.test.ts
@@ -83,7 +83,7 @@ describe('sendStructuredCompletion', () => {
 
     const body = createMock.mock.calls[0][0]
     expect(body.model).toBe('auto')
-    expect(body.auto_model_options).toEqual({ intelligence: 75 })
+    expect(body.auto_model_options).toEqual({ intelligence: 80 })
     expect(body).not.toHaveProperty('reasoning_effort')
     expect(body).not.toHaveProperty('temperature')
     expect(body.response_format).toEqual({


### PR DESCRIPTION
The model picker now offers a single **Auto** entry. When selected, a thick stepped slider under it sets the intelligence level (Instant, Low, Med, High, Extra, Max) and the collapsed trigger reads `Auto · High` etc. The reasoning effort and thinking controls are hidden for Auto since the router now chooses both model and effort.

Requests for Auto send `model: "auto"` with `auto_model_options: { intelligence: <0|20|40|60|80|100> }` instead of the per-candidate list; the router (tinfoilsh/confidential-model-router#472) picks the closest healthy model and effort from the control plane's published scores. The slider level persists device-locally like the selected model. Saved `auto-smart` / `auto-fast` ids (settings and synced chats) continue to resolve to Auto.

Depends on tinfoilsh/confidential-model-router#472 and tinfoilsh/controlplane#678.