### PR TITLE
fix: stabilize the model menu while using the Auto intelligence slider

### DIFF
--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -16,6 +16,7 @@ import { CONSTANTS } from './constants'
 import { DataFlowDiagram } from './DataFlowDiagram'
 import { type ReasoningEffort } from './hooks/use-reasoning-effort'
 import { ModelSelector } from './model-selector'
+import { ModelSelectorTriggerLabel } from './model-selector-trigger-label'
 import type { PromptPreset } from './prompts/types'
 import type { ProcessedDocument } from './renderers/types'
 import type { LabelType, LoadingState } from './types'
@@ -461,35 +462,12 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                           }}
                           className="flex items-center gap-1 py-1.5 text-content-secondary transition-colors hover:text-content-primary"
                         >
-                          {(() => {
-                            const label = getSelectedModelLabel(
-                              selectedModel,
-                              models,
-                              autoIntelligence,
-                            )
-                            if (!label) return null
-                            return (
-                              <>
-                                <span className="text-xs font-medium">
-                                  {label}
-                                </span>
-                                <svg
-                                  className={`h-3 w-3 transition-transform ${expandedLabel === 'model' ? 'rotate-180' : ''}`}
-                                  fill="none"
-                                  stroke="currentColor"
-                                  viewBox="0 0 24 24"
-                                  aria-hidden="true"
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M19 9l-7 7-7-7"
-                                  />
-                                </svg>
-                              </>
-                            )
-                          })()}
+                          <ModelSelectorTriggerLabel
+                            selectedModel={selectedModel}
+                            models={models}
+                            autoIntelligence={autoIntelligence}
+                            isOpen={expandedLabel === 'model'}
+                          />
                         </button>
 
                         {expandedLabel === 'model' && handleModelSelect && (

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -170,6 +170,7 @@ import { useSidebarChat } from './hooks/use-sidebar-chat'
 import { MessageQueue } from './message-queue'
 import { getBlankQueueId } from './message-queue-identity'
 import { ModelSelector } from './model-selector'
+import { ModelSelectorTriggerLabel } from './model-selector-trigger-label'
 import { openProjectChat } from './project-navigation'
 import { QuoteSelectionPopover } from './quote-selection-popover'
 import { initializeRenderers } from './renderers/client'
@@ -4448,35 +4449,12 @@ export function ChatInterface({
                                 }}
                                 className="flex items-center gap-1 py-1.5 text-content-secondary transition-colors hover:text-content-primary"
                               >
-                                {(() => {
-                                  const label = getSelectedModelLabel(
-                                    selectedModel,
-                                    models,
-                                    autoIntelligence,
-                                  )
-                                  if (!label) return null
-                                  return (
-                                    <>
-                                      <span className="text-xs font-medium">
-                                        {label}
-                                      </span>
-                                      <svg
-                                        className={`h-3 w-3 transition-transform ${expandedLabel === 'model' ? 'rotate-180' : ''}`}
-                                        fill="none"
-                                        stroke="currentColor"
-                                        viewBox="0 0 24 24"
-                                        aria-hidden="true"
-                                      >
-                                        <path
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                          strokeWidth={2}
-                                          d="M19 9l-7 7-7-7"
-                                        />
-                                      </svg>
-                                    </>
-                                  )
-                                })()}
+                                <ModelSelectorTriggerLabel
+                                  selectedModel={selectedModel}
+                                  models={models}
+                                  autoIntelligence={autoIntelligence}
+                                  isOpen={expandedLabel === 'model'}
+                                />
                               </button>
 
                               {expandedLabel === 'model' && (

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -1,5 +1,9 @@
 import type { AutoIntelligenceLevelId } from '@/config/models'
-import { isModelNameAvailable, type BaseModel } from '@/config/models'
+import {
+  isAutoModelId,
+  isModelNameAvailable,
+  type BaseModel,
+} from '@/config/models'
 import { useExecSnapshot } from '@/services/exec-snapshot/use-exec-snapshot'
 import { logWarning } from '@/utils/error-handling'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
@@ -205,7 +209,11 @@ export function useChatState({
       }
       updateChatModel(modelName)
       persistModelSelection(modelName)
-      setExpandedLabel(null)
+      // Auto reveals the intelligence slider inside the menu, so the menu
+      // stays open for the user to adjust it.
+      if (!isAutoModelId(modelName)) {
+        setExpandedLabel(null)
+      }
     },
     [models, updateChatModel, persistModelSelection, setExpandedLabel],
   )

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -1,9 +1,5 @@
 import type { AutoIntelligenceLevelId } from '@/config/models'
-import {
-  isAutoModelId,
-  isModelNameAvailable,
-  type BaseModel,
-} from '@/config/models'
+import { isModelNameAvailable, type BaseModel } from '@/config/models'
 import { useExecSnapshot } from '@/services/exec-snapshot/use-exec-snapshot'
 import { logWarning } from '@/utils/error-handling'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
@@ -11,7 +7,11 @@ import type { AIModel, Chat, LabelType, LoadingState, Message } from '../types'
 import { useChatMessaging, type ChatDispatchResult } from './use-chat-messaging'
 import { useChatStorage } from './use-chat-storage'
 import type { StreamErrorInfo } from './use-chat-streams'
-import { resolveChatModel, useModelManagement } from './use-model-management'
+import {
+  resolveChatModel,
+  shouldCloseMenuOnSelect,
+  useModelManagement,
+} from './use-model-management'
 import type { ReasoningEffort } from './use-reasoning-effort'
 import { useUIState, type ThemeMode } from './use-ui-state'
 
@@ -209,9 +209,7 @@ export function useChatState({
       }
       updateChatModel(modelName)
       persistModelSelection(modelName)
-      // Auto reveals the intelligence slider inside the menu, so the menu
-      // stays open for the user to adjust it.
-      if (!isAutoModelId(modelName)) {
+      if (shouldCloseMenuOnSelect(modelName)) {
         setExpandedLabel(null)
       }
     },

--- a/src/components/chat/hooks/use-model-management.ts
+++ b/src/components/chat/hooks/use-model-management.ts
@@ -38,6 +38,14 @@ export function resolveChatModel(
   return getDefaultModelId(models)
 }
 
+/**
+ * Whether picking a model should close the selector menu. Auto reveals the
+ * intelligence slider inside the menu, so the menu stays open for the user
+ * to adjust it.
+ */
+export const shouldCloseMenuOnSelect = (modelName: AIModel): boolean =>
+  !isAutoModelId(modelName)
+
 interface UseModelManagementProps {
   models: BaseModel[]
   isClient: boolean
@@ -123,7 +131,7 @@ export function useModelManagement({
       const modelName = event.detail as AIModel
       if (!modelName || !isModelNameAvailable(modelName, models)) return
       setSelectedModel(modelName)
-      if (!isAutoModelId(modelName)) {
+      if (shouldCloseMenuOnSelect(modelName)) {
         setExpandedLabel(null)
       }
     }
@@ -154,9 +162,7 @@ export function useModelManagement({
       }
 
       setSelectedModel(modelName)
-      // Auto reveals the intelligence slider inside the menu, so the menu
-      // stays open for the user to adjust it.
-      if (!isAutoModelId(modelName)) {
+      if (shouldCloseMenuOnSelect(modelName)) {
         setExpandedLabel(null)
       }
 

--- a/src/components/chat/hooks/use-model-management.ts
+++ b/src/components/chat/hooks/use-model-management.ts
@@ -1,5 +1,6 @@
 import {
   getDefaultModelId,
+  isAutoModelId,
   isModelNameAvailable,
   type BaseModel,
 } from '@/config/models'
@@ -122,7 +123,9 @@ export function useModelManagement({
       const modelName = event.detail as AIModel
       if (!modelName || !isModelNameAvailable(modelName, models)) return
       setSelectedModel(modelName)
-      setExpandedLabel(null)
+      if (!isAutoModelId(modelName)) {
+        setExpandedLabel(null)
+      }
     }
 
     window.addEventListener(
@@ -151,7 +154,11 @@ export function useModelManagement({
       }
 
       setSelectedModel(modelName)
-      setExpandedLabel(null)
+      // Auto reveals the intelligence slider inside the menu, so the menu
+      // stays open for the user to adjust it.
+      if (!isAutoModelId(modelName)) {
+        setExpandedLabel(null)
+      }
 
       // Save to local storage
       persistSelectedModel(modelName)

--- a/src/components/chat/model-selector-trigger-label.tsx
+++ b/src/components/chat/model-selector-trigger-label.tsx
@@ -1,0 +1,68 @@
+import {
+  AUTO_INTELLIGENCE_LEVELS,
+  getAutoDisplayName,
+  getSelectedModelLabel,
+  isAutoModelId,
+  type AutoIntelligenceLevelId,
+  type BaseModel,
+} from '@/config/models'
+
+type ModelSelectorTriggerLabelProps = {
+  selectedModel: string
+  models: BaseModel[]
+  autoIntelligence: AutoIntelligenceLevelId
+  isOpen: boolean
+}
+
+/**
+ * Contents of the collapsed model picker trigger. When Auto is selected every
+ * intelligence level's label is stacked in the same grid cell with all but the
+ * current one invisible, so the trigger keeps the width of the widest label
+ * and the menu anchored to it does not shift as the slider moves.
+ */
+export function ModelSelectorTriggerLabel({
+  selectedModel,
+  models,
+  autoIntelligence,
+  isOpen,
+}: ModelSelectorTriggerLabelProps) {
+  const label = getSelectedModelLabel(selectedModel, models, autoIntelligence)
+  if (!label) return null
+
+  return (
+    <>
+      {isAutoModelId(selectedModel) ? (
+        <span className="grid whitespace-nowrap text-right text-xs font-medium">
+          {AUTO_INTELLIGENCE_LEVELS.map((level) => {
+            const isCurrent = level.id === autoIntelligence
+            return (
+              <span
+                key={level.id}
+                aria-hidden={!isCurrent}
+                className={`col-start-1 row-start-1 ${isCurrent ? '' : 'invisible'}`}
+              >
+                {getAutoDisplayName(level.id)}
+              </span>
+            )
+          })}
+        </span>
+      ) : (
+        <span className="whitespace-nowrap text-xs font-medium">{label}</span>
+      )}
+      <svg
+        className={`h-3 w-3 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M19 9l-7 7-7-7"
+        />
+      </svg>
+    </>
+  )
+}

--- a/tests/components/chat/model-management.test.ts
+++ b/tests/components/chat/model-management.test.ts
@@ -312,6 +312,7 @@ describe('useModelManagement', () => {
     })
 
     it('keeps the menu open when Auto is picked so the slider can be adjusted', async () => {
+      localStorage.setItem(SETTINGS_SELECTED_MODEL, 'model-a')
       const { result } = renderHook(() =>
         useModelManagement({
           models: mockModels,
@@ -322,6 +323,7 @@ describe('useModelManagement', () => {
       await waitFor(() => {
         expect(result.current.hasValidatedModel).toBe(true)
       })
+      expect(result.current.selectedModel).toBe('model-a')
 
       act(() => {
         result.current.setExpandedLabel('model')

--- a/tests/components/chat/model-management.test.ts
+++ b/tests/components/chat/model-management.test.ts
@@ -288,6 +288,51 @@ describe('useModelManagement', () => {
 
       expect(result.current.selectedModel).toBe(initialModel)
     })
+
+    it('closes the menu when a concrete model is picked', async () => {
+      const { result } = renderHook(() =>
+        useModelManagement({
+          models: mockModels,
+          isClient: true,
+        }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.hasValidatedModel).toBe(true)
+      })
+
+      act(() => {
+        result.current.setExpandedLabel('model')
+      })
+      act(() => {
+        result.current.handleModelSelect('model-b')
+      })
+
+      expect(result.current.expandedLabel).toBeNull()
+    })
+
+    it('keeps the menu open when Auto is picked so the slider can be adjusted', async () => {
+      const { result } = renderHook(() =>
+        useModelManagement({
+          models: mockModels,
+          isClient: true,
+        }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.hasValidatedModel).toBe(true)
+      })
+
+      act(() => {
+        result.current.setExpandedLabel('model')
+      })
+      act(() => {
+        result.current.handleModelSelect(AUTO_MODEL_ID)
+      })
+
+      expect(result.current.selectedModel).toBe(AUTO_MODEL_ID)
+      expect(result.current.expandedLabel).toBe('model')
+    })
   })
 
   describe('localStorage persistence', () => {


### PR DESCRIPTION
Two follow-ups to the Auto intelligence slider (#577):

- The collapsed picker label ("Auto · Instant", "Auto · Max", ...) changed width with the slider, and since the menu is anchored to that button the whole popup shifted horizontally while dragging. The Auto label now stacks every level's text in one grid cell with only the current one visible, so the trigger always has the width of the widest label.
- Selecting Auto dismissed the menu immediately, hiding the slider it had just revealed. The menu now stays open when Auto is picked; choosing any concrete model still closes it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two issues with the Auto intelligence slider that made the model menu unstable and hard to use.

- Stacks every Auto level's label in one grid cell so the trigger keeps the width of the widest label, preventing the popup from shifting while the slider moves.
- Keeps the menu open when Auto is picked so the slider stays visible; selecting a concrete model still closes it.
- Adds a shared `shouldCloseMenuOnSelect` rule so the close behavior is consistent across all model selection paths.

<sup>Written for commit ec8cff8869544fd1b9bbe6f7de71a2c24c1d877b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

