### PR TITLE
feat: tell users why a chat import or backup restore failed

### DIFF
--- a/src/components/chat/native-backup-restore.tsx
+++ b/src/components/chat/native-backup-restore.tsx
@@ -69,7 +69,7 @@ export function NativeBackupRestore({
               : next.state === 'interrupted'
                 ? "The cloud restore was interrupted before we could confirm the result. We'll email you whether it finished or failed. No local chats were restored; reselect this archive afterward to restore them."
                 : next.state === 'failed'
-                  ? `The cloud restore failed. ${describeImportFailure(next.failureReason)} No local chats were restored.`
+                  ? `The cloud restore failed. ${describeImportFailure(next.failureReason, 'backup_restore')} No local chats were restored.`
                   : next.state === 'partial'
                     ? 'Backup restored with warnings.'
                     : 'Backup restored successfully.',

--- a/src/components/chat/native-backup-restore.tsx
+++ b/src/components/chat/native-backup-restore.tsx
@@ -1,3 +1,4 @@
+import { describeImportFailure } from '@/services/chat-import/import-failure-copy'
 // prettier-ignore
 import { NATIVE_RESTORE_KINDS,restoreNativeBackup,type NativeRestoreResult } from '@/services/native-backup/orchestrate'
 import { useEffect, useRef, useState } from 'react'
@@ -65,11 +66,13 @@ export function NativeBackupRestore({
               : 'Backup restored successfully, but chats could not be refreshed. Reload to see restored chats.'
             : next.state === 'pending'
               ? "The cloud restore is still running. We'll email you when it finishes. No local chats were restored; reselect this archive afterward to restore them."
-              : next.state === 'failed'
-                ? 'The cloud restore failed. No local chats were restored.'
-                : next.state === 'partial'
-                  ? 'Backup restored with warnings.'
-                  : 'Backup restored successfully.',
+              : next.state === 'interrupted'
+                ? "The cloud restore was interrupted before we could confirm the result. We'll email you whether it finished or failed. No local chats were restored; reselect this archive afterward to restore them."
+                : next.state === 'failed'
+                  ? `The cloud restore failed. ${describeImportFailure(next.failureReason)} No local chats were restored.`
+                  : next.state === 'partial'
+                    ? 'Backup restored with warnings.'
+                    : 'Backup restored successfully.',
         )
     } catch (cause) {
       if (!current.signal.aborted)
@@ -129,24 +132,26 @@ export function NativeBackupRestore({
           {message}
         </p>
       )}
-      {result && result.state !== 'pending' && (
-        <ul className="mt-2 space-y-1 text-xs text-content-muted">
-          {NATIVE_RESTORE_KINDS.map((kind) => {
-            const value = result.report[kind]
-            return (
-              <li key={kind}>
-                {kind.replaceAll('_', ' ')}: {value.imported} imported,{' '}
-                {value.skipped} skipped, {value.failed} failed, {value.blocked}{' '}
-                blocked
-                {value.warnings.length > 0 &&
-                  `, warnings: ${value.warnings.join('; ')}`}
-                {value.errors.length > 0 &&
-                  `, errors: ${value.errors.join('; ')}`}
-              </li>
-            )
-          })}
-        </ul>
-      )}
+      {result &&
+        result.state !== 'pending' &&
+        result.state !== 'interrupted' && (
+          <ul className="mt-2 space-y-1 text-xs text-content-muted">
+            {NATIVE_RESTORE_KINDS.map((kind) => {
+              const value = result.report[kind]
+              return (
+                <li key={kind}>
+                  {kind.replaceAll('_', ' ')}: {value.imported} imported,{' '}
+                  {value.skipped} skipped, {value.failed} failed,{' '}
+                  {value.blocked} blocked
+                  {value.warnings.length > 0 &&
+                    `, warnings: ${value.warnings.join('; ')}`}
+                  {value.errors.length > 0 &&
+                    `, errors: ${value.errors.join('; ')}`}
+                </li>
+              )
+            })}
+          </ul>
+        )}
     </div>
   )
 }

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -27,6 +27,7 @@ import { useSyncHealthAttention } from '@/hooks/use-sync-health'
 import { useToast } from '@/hooks/use-toast'
 import { authTokenManager } from '@/services/auth'
 import { buildChatExport } from '@/services/chat-export/export-archive'
+import { describeImportFailure } from '@/services/chat-import/import-failure-copy'
 import {
   parseLocalTinfoilExportForAccess,
   PremiumProjectImportRequiredError,
@@ -55,7 +56,10 @@ import { clearDeletedProjectsForAccount } from '@/services/project/project-delet
 import { chatStorage } from '@/services/storage/chat-storage'
 import { projectCache } from '@/services/storage/project-cache'
 import { sessionChatStorage } from '@/services/storage/session-storage'
-import { attachmentGet } from '@/services/sync-enclave/sync-api'
+import {
+  attachmentGet,
+  type ImportStatusResponse,
+} from '@/services/sync-enclave/sync-api'
 import { TINFOIL_COLORS } from '@/theme/colors'
 import {
   clearExplicitSignoutIntent,
@@ -140,6 +144,42 @@ const DASHBOARD_URL = 'https://dash.tinfoil.sh'
 
 const DELETE_ALL_CHATS_CONFIRM_PHRASE = 'delete all chats'
 const DELETE_ALL_PROJECTS_CONFIRM_PHRASE = 'delete all projects'
+
+interface ImportResult {
+  success: boolean
+  chatsImported: number
+  projectsImported: number
+  errors: string[]
+  pending?: boolean
+  /** The enclave job ended without completing (distinct from per-chat errors). */
+  failed?: boolean
+  message?: string
+}
+
+/**
+ * Turns the enclave's kickoff snapshot into the panel state and toast
+ * copy. The job normally reports staging/running here and finishes off
+ * device, but a job that has already failed must not be announced as
+ * started.
+ */
+export function describeOffDeviceImportKickoff(
+  status: ImportStatusResponse,
+  sourceLabel: string,
+): ImportResult & { message: string } {
+  const pending = status.status === 'staging' || status.status === 'running'
+  const failed = status.status === 'failed'
+  return {
+    success: !failed,
+    chatsImported: status.imported,
+    projectsImported: 0,
+    errors: status.errors ?? [],
+    pending,
+    failed,
+    message: failed
+      ? describeImportFailure(status.failure_reason)
+      : `Your ${sourceLabel} export is being imported securely. We'll email you when it's done.`,
+  }
+}
 
 export function getDeleteAllChatsSuccessTitle(
   isSignedIn: boolean,
@@ -542,14 +582,7 @@ export function SettingsModal({
     total: number
     type: 'chats' | 'projects'
   } | null>(null)
-  const [importResult, setImportResult] = useState<{
-    success: boolean
-    chatsImported: number
-    projectsImported: number
-    errors: string[]
-    pending?: boolean
-    message?: string
-  } | null>(null)
+  const [importResult, setImportResult] = useState<ImportResult | null>(null)
   const chatGptFileInputRef = useRef<HTMLInputElement>(null)
   const claudeConversationsFileInputRef = useRef<HTMLInputElement>(null)
   const claudeProjectsFileInputRef = useRef<HTMLInputElement>(null)
@@ -1312,23 +1345,18 @@ export function SettingsModal({
     setImportResult(null)
     try {
       const { status } = await runOffDeviceImport(source, file)
-      const errors = status.errors ?? []
-      const pending = status.status === 'staging' || status.status === 'running'
-      setImportResult({
-        success: status.status !== 'failed',
-        chatsImported: status.imported,
-        projectsImported: 0,
-        errors,
-        pending,
-        message: pending
-          ? `Your ${sourceLabel} export is being imported securely. We'll email you when it's done.`
-          : undefined,
-      })
-      toast({
-        title: 'Import started',
-        description: `Your ${sourceLabel} export is being imported securely. We'll email you when it's done.`,
-      })
-      if (!pending && onChatsUpdated) {
+      const result = describeOffDeviceImportKickoff(status, sourceLabel)
+      setImportResult(result)
+      toast(
+        result.failed
+          ? {
+              title: 'Import failed',
+              description: result.message,
+              variant: 'destructive',
+            }
+          : { title: 'Import started', description: result.message },
+      )
+      if (!result.pending && onChatsUpdated) {
         onChatsUpdated()
       }
     } catch (err) {
@@ -3924,7 +3952,9 @@ ${encryptionKey.replace('key_', '')}
                                 ? 'Import in progress'
                                 : importResult.success
                                   ? 'Import complete'
-                                  : 'Import completed with errors'}
+                                  : importResult.failed
+                                    ? 'Import failed'
+                                    : 'Import completed with errors'}
                             </div>
                             {importResult.message && (
                               <div className="font-aeonik-fono text-xs text-content-muted">

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -165,7 +165,7 @@ interface ImportResult {
 export function describeOffDeviceImportKickoff(
   status: ImportStatusResponse,
   sourceLabel: string,
-): ImportResult & { message: string } {
+): ImportResult {
   const pending = status.status === 'staging' || status.status === 'running'
   const failed = status.status === 'failed'
   return {
@@ -177,8 +177,17 @@ export function describeOffDeviceImportKickoff(
     failed,
     message: failed
       ? describeImportFailure(status.failure_reason)
-      : `Your ${sourceLabel} export is being imported securely. We'll email you when it's done.`,
+      : pending
+        ? `Your ${sourceLabel} export is being imported securely. We'll email you when it's done.`
+        : undefined,
   }
+}
+
+export function importResultTitle(result: ImportResult): string {
+  if (result.pending) return 'Import in progress'
+  if (result.success) return 'Import complete'
+  if (result.failed) return 'Import failed'
+  return 'Import completed with errors'
 }
 
 export function getDeleteAllChatsSuccessTitle(
@@ -1347,15 +1356,15 @@ export function SettingsModal({
       const { status } = await runOffDeviceImport(source, file)
       const result = describeOffDeviceImportKickoff(status, sourceLabel)
       setImportResult(result)
-      toast(
-        result.failed
-          ? {
-              title: 'Import failed',
-              description: result.message,
-              variant: 'destructive',
-            }
-          : { title: 'Import started', description: result.message },
-      )
+      if (result.failed) {
+        toast({
+          title: 'Import failed',
+          description: result.message,
+          variant: 'destructive',
+        })
+      } else if (result.pending) {
+        toast({ title: 'Import started', description: result.message })
+      }
       if (!result.pending && onChatsUpdated) {
         onChatsUpdated()
       }
@@ -3948,13 +3957,7 @@ ${encryptionKey.replace('key_', '')}
                                   : 'text-red-500',
                               )}
                             >
-                              {importResult.pending
-                                ? 'Import in progress'
-                                : importResult.success
-                                  ? 'Import complete'
-                                  : importResult.failed
-                                    ? 'Import failed'
-                                    : 'Import completed with errors'}
+                              {importResultTitle(importResult)}
                             </div>
                             {importResult.message && (
                               <div className="font-aeonik-fono text-xs text-content-muted">

--- a/src/services/chat-import/import-failure-copy.ts
+++ b/src/services/chat-import/import-failure-copy.ts
@@ -1,16 +1,36 @@
 import type { ImportFailureReason } from '@/services/sync-enclave/sync-api'
 
-const IMPORT_FAILURE_COPY: Record<ImportFailureReason, string> = {
-  timeout:
-    'The import ran out of time before finishing. Chats already imported were kept; run the import again to continue with the rest.',
-  invalid_archive:
-    'The file could not be read as a supported chat export. Export your chats again and upload the new file.',
-  limit_exceeded:
-    'The export is larger than the import limits allow. Try splitting it into smaller exports.',
-  key_mismatch:
-    'The encryption key used for the import no longer matches the key on your account. Nothing was written; try the import again.',
-  internal:
-    'Something went wrong on our side while processing the import. Please try again.',
+/** Which user flow drove the enclave import job; picks matching wording. */
+export type ImportSurface = 'chat_import' | 'backup_restore'
+
+const IMPORT_FAILURE_COPY: Record<
+  ImportSurface,
+  Record<ImportFailureReason, string>
+> = {
+  chat_import: {
+    timeout:
+      'The import ran out of time before finishing. Chats already imported were kept; run the import again to continue with the rest.',
+    invalid_archive:
+      'The file could not be read as a supported chat export. Export your chats again and upload the new file.',
+    limit_exceeded:
+      'The export is larger than the import limits allow. Try splitting it into smaller exports.',
+    key_mismatch:
+      'The encryption key used for the import no longer matches the key on your account. Nothing was written; try the import again.',
+    internal:
+      'Something went wrong on our side while processing the import. Please try again.',
+  },
+  backup_restore: {
+    timeout:
+      'The restore ran out of time before finishing. Cloud items already restored were kept; reselect the archive to continue with the rest.',
+    invalid_archive:
+      'The archive could not be read as a Tinfoil backup. Export a new backup and try again.',
+    limit_exceeded:
+      'The backup is larger than the restore limits allow. Try restoring from a smaller backup.',
+    key_mismatch:
+      'The encryption key used for the restore no longer matches the key on your account. Nothing was written; try the restore again.',
+    internal:
+      'Something went wrong on our side while restoring the backup. Please try again.',
+  },
 }
 
 /**
@@ -18,8 +38,12 @@ const IMPORT_FAILURE_COPY: Record<ImportFailureReason, string> = {
  * generic message for reasons this build does not know about so a
  * newer enclave never produces an empty explanation.
  */
-export function describeImportFailure(reason?: string): string {
-  if (reason && Object.hasOwn(IMPORT_FAILURE_COPY, reason))
-    return IMPORT_FAILURE_COPY[reason as ImportFailureReason]
-  return IMPORT_FAILURE_COPY.internal
+export function describeImportFailure(
+  reason: string | undefined,
+  surface: ImportSurface = 'chat_import',
+): string {
+  const copy = IMPORT_FAILURE_COPY[surface]
+  if (reason && Object.hasOwn(copy, reason))
+    return copy[reason as ImportFailureReason]
+  return copy.internal
 }

--- a/src/services/chat-import/import-failure-copy.ts
+++ b/src/services/chat-import/import-failure-copy.ts
@@ -1,0 +1,25 @@
+import type { ImportFailureReason } from '@/services/sync-enclave/sync-api'
+
+const IMPORT_FAILURE_COPY: Record<ImportFailureReason, string> = {
+  timeout:
+    'The import ran out of time before finishing. Chats already imported were kept; run the import again to continue with the rest.',
+  invalid_archive:
+    'The file could not be read as a supported chat export. Export your chats again and upload the new file.',
+  limit_exceeded:
+    'The export is larger than the import limits allow. Try splitting it into smaller exports.',
+  key_mismatch:
+    'The encryption key used for the import no longer matches the key on your account. Nothing was written; try the import again.',
+  internal:
+    'Something went wrong on our side while processing the import. Please try again.',
+}
+
+/**
+ * User-facing explanation for a failed import job. Falls back to the
+ * generic message for reasons this build does not know about so a
+ * newer enclave never produces an empty explanation.
+ */
+export function describeImportFailure(reason?: string): string {
+  if (reason && Object.hasOwn(IMPORT_FAILURE_COPY, reason))
+    return IMPORT_FAILURE_COPY[reason as ImportFailureReason]
+  return IMPORT_FAILURE_COPY.internal
+}

--- a/src/services/native-backup/orchestrate.ts
+++ b/src/services/native-backup/orchestrate.ts
@@ -1,8 +1,9 @@
 import type { Chat } from '@/components/chat/types'
 import { runOffDeviceImport } from '@/services/chat-import/off-device-import'
 import { chatStorage } from '@/services/storage/chat-storage'
+import { SyncEnclaveError } from '@/services/sync-enclave'
 // prettier-ignore
-import { importStatus,type ImportStatusResponse } from '@/services/sync-enclave/sync-api'
+import { importStatus,type ImportFailureReason,type ImportStatusResponse } from '@/services/sync-enclave/sync-api'
 import { uint8ArrayToBase64 } from '@/utils/binary-codec'
 import { sha256 } from '@noble/hashes/sha2.js'
 import { bytesToHex } from '@noble/hashes/utils.js'
@@ -21,8 +22,13 @@ export const NATIVE_RESTORE_KINDS = ['projects', 'project_documents', 'cloud_cha
 export type NativeRestoreKind = (typeof NATIVE_RESTORE_KINDS)[number]
 // prettier-ignore
 export type NativeRestoreCount = { imported: number; skipped: number; failed: number; blocked: number; warnings: string[]; errors: string[] }
+/**
+ * 'interrupted' means the enclave no longer knows the job (it restarted
+ * or reaped it) while we were still polling, so the outcome is unknown
+ * to the browser; the completion or failure email is the only signal.
+ */
 // prettier-ignore
-export type NativeRestoreResult = { state: 'completed' | 'partial' | 'failed' | 'pending'; jobId?: string; report: Record<NativeRestoreKind, NativeRestoreCount> }
+export type NativeRestoreResult = { state: 'completed' | 'partial' | 'failed' | 'pending' | 'interrupted'; jobId?: string; failureReason?: ImportFailureReason; report: Record<NativeRestoreKind, NativeRestoreCount> }
 // prettier-ignore
 type Dependencies = { validate: typeof validateAndPackageNativeBackup; upload: typeof runOffDeviceImport; status: typeof importStatus; forEachImage: typeof forEachNativeBackupLocalImage; getChat(id: string): Promise<Chat | null>; saveChat(chat: Chat, skipCloudSync?: boolean): Promise<Chat | null>; wait(ms: number, signal: AbortSignal): Promise<void> }
 // prettier-ignore
@@ -51,6 +57,12 @@ const defaults: Dependencies = {
       signal.addEventListener('abort', abort, { once: true })
     })
   },
+}
+
+// A job we were just polling has vanished from the enclave, which only
+// happens when the enclave restarted or reaped it.
+function isImportJobGone(cause: unknown): boolean {
+  return cause instanceof SyncEnclaveError && cause.status === 404
 }
 
 function emptyReport(): NativeRestoreResult['report'] {
@@ -321,7 +333,13 @@ export async function restoreNativeBackup(
         attempt++
       ) {
         await dependencies.wait(POLL_INTERVAL_MS, signal)
-        status = await dependencies.status(jobId, signal)
+        try {
+          status = await dependencies.status(jobId, signal)
+        } catch (cause) {
+          if (isImportJobGone(cause))
+            return { state: 'interrupted', jobId, report }
+          throw cause
+        }
         events.onPhase?.(status.phase)
       }
     } finally {
@@ -336,7 +354,9 @@ export async function restoreNativeBackup(
     })
     if (status!.status !== 'completed' && status!.status !== 'failed')
       return { state: 'pending', jobId, report }
-    if (status!.status === 'failed') return { state: 'failed', jobId, report }
+    if (status!.status === 'failed')
+      // prettier-ignore
+      return { state: 'failed', jobId, failureReason: status!.failure_reason, report }
   }
   await restoreLocalChats(
     validated,

--- a/src/services/sync-enclave/sync-api.ts
+++ b/src/services/sync-enclave/sync-api.ts
@@ -454,6 +454,14 @@ export type ImportSource = 'chatgpt' | 'claude' | 'tinfoil' | 'tinfoil_backup'
 export type ImportJobStatus =
   'idle' | 'staging' | 'running' | 'completed' | 'failed'
 
+/**
+ * Why a job ended with status 'failed'. The enclave classifies the
+ * underlying error into one of these so the UI can explain what to do
+ * next without seeing raw error text.
+ */
+export type ImportFailureReason =
+  'timeout' | 'invalid_archive' | 'limit_exceeded' | 'key_mismatch' | 'internal'
+
 export interface ImportCreateRequest {
   source: ImportSource
   /** Total size of the raw archive in bytes. */
@@ -498,6 +506,8 @@ export interface ImportStatusResponse {
   errors?: string[]
   project_mappings?: Record<string, string>
   job_id?: string
+  /** Set only when status is 'failed'. */
+  failure_reason?: ImportFailureReason
 }
 
 /**
@@ -548,7 +558,7 @@ export async function importUploadChunk(
 /**
  * Kick off the detached import job. The enclave validates the staged
  * archive, parses it, seals every chat + attachment under the supplied
- * CEK, and emails the user on completion.
+ * CEK, and emails the user when the job completes or fails.
  */
 export async function importStart(
   req: ImportStartRequest,

--- a/tests/components/chat/settings-modal.test.ts
+++ b/tests/components/chat/settings-modal.test.ts
@@ -1,4 +1,5 @@
 import {
+  describeOffDeviceImportKickoff,
   getDeleteAllChatsSuccessDescription,
   getDeleteAllChatsSuccessTitle,
 } from '@/components/chat/settings-modal'
@@ -31,5 +32,56 @@ describe('settings chat deletion confirmation', () => {
     expect(getDeleteAllChatsSuccessDescription(false, false)).toBe(
       'Removed all chats from this browser session.',
     )
+  })
+})
+
+describe('off-device import kickoff', () => {
+  it('announces a running job and promises an email', () => {
+    const result = describeOffDeviceImportKickoff(
+      { status: 'running', imported: 0, failed: 0, total: 0 },
+      'Claude',
+    )
+    expect(result).toMatchObject({
+      success: true,
+      pending: true,
+      failed: false,
+    })
+    expect(result.message).toMatch(/Claude export is being imported/)
+    expect(result.message).toMatch(/email you/)
+  })
+
+  it('reports a job that already failed instead of announcing a start', () => {
+    const result = describeOffDeviceImportKickoff(
+      {
+        status: 'failed',
+        imported: 0,
+        failed: 0,
+        total: 0,
+        errors: ['import key is not the current key'],
+        failure_reason: 'key_mismatch',
+      },
+      'Claude',
+    )
+    expect(result).toMatchObject({
+      success: false,
+      pending: false,
+      failed: true,
+      errors: ['import key is not the current key'],
+    })
+    expect(result.message).toMatch(/encryption key/i)
+    expect(result.message).not.toMatch(/being imported/)
+  })
+
+  it('treats a job that completed synchronously as done', () => {
+    const result = describeOffDeviceImportKickoff(
+      { status: 'completed', imported: 2, failed: 0, total: 2 },
+      'ChatGPT',
+    )
+    expect(result).toMatchObject({
+      success: true,
+      pending: false,
+      failed: false,
+      chatsImported: 2,
+    })
   })
 })

--- a/tests/components/chat/settings-modal.test.ts
+++ b/tests/components/chat/settings-modal.test.ts
@@ -2,6 +2,7 @@ import {
   describeOffDeviceImportKickoff,
   getDeleteAllChatsSuccessDescription,
   getDeleteAllChatsSuccessTitle,
+  importResultTitle,
 } from '@/components/chat/settings-modal'
 import { describe, expect, it } from 'vitest'
 
@@ -83,5 +84,22 @@ describe('off-device import kickoff', () => {
       failed: false,
       chatsImported: 2,
     })
+    expect(result.message).toBeUndefined()
+  })
+
+  it('titles the result by its outcome', () => {
+    const base = { chatsImported: 0, projectsImported: 0, errors: [] }
+    expect(importResultTitle({ ...base, success: true, pending: true })).toBe(
+      'Import in progress',
+    )
+    expect(importResultTitle({ ...base, success: true })).toBe(
+      'Import complete',
+    )
+    expect(importResultTitle({ ...base, success: false, failed: true })).toBe(
+      'Import failed',
+    )
+    expect(importResultTitle({ ...base, success: false })).toBe(
+      'Import completed with errors',
+    )
   })
 })

--- a/tests/components/native-backup-restore.test.tsx
+++ b/tests/components/native-backup-restore.test.tsx
@@ -235,13 +235,29 @@ describe('NativeBackupRestore', () => {
     selectArchive(view.container)
     fireEvent.click(await screen.findByRole('button', { name: 'Close' }))
 
-    finish({ state: 'failed', report })
+    finish({ state: 'failed', failureReason: 'timeout', report })
 
-    expect(
-      await screen.findByText(
-        'The cloud restore failed. No local chats were restored.',
-      ),
-    ).toBeVisible()
+    const message = await screen.findByRole('status')
+    expect(message).toHaveTextContent(/^The cloud restore failed\./)
+    expect(message).toHaveTextContent(/ran out of time/i)
+    expect(message).toHaveTextContent(/No local chats were restored\.$/)
+  })
+
+  it('explains an interrupted restore without a report table', async () => {
+    mocks.restore.mockResolvedValue({
+      state: 'interrupted',
+      jobId: 'job-1',
+      report,
+    })
+    const { container } = render(
+      <NativeBackupRestore available ownerId="owner" />,
+    )
+    selectArchive(container)
+
+    const message = await screen.findByRole('status')
+    expect(message).toHaveTextContent(/interrupted/i)
+    expect(message).toHaveTextContent("We'll email you")
+    expect(screen.queryByRole('list')).not.toBeInTheDocument()
   })
 
   it('replaces the dismissed progress message after completion', async () => {

--- a/tests/fixtures/native-backup-import-status-failed.json
+++ b/tests/fixtures/native-backup-import-status-failed.json
@@ -1,0 +1,15 @@
+{
+  "status": "failed",
+  "phase": "chats",
+  "imported": 2,
+  "failed": 0,
+  "total": 5,
+  "counts": {
+    "project": { "imported": 1, "skipped": 0, "failed": 0, "blocked": 0 },
+    "document": { "imported": 0, "skipped": 0, "failed": 0, "blocked": 0 },
+    "chat": { "imported": 1, "skipped": 0, "failed": 0, "blocked": 0 }
+  },
+  "errors": ["import timed out"],
+  "job_id": "job-1",
+  "failure_reason": "timeout"
+}

--- a/tests/services/chat-import/import-failure-copy.test.ts
+++ b/tests/services/chat-import/import-failure-copy.test.ts
@@ -1,0 +1,27 @@
+import { describeImportFailure } from '@/services/chat-import/import-failure-copy'
+import { describe, expect, it } from 'vitest'
+
+describe('describeImportFailure', () => {
+  it('gives each known reason a distinct explanation', () => {
+    const reasons = [
+      'timeout',
+      'invalid_archive',
+      'limit_exceeded',
+      'key_mismatch',
+      'internal',
+    ] as const
+    const copy = reasons.map(describeImportFailure)
+    expect(new Set(copy).size).toBe(reasons.length)
+    expect(describeImportFailure('timeout')).toMatch(/run the import again/i)
+    expect(describeImportFailure('key_mismatch')).toMatch(
+      /nothing was written/i,
+    )
+  })
+
+  it('falls back to the generic explanation for unknown or missing reasons', () => {
+    const generic = describeImportFailure('internal')
+    expect(describeImportFailure('something_new')).toBe(generic)
+    expect(describeImportFailure(undefined)).toBe(generic)
+    expect(describeImportFailure('toString')).toBe(generic)
+  })
+})

--- a/tests/services/chat-import/import-failure-copy.test.ts
+++ b/tests/services/chat-import/import-failure-copy.test.ts
@@ -10,11 +10,21 @@ describe('describeImportFailure', () => {
       'key_mismatch',
       'internal',
     ] as const
-    const copy = reasons.map(describeImportFailure)
+    const copy = reasons.map((reason) => describeImportFailure(reason))
     expect(new Set(copy).size).toBe(reasons.length)
     expect(describeImportFailure('timeout')).toMatch(/run the import again/i)
     expect(describeImportFailure('key_mismatch')).toMatch(
       /nothing was written/i,
+    )
+  })
+
+  it('uses restore wording for the backup restore surface', () => {
+    const restore = describeImportFailure('timeout', 'backup_restore')
+    expect(restore).toMatch(/restore/i)
+    expect(restore).not.toMatch(/\bimport\b/i)
+    expect(restore).not.toBe(describeImportFailure('timeout'))
+    expect(describeImportFailure('nope', 'backup_restore')).toBe(
+      describeImportFailure('internal', 'backup_restore'),
     )
   })
 

--- a/tests/services/native-backup/orchestrate.test.ts
+++ b/tests/services/native-backup/orchestrate.test.ts
@@ -1,5 +1,6 @@
 import { restoreNativeBackup } from '@/services/native-backup/orchestrate'
 import type { ValidatedNativeRestore } from '@/services/native-backup/restore'
+import { SyncEnclaveError } from '@/services/sync-enclave'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const sourceFile = new File(['plaintext'], 'backup.zip')
@@ -455,6 +456,75 @@ describe('restoreNativeBackup', () => {
       expect(saveChat).not.toHaveBeenCalled()
     },
   )
+
+  it('carries the enclave failure reason on a failed cloud job', async () => {
+    dependencies.upload.mockResolvedValue({
+      jobId: 'job-1',
+      status: { status: 'running', imported: 0, failed: 0, total: 1 },
+    })
+    dependencies.status.mockResolvedValue({
+      status: 'failed',
+      imported: 0,
+      failed: 0,
+      total: 1,
+      errors: ['import timed out'],
+      failure_reason: 'timeout',
+    })
+
+    const result = await restoreNativeBackup(
+      sourceFile,
+      'owner-a',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+
+    expect(result).toMatchObject({ state: 'failed', failureReason: 'timeout' })
+    expect(result.report.cloud_chats.errors).toEqual(['import timed out'])
+    expect(saveChat).not.toHaveBeenCalled()
+  })
+
+  it('reports an interrupted restore when the enclave forgets the job mid-poll', async () => {
+    dependencies.upload.mockResolvedValue({
+      jobId: 'job-1',
+      status: { status: 'running', imported: 0, failed: 0, total: 1 },
+    })
+    dependencies.status.mockRejectedValue(
+      new SyncEnclaveError('import job not found', 404, 'NOT_FOUND'),
+    )
+
+    const result = await restoreNativeBackup(
+      sourceFile,
+      'owner-a',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+
+    expect(result).toMatchObject({ state: 'interrupted', jobId: 'job-1' })
+    expect(dependencies.status).toHaveBeenCalledOnce()
+    expect(saveChat).not.toHaveBeenCalled()
+  })
+
+  it('rethrows status poll failures other than a missing job', async () => {
+    dependencies.upload.mockResolvedValue({
+      jobId: 'job-1',
+      status: { status: 'running', imported: 0, failed: 0, total: 1 },
+    })
+    dependencies.status.mockRejectedValue(
+      new SyncEnclaveError('sync enclave request failed: 503', 503, 'HTTP_503'),
+    )
+
+    await expect(
+      restoreNativeBackup(
+        sourceFile,
+        'owner-a',
+        new AbortController().signal,
+        {},
+        dependencies,
+      ),
+    ).rejects.toMatchObject({ status: 503 })
+  })
 
   it('detaches chats from failed projects and treats warnings as partial', async () => {
     dependencies.upload.mockResolvedValue({

--- a/tests/services/sync-enclave/import-status-contract.test.ts
+++ b/tests/services/sync-enclave/import-status-contract.test.ts
@@ -1,5 +1,6 @@
 import type { ImportStatusResponse } from '@/services/sync-enclave/sync-api'
 import { describe, expect, it } from 'vitest'
+import failedFixture from '../../fixtures/native-backup-import-status-failed.json'
 import fixture from '../../fixtures/native-backup-import-status.json'
 
 describe('native backup import status contract', () => {
@@ -25,5 +26,23 @@ describe('native backup import status contract', () => {
     expect(status.project_mappings).toEqual({
       'source-project': 'destination-project',
     })
+  })
+
+  it('carries a failure reason only on a failed job', () => {
+    const failed = failedFixture as ImportStatusResponse
+    expect(Object.keys(failed)).toEqual([
+      'status',
+      'phase',
+      'imported',
+      'failed',
+      'total',
+      'counts',
+      'errors',
+      'job_id',
+      'failure_reason',
+    ])
+    expect(failed.status).toBe('failed')
+    expect(failed.failure_reason).toBe('timeout')
+    expect(fixture).not.toHaveProperty('failure_reason')
   })
 })

--- a/tests/services/sync-enclave/sync-api.test.ts
+++ b/tests/services/sync-enclave/sync-api.test.ts
@@ -638,8 +638,23 @@ describe('sync-api (enclave JSON-RPC)', () => {
     )
     const status = await api.importStatus('job-1')
     expect(status.errors).toEqual([])
+    expect(status.failure_reason).toBeUndefined()
     expect(lastRequest()[0]).toBe('/v1/import/status')
     expect(lastBody()).toEqual({ job_id: 'job-1' })
+
+    mockFetch.mockResolvedValueOnce(
+      ok({
+        status: 'failed',
+        imported: 1,
+        failed: 0,
+        total: 2,
+        errors: ['import timed out'],
+        failure_reason: 'timeout',
+      }),
+    )
+    const failed = await api.importStatus('job-1')
+    expect(failed.failure_reason).toBe('timeout')
+    expect(failed.errors).toEqual(['import timed out'])
   })
 
   it('searchQuery posts /v1/search/query and normalizes null results', async () => {


### PR DESCRIPTION
The sync enclave now reports a `failure_reason` (`timeout`, `invalid_archive`, `limit_exceeded`, `key_mismatch`, `internal`) on failed import jobs (tinfoilsh/confidential-sync#48) and emails the user on failure (tinfoilsh/controlplane#702). This wires the webapp to it.

- Types `failure_reason` on `ImportStatusResponse` and adds a single reason-to-copy helper shared by both import surfaces.
- Native backup restore carries the reason into its result and shows it instead of a fixed "The cloud restore failed." A 404 while polling (enclave restarted or reaped the job) is now a distinct `interrupted` state rather than leaking "import job not found" to the user.
- ChatGPT/Claude import no longer toasts "Import started" when the kickoff snapshot already says `failed`; the panel shows "Import failed" with the reason instead of "Import completed with errors".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the enclave's `failure_reason` (`timeout`, `invalid_archive`, `limit_exceeded`, `key_mismatch`, `internal`) as user-facing copy when a chat import or backup restore fails, and fixes two misleading results along the way.

- Backup restore now shows the specific reason for a cloud failure with restore-specific wording instead of the fixed "The cloud restore failed."
- A 404 while polling restore status is reported as `interrupted` rather than leaking "import job not found"; the outcome email is the only signal.
- ChatGPT/Claude imports whose kickoff snapshot already says `failed` no longer toast "Import started"; the panel and toast show "Import failed" with the reason.

<sup>Written for commit 8f0f76cb3bfe1c866a9a3e1f85ce295c24fe15ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

