### PR TITLE
fix: close the gap between slider fill and thumb

### DIFF
--- a/src/components/ui/stepped-slider.tsx
+++ b/src/components/ui/stepped-slider.tsx
@@ -49,7 +49,7 @@ export function SteppedSlider<T extends string>({
       }}
     >
       <SliderPrimitive.Track className="relative h-8 w-full grow overflow-hidden rounded-full bg-content-muted/25">
-        <SliderPrimitive.Range className="absolute h-full rounded-full bg-brand-accent-light" />
+        <SliderPrimitive.Range className="absolute h-full bg-brand-accent-light" />
         <div
           className="pointer-events-none absolute inset-y-0 flex items-center justify-between"
           style={{ left: '1rem', right: '1rem' }}


### PR DESCRIPTION
Remove the green fill’s inner rounding so it extends beneath the thumb without leaving a gap. The outer track keeps its rounded corners.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the slider fill’s inner rounding so it extends fully beneath the thumb without leaving a gap. The outer track keeps its rounded corners.

<sup>Written for commit 0f3e18040282a4341015a4cf27d398aacf9a41c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

