### PR TITLE
fix: refine the intelligence slider and Max animation

### DIFF
--- a/src/components/ui/stepped-slider.tsx
+++ b/src/components/ui/stepped-slider.tsx
@@ -16,8 +16,8 @@ type SteppedSliderProps<T extends string> = {
 }
 
 /**
- * A discrete slider with one stop per step. The slim rail meets a green-edged
- * thumb; inset dots follow the thumb's center from the first stop to the last.
+ * A discrete slider with one stop per step. The pill-shaped fill wraps around
+ * an inset white thumb; dots follow its center from the first stop to the last.
  */
 export function SteppedSlider<T extends string>({
   steps,
@@ -31,11 +31,13 @@ export function SteppedSlider<T extends string>({
     steps.findIndex((step) => step.id === value),
   )
   const lastIndex = steps.length - 1
+  // Include the thumb's width and Radix's in-bounds offset in the fill.
+  const fillExtension = 1 - index / Math.max(lastIndex, 1)
 
   return (
     <SliderPrimitive.Root
       className={cn(
-        'relative flex h-8 w-full cursor-pointer touch-none select-none items-center',
+        'relative flex h-[var(--slider-size)] w-full cursor-pointer touch-none select-none items-center [--slider-size:2rem]',
         className,
       )}
       min={0}
@@ -47,10 +49,15 @@ export function SteppedSlider<T extends string>({
         if (step && step.id !== value) onValueChange(step.id)
       }}
     >
-      <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-content-muted/20">
-        <SliderPrimitive.Range className="absolute h-full rounded-full bg-brand-accent-light" />
+      <SliderPrimitive.Track className="relative h-full w-full grow overflow-hidden rounded-full bg-content-muted/20">
+        <SliderPrimitive.Range
+          className="absolute h-full rounded-full bg-brand-accent-light"
+          style={{
+            marginInlineEnd: `calc(var(--slider-size) * -${fillExtension})`,
+          }}
+        />
         <div
-          className="pointer-events-none absolute inset-x-2.5 inset-y-0 flex items-center justify-between"
+          className="pointer-events-none absolute inset-x-3.5 inset-y-0 flex items-center justify-between"
           aria-hidden="true"
         >
           {steps.map((step, i) => (
@@ -65,7 +72,7 @@ export function SteppedSlider<T extends string>({
         </div>
       </SliderPrimitive.Track>
       <SliderPrimitive.Thumb
-        className="block h-6 w-6 cursor-grab rounded-full border-[3px] border-brand-accent-light bg-white shadow-sm ring-offset-surface-chat transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-light focus-visible:ring-offset-2 active:cursor-grabbing"
+        className="block size-[var(--slider-size)] cursor-grab rounded-full border-4 border-transparent bg-white bg-clip-padding ring-offset-surface-chat drop-shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-light focus-visible:ring-offset-2 active:cursor-grabbing"
         aria-label={ariaLabel}
         aria-valuetext={steps[index]?.label}
       />

--- a/src/components/ui/stepped-slider.tsx
+++ b/src/components/ui/stepped-slider.tsx
@@ -16,9 +16,8 @@ type SteppedSliderProps<T extends string> = {
 }
 
 /**
- * A discrete slider with one stop per step. The track is as tall as a switch
- * so the fill reads as a level indicator; a dot marks each stop and the thumb
- * covers the current one.
+ * A discrete slider with one stop per step. The slim rail meets a green-edged
+ * thumb; inset dots follow the thumb's center from the first stop to the last.
  */
 export function SteppedSlider<T extends string>({
   steps,
@@ -36,7 +35,7 @@ export function SteppedSlider<T extends string>({
   return (
     <SliderPrimitive.Root
       className={cn(
-        'relative flex h-8 w-full touch-none select-none items-center',
+        'relative flex h-8 w-full cursor-pointer touch-none select-none items-center',
         className,
       )}
       min={0}
@@ -48,26 +47,25 @@ export function SteppedSlider<T extends string>({
         if (step && step.id !== value) onValueChange(step.id)
       }}
     >
-      <SliderPrimitive.Track className="relative h-8 w-full grow overflow-hidden rounded-full bg-content-muted/25">
-        <SliderPrimitive.Range className="absolute h-full bg-brand-accent-light" />
+      <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-content-muted/20">
+        <SliderPrimitive.Range className="absolute h-full rounded-full bg-brand-accent-light" />
         <div
-          className="pointer-events-none absolute inset-y-0 flex items-center justify-between"
-          style={{ left: '1rem', right: '1rem' }}
+          className="pointer-events-none absolute inset-x-2.5 inset-y-0 flex items-center justify-between"
           aria-hidden="true"
         >
           {steps.map((step, i) => (
             <span
               key={step.id}
               className={cn(
-                'h-1.5 w-1.5 rounded-full',
-                i <= index ? 'bg-white/60' : 'bg-content-muted/70',
+                'h-1 w-1 shrink-0 rounded-full',
+                i <= index ? 'bg-white/70' : 'bg-content-muted/40',
               )}
             />
           ))}
         </div>
       </SliderPrimitive.Track>
       <SliderPrimitive.Thumb
-        className="block h-7 w-7 rounded-full bg-white shadow-md ring-offset-surface-chat transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-light focus-visible:ring-offset-2"
+        className="block h-6 w-6 cursor-grab rounded-full border-[3px] border-brand-accent-light bg-white shadow-sm ring-offset-surface-chat transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-light focus-visible:ring-offset-2 active:cursor-grabbing"
         aria-label={ariaLabel}
         aria-valuetext={steps[index]?.label}
       />

--- a/src/components/ui/stepped-slider.tsx
+++ b/src/components/ui/stepped-slider.tsx
@@ -51,7 +51,10 @@ export function SteppedSlider<T extends string>({
     >
       <SliderPrimitive.Track className="relative h-full w-full grow overflow-hidden rounded-full bg-content-muted/20">
         <SliderPrimitive.Range
-          className="absolute h-full rounded-full bg-brand-accent-light"
+          className={cn(
+            'absolute h-full rounded-full bg-brand-accent-light',
+            index === lastIndex && 'stepped-slider-max-fill',
+          )}
           style={{
             marginInlineEnd: `calc(var(--slider-size) * -${fillExtension})`,
           }}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -165,33 +165,27 @@
 
 @layer utilities {
   .stepped-slider-max-fill {
-    --slider-max-cycle: 6s;
-    background-image: linear-gradient(
-      110deg,
-      hsl(var(--color-accent-light)),
-      theme('colors.sky.400'),
-      theme('colors.violet.400'),
-      theme('colors.pink.400'),
-      theme('colors.amber.300'),
-      hsl(var(--color-accent-light))
-    );
-    background-size: 200% 100%;
-    background-position: 50% 50%;
+    --slider-max-cycle: 8s;
+    --slider-max-pattern-width: 1.5rem;
+    --slider-max-pattern-height: 1rem;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 16'%3E%3Cpath d='M-6 12L6 4L18 12L30 4' fill='none' stroke='white' stroke-opacity='.16' stroke-width='1.5' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-size: var(--slider-max-pattern-width)
+      var(--slider-max-pattern-height);
+    background-position: 0 0;
   }
 
   @media (prefers-reduced-motion: no-preference) {
     .stepped-slider-max-fill {
-      animation: slider-max-flow var(--slider-max-cycle) ease-in-out infinite
-        alternate;
+      animation: slider-max-flow var(--slider-max-cycle) linear infinite;
     }
   }
 
   @keyframes slider-max-flow {
     from {
-      background-position: 0% 50%;
+      background-position: 0 0;
     }
     to {
-      background-position: 100% 50%;
+      background-position: var(--slider-max-pattern-width) 0;
     }
   }
 

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -164,6 +164,37 @@
 }
 
 @layer utilities {
+  .stepped-slider-max-fill {
+    --slider-max-cycle: 6s;
+    background-image: linear-gradient(
+      110deg,
+      hsl(var(--color-accent-light)),
+      theme('colors.sky.400'),
+      theme('colors.violet.400'),
+      theme('colors.pink.400'),
+      theme('colors.amber.300'),
+      hsl(var(--color-accent-light))
+    );
+    background-size: 200% 100%;
+    background-position: 50% 50%;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .stepped-slider-max-fill {
+      animation: slider-max-flow var(--slider-max-cycle) ease-in-out infinite
+        alternate;
+    }
+  }
+
+  @keyframes slider-max-flow {
+    from {
+      background-position: 0% 50%;
+    }
+    to {
+      background-position: 100% 50%;
+    }
+  }
+
   .redacted-text-block {
     display: none;
   }

--- a/tests/components/ui/stepped-slider.test.tsx
+++ b/tests/components/ui/stepped-slider.test.tsx
@@ -87,4 +87,20 @@ describe('SteppedSlider', () => {
     expect(screen.getByRole('slider')).toHaveAttribute('aria-valuetext', 'High')
     expect(onValueChange).not.toHaveBeenCalled()
   })
+
+  it('uses the multicolor fill only at the maximum and removes it when stepping down', () => {
+    const { container } = render(<ControlledSlider />)
+    const thumb = screen.getByRole('slider', { name: 'Intelligence' })
+
+    expect(container.querySelector('.stepped-slider-max-fill')).toBeNull()
+
+    fireEvent.keyDown(thumb, { key: 'End' })
+    expect(
+      container.querySelector('.stepped-slider-max-fill'),
+    ).toBeInTheDocument()
+
+    fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
+    expect(thumb).toHaveAttribute('aria-valuetext', 'Medium')
+    expect(container.querySelector('.stepped-slider-max-fill')).toBeNull()
+  })
 })

--- a/tests/components/ui/stepped-slider.test.tsx
+++ b/tests/components/ui/stepped-slider.test.tsx
@@ -1,0 +1,90 @@
+import { SteppedSlider } from '@/components/ui/stepped-slider'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const STEPS = [
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'High' },
+] as const
+
+function ControlledSlider() {
+  const [value, setValue] = useState<(typeof STEPS)[number]['id']>('medium')
+  return (
+    <SteppedSlider
+      steps={STEPS}
+      value={value}
+      onValueChange={setValue}
+      aria-label="Intelligence"
+    />
+  )
+}
+
+afterEach(cleanup)
+
+describe('SteppedSlider', () => {
+  it.each(STEPS)('exposes the selected $label step and bounds', (step) => {
+    render(
+      <SteppedSlider
+        steps={STEPS}
+        value={step.id}
+        onValueChange={vi.fn()}
+        aria-label="Intelligence"
+      />,
+    )
+
+    const thumb = screen.getByRole('slider', { name: 'Intelligence' })
+    expect(thumb).toHaveAttribute('aria-valuenow', String(STEPS.indexOf(step)))
+    expect(thumb).toHaveAttribute('aria-valuetext', step.label)
+    expect(thumb).toHaveAttribute('aria-valuemin', '0')
+    expect(thumb).toHaveAttribute('aria-valuemax', String(STEPS.length - 1))
+  })
+
+  it('moves between steps with arrow keys and stays within the endpoints', () => {
+    render(<ControlledSlider />)
+    const thumb = screen.getByRole('slider', { name: 'Intelligence' })
+
+    for (const [key, label] of [
+      ['ArrowRight', 'High'],
+      ['ArrowRight', 'High'],
+      ['ArrowLeft', 'Medium'],
+      ['ArrowDown', 'Low'],
+      ['ArrowDown', 'Low'],
+      ['ArrowUp', 'Medium'],
+    ]) {
+      fireEvent.keyDown(thumb, { key })
+      expect(thumb).toHaveAttribute('aria-valuetext', label)
+      expect(thumb).toHaveAttribute(
+        'aria-valuenow',
+        String(STEPS.findIndex((step) => step.label === label)),
+      )
+    }
+  })
+
+  it('jumps to the first and last steps with Home and End', () => {
+    render(<ControlledSlider />)
+    const thumb = screen.getByRole('slider', { name: 'Intelligence' })
+
+    fireEvent.keyDown(thumb, { key: 'Home' })
+    expect(thumb).toHaveAttribute('aria-valuetext', 'Low')
+
+    fireEvent.keyDown(thumb, { key: 'End' })
+    expect(thumb).toHaveAttribute('aria-valuetext', 'High')
+  })
+
+  it('follows external value changes without emitting a selection', () => {
+    const onValueChange = vi.fn()
+    const props = {
+      steps: STEPS,
+      onValueChange,
+      'aria-label': 'Intelligence',
+    }
+    const { rerender } = render(<SteppedSlider {...props} value="low" />)
+
+    rerender(<SteppedSlider {...props} value="high" />)
+
+    expect(screen.getByRole('slider')).toHaveAttribute('aria-valuetext', 'High')
+    expect(onValueChange).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/ui/stepped-slider.test.tsx
+++ b/tests/components/ui/stepped-slider.test.tsx
@@ -88,7 +88,7 @@ describe('SteppedSlider', () => {
     expect(onValueChange).not.toHaveBeenCalled()
   })
 
-  it('uses the multicolor fill only at the maximum and removes it when stepping down', () => {
+  it('uses the patterned fill only at the maximum and removes it when stepping down', () => {
     const { container } = render(<ControlledSlider />)
     const thumb = screen.getByRole('slider', { name: 'Intelligence' })
 

--- a/tests/components/ui/stepped-slider.test.tsx
+++ b/tests/components/ui/stepped-slider.test.tsx
@@ -1,7 +1,12 @@
 import { SteppedSlider } from '@/components/ui/stepped-slider'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { Window } from 'happy-dom'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import postcss from 'postcss'
 import { useState } from 'react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import tailwindcss from 'tailwindcss'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 const STEPS = [
   { id: 'low', label: 'Low' },
@@ -102,5 +107,52 @@ describe('SteppedSlider', () => {
     fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
     expect(thumb).toHaveAttribute('aria-valuetext', 'Medium')
     expect(container.querySelector('.stepped-slider-max-fill')).toBeNull()
+  })
+
+  describe('computed fill animation', () => {
+    let css: string
+
+    beforeAll(async () => {
+      const stylesheetPath = resolve('src/styles/tailwind.css')
+      const configPath = resolve('tailwind.config.js')
+      const result = await postcss([tailwindcss(configPath)]).process(
+        await readFile(stylesheetPath, 'utf8'),
+        { from: stylesheetPath },
+      )
+      css = result.css
+    })
+
+    it.each(['no-preference', 'reduce'])(
+      'respects the %s motion preference at Max and after stepping down',
+      async (prefersReducedMotion) => {
+        const browserWindow = new Window({
+          settings: { device: { prefersReducedMotion } },
+        })
+        try {
+          const style = browserWindow.document.createElement('style')
+          style.textContent = css
+          browserWindow.document.head.append(style)
+          const { container } = render(<ControlledSlider />)
+          const thumb = screen.getByRole('slider', { name: 'Intelligence' })
+
+          for (const key of ['End', 'ArrowLeft']) {
+            fireEvent.keyDown(thumb, { key })
+            browserWindow.document.body.innerHTML = container.innerHTML
+            const fill = browserWindow.document.querySelector(
+              '.bg-brand-accent-light',
+            )!
+            const computed = browserWindow.getComputedStyle(fill)
+
+            expect(computed.animation).toBe(
+              key === 'End' && prefersReducedMotion === 'no-preference'
+                ? 'slider-max-flow 8s linear infinite'
+                : '',
+            )
+          }
+        } finally {
+          await browserWindow.happyDOM.close()
+        }
+      },
+    )
   })
 })


### PR DESCRIPTION
Keep the thick slider while aligning its rounded green fill with the inset white thumb and step markers. At Max, add a faint, slowly moving zigzag that stays static when reduced motion is enabled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the intelligence slider so the green fill now aligns with the inset white thumb and step markers, and adds a subtle animated zigzag at the Max level that stays static when reduced motion is enabled.

<sup>Written for commit 86bd93a35e1539f81983de54d314a7ae40987f63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

