### PR TITLE
feat: show experimental and deprecated model tags

### DIFF
--- a/src/components/chat/model-lifecycle-badges.tsx
+++ b/src/components/chat/model-lifecycle-badges.tsx
@@ -5,10 +5,11 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import type { BaseModel } from '@/config/models'
-import { InformationCircleIcon } from '@heroicons/react/24/outline'
 
+// Matches the "Default" chip in the effort menu so the labels read as quiet
+// metadata rather than alerts.
 const BADGE_CLASS_NAME =
-  'inline-flex shrink-0 cursor-help items-center gap-1 whitespace-nowrap rounded-md px-1.5 py-px font-aeonik text-xs font-normal leading-none tracking-normal'
+  'inline-flex shrink-0 cursor-help items-center whitespace-nowrap rounded bg-surface-card px-1.5 py-0.5 text-xs font-normal'
 
 const EXPERIMENTAL_TOOLTIP =
   'Support and availability are not guaranteed. This model can be deprecated at any time.'
@@ -28,8 +29,7 @@ export function ModelLifecycleBadges({
           {
             label: 'Experimental',
             tooltip: EXPERIMENTAL_TOOLTIP,
-            className:
-              'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+            className: 'text-content-muted',
           },
         ]
       : []),
@@ -40,8 +40,7 @@ export function ModelLifecycleBadges({
             tooltip: model.deprecationdate
               ? `This model will be taken offline on ${model.deprecationdate}.`
               : DEPRECATION_TOOLTIP,
-            className:
-              'bg-amber-50 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+            className: 'text-amber-700 dark:text-amber-400',
           },
         ]
       : []),
@@ -49,15 +48,11 @@ export function ModelLifecycleBadges({
 
   return (
     <TooltipProvider>
-      <span className="my-0.5 flex flex-wrap items-center gap-1">
+      <span className="mb-1 mt-0.5 flex flex-wrap items-center gap-1">
         {badges.map(({ label, tooltip, className }) => (
           <Tooltip key={label}>
             <TooltipTrigger asChild>
               <span className={`${BADGE_CLASS_NAME} ${className}`}>
-                <InformationCircleIcon
-                  className="h-3 w-3 shrink-0"
-                  aria-hidden="true"
-                />
                 {label}
                 <span className="sr-only">: {tooltip}</span>
               </span>

--- a/src/components/chat/model-lifecycle-badges.tsx
+++ b/src/components/chat/model-lifecycle-badges.tsx
@@ -1,0 +1,29 @@
+import type { BaseModel } from '@/config/models'
+
+const BADGE_CLASS_NAME =
+  'inline-flex shrink-0 items-center whitespace-nowrap rounded-md px-1.5 py-px font-aeonik text-[10px] font-normal leading-none tracking-normal'
+
+export function ModelLifecycleBadges({
+  model,
+}: {
+  model: Pick<BaseModel, 'experimental' | 'deprecated'>
+}) {
+  return (
+    <>
+      {model.experimental === true && (
+        <span
+          className={`${BADGE_CLASS_NAME} bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200`}
+        >
+          Experimental
+        </span>
+      )}
+      {model.deprecated === true && (
+        <span
+          className={`${BADGE_CLASS_NAME} bg-amber-50 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200`}
+        >
+          Deprecated
+        </span>
+      )}
+    </>
+  )
+}

--- a/src/components/chat/model-lifecycle-badges.tsx
+++ b/src/components/chat/model-lifecycle-badges.tsx
@@ -1,29 +1,73 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import type { BaseModel } from '@/config/models'
+import { InformationCircleIcon } from '@heroicons/react/24/outline'
 
 const BADGE_CLASS_NAME =
-  'inline-flex shrink-0 items-center whitespace-nowrap rounded-md px-1.5 py-px font-aeonik text-[10px] font-normal leading-none tracking-normal'
+  'inline-flex shrink-0 cursor-help items-center gap-1 whitespace-nowrap rounded-md px-1.5 py-px font-aeonik text-xs font-normal leading-none tracking-normal'
+
+const EXPERIMENTAL_TOOLTIP =
+  'Support and availability are not guaranteed. This model can be deprecated at any time.'
+const DEPRECATION_TOOLTIP =
+  'This model is deprecated. An offline date has not been announced.'
 
 export function ModelLifecycleBadges({
   model,
 }: {
-  model: Pick<BaseModel, 'experimental' | 'deprecated'>
+  model: Pick<BaseModel, 'experimental' | 'deprecated' | 'deprecationdate'>
 }) {
+  if (model.experimental !== true && model.deprecated !== true) return null
+
+  const badges = [
+    ...(model.experimental === true
+      ? [
+          {
+            label: 'Experimental',
+            tooltip: EXPERIMENTAL_TOOLTIP,
+            className:
+              'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+          },
+        ]
+      : []),
+    ...(model.deprecated === true
+      ? [
+          {
+            label: 'Deprecated',
+            tooltip: model.deprecationdate
+              ? `This model will be taken offline on ${model.deprecationdate}.`
+              : DEPRECATION_TOOLTIP,
+            className:
+              'bg-amber-50 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+          },
+        ]
+      : []),
+  ]
+
   return (
-    <>
-      {model.experimental === true && (
-        <span
-          className={`${BADGE_CLASS_NAME} bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200`}
-        >
-          Experimental
-        </span>
-      )}
-      {model.deprecated === true && (
-        <span
-          className={`${BADGE_CLASS_NAME} bg-amber-50 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200`}
-        >
-          Deprecated
-        </span>
-      )}
-    </>
+    <TooltipProvider>
+      <span className="my-0.5 flex flex-wrap items-center gap-1">
+        {badges.map(({ label, tooltip, className }) => (
+          <Tooltip key={label}>
+            <TooltipTrigger asChild>
+              <span className={`${BADGE_CLASS_NAME} ${className}`}>
+                <InformationCircleIcon
+                  className="h-3 w-3 shrink-0"
+                  aria-hidden="true"
+                />
+                {label}
+                <span className="sr-only">: {tooltip}</span>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs border-border-subtle bg-surface-chat font-aeonik text-xs text-content-primary">
+              {tooltip}
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      </span>
+    </TooltipProvider>
   )
 }

--- a/src/components/chat/model-lifecycle-badges.tsx
+++ b/src/components/chat/model-lifecycle-badges.tsx
@@ -6,10 +6,8 @@ import {
 } from '@/components/ui/tooltip'
 import type { BaseModel } from '@/config/models'
 
-// Matches the "Default" chip in the effort menu so the labels read as quiet
-// metadata rather than alerts.
 const BADGE_CLASS_NAME =
-  'inline-flex shrink-0 cursor-help items-center whitespace-nowrap rounded bg-surface-card px-1.5 py-0.5 text-xs font-normal'
+  'inline-flex shrink-0 cursor-help items-center whitespace-nowrap rounded px-1.5 py-0.5 text-xs font-normal'
 
 const EXPERIMENTAL_TOOLTIP =
   'Support and availability are not guaranteed. This model can be deprecated at any time.'
@@ -29,7 +27,8 @@ export function ModelLifecycleBadges({
           {
             label: 'Experimental',
             tooltip: EXPERIMENTAL_TOOLTIP,
-            className: 'text-content-muted',
+            className:
+              'bg-blue-500/10 text-blue-600 dark:bg-blue-400/15 dark:text-blue-300',
           },
         ]
       : []),
@@ -40,7 +39,8 @@ export function ModelLifecycleBadges({
             tooltip: model.deprecationdate
               ? `This model will be taken offline on ${model.deprecationdate}.`
               : DEPRECATION_TOOLTIP,
-            className: 'text-amber-700 dark:text-amber-400',
+            className:
+              'bg-amber-500/10 text-amber-700 dark:bg-amber-400/15 dark:text-amber-300',
           },
         ]
       : []),

--- a/src/components/chat/model-lifecycle-badges.tsx
+++ b/src/components/chat/model-lifecycle-badges.tsx
@@ -48,7 +48,7 @@ export function ModelLifecycleBadges({
 
   return (
     <TooltipProvider>
-      <span className="mb-1 mt-0.5 flex flex-wrap items-center gap-1">
+      <span className="mt-1.5 flex flex-wrap items-center gap-1">
         {badges.map(({ label, tooltip, className }) => (
           <Tooltip key={label}>
             <TooltipTrigger asChild>

--- a/src/components/chat/model-lifecycle-badges.tsx
+++ b/src/components/chat/model-lifecycle-badges.tsx
@@ -47,7 +47,7 @@ export function ModelLifecycleBadges({
   ]
 
   return (
-    <TooltipProvider>
+    <TooltipProvider delayDuration={0}>
       <span className="mt-1.5 flex flex-wrap items-center gap-1">
         {badges.map(({ label, tooltip, className }) => (
           <Tooltip key={label}>

--- a/src/components/chat/model-selector-trigger-label.tsx
+++ b/src/components/chat/model-selector-trigger-label.tsx
@@ -1,11 +1,13 @@
 import {
   AUTO_INTELLIGENCE_LEVELS,
+  findSelectableModel,
   getAutoDisplayName,
   getSelectedModelLabel,
   isAutoModelId,
   type AutoIntelligenceLevelId,
   type BaseModel,
 } from '@/config/models'
+import { ModelLifecycleBadges } from './model-lifecycle-badges'
 
 type ModelSelectorTriggerLabelProps = {
   selectedModel: string
@@ -27,6 +29,7 @@ export function ModelSelectorTriggerLabel({
   isOpen,
 }: ModelSelectorTriggerLabelProps) {
   const label = getSelectedModelLabel(selectedModel, models, autoIntelligence)
+  const model = findSelectableModel(selectedModel, models)
   if (!label) return null
 
   return (
@@ -47,7 +50,10 @@ export function ModelSelectorTriggerLabel({
           })}
         </span>
       ) : (
-        <span className="whitespace-nowrap text-xs font-medium">{label}</span>
+        <span className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs font-medium">
+          <span className="whitespace-nowrap">{label}</span>
+          {model && <ModelLifecycleBadges model={model} />}
+        </span>
       )}
       <svg
         className={`h-3 w-3 transition-transform ${isOpen ? 'rotate-180' : ''}`}

--- a/src/components/chat/model-selector-trigger-label.tsx
+++ b/src/components/chat/model-selector-trigger-label.tsx
@@ -1,13 +1,11 @@
 import {
   AUTO_INTELLIGENCE_LEVELS,
-  findSelectableModel,
   getAutoDisplayName,
   getSelectedModelLabel,
   isAutoModelId,
   type AutoIntelligenceLevelId,
   type BaseModel,
 } from '@/config/models'
-import { ModelLifecycleBadges } from './model-lifecycle-badges'
 
 type ModelSelectorTriggerLabelProps = {
   selectedModel: string
@@ -29,7 +27,6 @@ export function ModelSelectorTriggerLabel({
   isOpen,
 }: ModelSelectorTriggerLabelProps) {
   const label = getSelectedModelLabel(selectedModel, models, autoIntelligence)
-  const model = findSelectableModel(selectedModel, models)
   if (!label) return null
 
   return (
@@ -50,10 +47,7 @@ export function ModelSelectorTriggerLabel({
           })}
         </span>
       ) : (
-        <span className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs font-medium">
-          <span className="whitespace-nowrap">{label}</span>
-          {model && <ModelLifecycleBadges model={model} />}
-        </span>
+        <span className="whitespace-nowrap text-xs font-medium">{label}</span>
       )}
       <svg
         className={`h-3 w-3 transition-transform ${isOpen ? 'rotate-180' : ''}`}

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -451,10 +451,8 @@ export function ModelSelector({
           )}
         </div>
         <div className="flex min-w-0 flex-1 flex-col">
-          <span className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
-            <span className="font-medium">{model.name}</span>
-            {!model.isAuto && <ModelLifecycleBadges model={model} />}
-          </span>
+          <span className="font-medium">{model.name}</span>
+          {!model.isAuto && <ModelLifecycleBadges model={model} />}
           {!model.isAuto && model.chatConfig?.descriptionShort && (
             <span className="text-xs text-content-muted">
               {model.chatConfig.descriptionShort}

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -422,7 +422,7 @@ export function ModelSelector({
         key={model.modelName}
         role="menuitemradio"
         aria-checked={isSelected}
-        className={`relative flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm transition-colors ${isSelected ? 'text-content-primary' : 'cursor-pointer text-content-secondary hover:bg-surface-card/70'}`}
+        className={`relative flex w-full items-start gap-3 rounded-md px-3 py-2.5 text-left text-sm transition-colors ${isSelected ? 'text-content-primary' : 'cursor-pointer text-content-secondary hover:bg-surface-card/70'}`}
         {...menuItemHandlers(() => {
           onSelect(model.modelName as AIModel)
           focusTrigger()
@@ -452,16 +452,16 @@ export function ModelSelector({
         </div>
         <div className="flex min-w-0 flex-1 flex-col">
           <span className="font-medium">{model.name}</span>
-          {!model.isAuto && <ModelLifecycleBadges model={model} />}
           {!model.isAuto && model.chatConfig?.descriptionShort && (
             <span className="text-xs text-content-muted">
               {model.chatConfig.descriptionShort}
             </span>
           )}
+          {!model.isAuto && <ModelLifecycleBadges model={model} />}
         </div>
         {isSelected && (
           <CheckIcon
-            className="h-4 w-4 flex-none text-brand-accent-dark dark:text-brand-accent-light"
+            className="mt-0.5 h-4 w-4 flex-none text-brand-accent-dark dark:text-brand-accent-light"
             aria-hidden="true"
           />
         )}

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -28,6 +28,7 @@ import {
   supportsThinkingToggle,
   type ReasoningEffort,
 } from './hooks/use-reasoning-effort'
+import { ModelLifecycleBadges } from './model-lifecycle-badges'
 import type { AIModel } from './types'
 
 const EFFORT_OPTIONS: {
@@ -449,16 +450,17 @@ export function ModelSelector({
             </>
           )}
         </div>
-        {!model.isAuto && model.chatConfig?.descriptionShort ? (
-          <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
             <span className="font-medium">{model.name}</span>
+            {!model.isAuto && <ModelLifecycleBadges model={model} />}
+          </span>
+          {!model.isAuto && model.chatConfig?.descriptionShort && (
             <span className="text-xs text-content-muted">
               {model.chatConfig.descriptionShort}
             </span>
-          </div>
-        ) : (
-          <span className="flex-1 font-medium">{model.name}</span>
-        )}
+          )}
+        </div>
         {isSelected && (
           <CheckIcon
             className="h-4 w-4 flex-none text-brand-accent-dark dark:text-brand-accent-light"

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -172,6 +172,7 @@ export type BaseModel = {
   toolCalling?: boolean
   experimental?: boolean
   deprecated?: boolean
+  deprecationdate?: string
   chatConfig?: ChatConfig
   /** True for the synthetic Auto picker entry; never a real backend model. */
   isAuto?: boolean

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -170,6 +170,8 @@ export type BaseModel = {
   paid?: boolean
   multimodal?: boolean
   toolCalling?: boolean
+  experimental?: boolean
+  deprecated?: boolean
   chatConfig?: ChatConfig
   /** True for the synthetic Auto picker entry; never a real backend model. */
   isAuto?: boolean

--- a/tests/components/chat/model-selector.test.tsx
+++ b/tests/components/chat/model-selector.test.tsx
@@ -2,6 +2,7 @@ import { ModelSelector } from '@/components/chat/model-selector'
 import { ModelSelectorTriggerLabel } from '@/components/chat/model-selector-trigger-label'
 import { AUTO_MODEL_ID, type BaseModel } from '@/config/models'
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -20,11 +21,19 @@ const MODEL: BaseModel = {
   chat: true,
 }
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
 
 describe('model lifecycle tags', () => {
   it.each([
     { flags: {}, experimental: false, deprecated: false },
+    {
+      flags: { deprecationdate: '2026-10-01' },
+      experimental: false,
+      deprecated: false,
+    },
     {
       flags: { experimental: false, deprecated: false },
       experimental: false,
@@ -38,7 +47,7 @@ describe('model lifecycle tags', () => {
       deprecated: true,
     },
   ])(
-    'renders the flags $flags in the menu and trigger',
+    'renders the flags $flags only in the menu',
     ({ flags, experimental, deprecated }) => {
       const model = { ...MODEL, ...flags }
       const onSelect = vi.fn()
@@ -62,15 +71,17 @@ describe('model lifecycle tags', () => {
       )
 
       const row = screen.getByRole('menuitemradio', { name: /GPT-OSS 120B/ })
-      for (const element of [row, screen.getByTestId('trigger')]) {
-        expect(within(element).queryByText('Experimental') !== null).toBe(
-          experimental,
-        )
-        expect(within(element).queryByText('Deprecated') !== null).toBe(
-          deprecated,
-        )
-        expect(within(element).getByText(model.name)).toBeVisible()
-      }
+      const trigger = screen.getByTestId('trigger')
+      expect(
+        within(trigger).queryByText('Experimental'),
+      ).not.toBeInTheDocument()
+      expect(within(trigger).queryByText('Deprecated')).not.toBeInTheDocument()
+      expect(within(trigger).getByText(model.name)).toBeVisible()
+      expect(within(row).queryByText('Experimental') !== null).toBe(
+        experimental,
+      )
+      expect(within(row).queryByText('Deprecated') !== null).toBe(deprecated)
+      expect(within(row).getByText(model.name)).toBeVisible()
       expect(row).toHaveAttribute('aria-checked', 'true')
       fireEvent.click(row)
       expect(onSelect).toHaveBeenCalledExactlyOnceWith(model.modelName)
@@ -108,6 +119,13 @@ describe('model lifecycle tags', () => {
     const row = screen.getByRole('menuitemradio', { name: /GPT-OSS 120B/ })
     expect(within(row).getByText('Experimental')).toBeVisible()
     expect(within(row).getByText('Deprecated')).toBeVisible()
+    const name = within(row).getByText(taggedModel.name)
+    const badgeRow = within(row).getByText('Experimental').parentElement
+    expect(name.nextElementSibling).toBe(badgeRow)
+    expect(badgeRow?.nextElementSibling).toHaveTextContent(
+      'Best for quick reasoning tasks',
+    )
+    expect(name.parentElement).toHaveClass('flex-col')
     expect(
       within(row).getByText('Best for quick reasoning tasks'),
     ).toBeVisible()
@@ -129,6 +147,65 @@ describe('model lifecycle tags', () => {
     expect(screen.queryByText('Experimental')).not.toBeInTheDocument()
     expect(screen.queryByText('Deprecated')).not.toBeInTheDocument()
   })
+
+  it.each([
+    {
+      flags: { experimental: true },
+      label: 'Experimental',
+      tooltip:
+        'Support and availability are not guaranteed. This model can be deprecated at any time.',
+    },
+    {
+      flags: { deprecated: true },
+      label: 'Deprecated',
+      tooltip:
+        'This model is deprecated. An offline date has not been announced.',
+    },
+    {
+      flags: {
+        experimental: true,
+        deprecated: true,
+        deprecationdate: '2026-10-01',
+      },
+      label: 'Deprecated',
+      tooltip: 'This model will be taken offline on 2026-10-01.',
+    },
+  ])(
+    'shows the $label explanation on hover without selecting the model',
+    async ({ flags, label, tooltip }) => {
+      vi.useFakeTimers()
+      const onSelect = vi.fn()
+      render(
+        <ModelSelector
+          selectedModel={AUTO_MODEL_ID}
+          models={[{ ...MODEL, ...flags }]}
+          onSelect={onSelect}
+          isDarkMode={false}
+        />,
+      )
+      const row = screen.getByRole('menuitemradio', { name: /GPT-OSS 120B/ })
+      const badge = within(row).getByText(label)
+      expect(badge.tagName).toBe('SPAN')
+      expect(badge).not.toHaveAttribute('tabindex')
+      expect(row.querySelector('button')).toBeNull()
+      expect(within(badge).getByText(`: ${tooltip}`)).toHaveClass('sr-only')
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+      await act(async () => {
+        fireEvent.pointerMove(badge, { pointerType: 'mouse' })
+        await vi.runOnlyPendingTimersAsync()
+      })
+      const content = screen.getByRole('tooltip')
+      expect(content).toHaveTextContent(tooltip)
+      expect(row.contains(content)).toBe(false)
+      expect(onSelect).not.toHaveBeenCalled()
+
+      fireEvent.keyDown(badge, { key: 'Escape' })
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+      fireEvent.click(badge)
+      expect(onSelect).toHaveBeenCalledExactlyOnceWith(MODEL.modelName)
+    },
+  )
 
   it('renders no trigger label for an unavailable model', () => {
     const { container } = render(

--- a/tests/components/chat/model-selector.test.tsx
+++ b/tests/components/chat/model-selector.test.tsx
@@ -120,11 +120,10 @@ describe('model lifecycle tags', () => {
     expect(within(row).getByText('Experimental')).toBeVisible()
     expect(within(row).getByText('Deprecated')).toBeVisible()
     const name = within(row).getByText(taggedModel.name)
+    const description = within(row).getByText('Best for quick reasoning tasks')
     const badgeRow = within(row).getByText('Experimental').parentElement
-    expect(name.nextElementSibling).toBe(badgeRow)
-    expect(badgeRow?.nextElementSibling).toHaveTextContent(
-      'Best for quick reasoning tasks',
-    )
+    expect(name.nextElementSibling).toBe(description)
+    expect(description.nextElementSibling).toBe(badgeRow)
     expect(name.parentElement).toHaveClass('flex-col')
     expect(
       within(row).getByText('Best for quick reasoning tasks'),

--- a/tests/components/chat/model-selector.test.tsx
+++ b/tests/components/chat/model-selector.test.tsx
@@ -1,0 +1,144 @@
+import { ModelSelector } from '@/components/chat/model-selector'
+import { ModelSelectorTriggerLabel } from '@/components/chat/model-selector-trigger-label'
+import { AUTO_MODEL_ID, type BaseModel } from '@/config/models'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const MODEL: BaseModel = {
+  modelName: 'gpt-oss-120b',
+  image: 'openai.png',
+  name: 'GPT-OSS 120B',
+  nameShort: 'GPT-OSS',
+  description: 'Reasoning model',
+  type: 'chat',
+  chat: true,
+}
+
+afterEach(cleanup)
+
+describe('model lifecycle tags', () => {
+  it.each([
+    { flags: {}, experimental: false, deprecated: false },
+    {
+      flags: { experimental: false, deprecated: false },
+      experimental: false,
+      deprecated: false,
+    },
+    { flags: { experimental: true }, experimental: true, deprecated: false },
+    { flags: { deprecated: true }, experimental: false, deprecated: true },
+    {
+      flags: { experimental: true, deprecated: true },
+      experimental: true,
+      deprecated: true,
+    },
+  ])(
+    'renders the flags $flags in the menu and trigger',
+    ({ flags, experimental, deprecated }) => {
+      const model = { ...MODEL, ...flags }
+      const onSelect = vi.fn()
+      render(
+        <>
+          <button type="button" data-testid="trigger">
+            <ModelSelectorTriggerLabel
+              selectedModel={model.modelName}
+              models={[model]}
+              autoIntelligence="high"
+              isOpen={true}
+            />
+          </button>
+          <ModelSelector
+            selectedModel={model.modelName}
+            models={[model]}
+            onSelect={onSelect}
+            isDarkMode={false}
+          />
+        </>,
+      )
+
+      const row = screen.getByRole('menuitemradio', { name: /GPT-OSS 120B/ })
+      for (const element of [row, screen.getByTestId('trigger')]) {
+        expect(within(element).queryByText('Experimental') !== null).toBe(
+          experimental,
+        )
+        expect(within(element).queryByText('Deprecated') !== null).toBe(
+          deprecated,
+        )
+        expect(within(element).getByText(model.name)).toBeVisible()
+      }
+      expect(row).toHaveAttribute('aria-checked', 'true')
+      fireEvent.click(row)
+      expect(onSelect).toHaveBeenCalledExactlyOnceWith(model.modelName)
+    },
+  )
+
+  it('shows tags with a description under Other models without exposing API-only models', () => {
+    const taggedModel: BaseModel = {
+      ...MODEL,
+      experimental: true,
+      deprecated: true,
+      chatConfig: { descriptionShort: 'Best for quick reasoning tasks' },
+    }
+    const models: BaseModel[] = [
+      ...Array.from({ length: 20 }, (_, index) => ({
+        ...MODEL,
+        modelName: `chat-${index}`,
+        name: `Chat ${index}`,
+      })),
+      taggedModel,
+      { ...taggedModel, modelName: 'api-only', name: 'API only', chat: false },
+    ]
+    const onSelect = vi.fn()
+    render(
+      <ModelSelector
+        selectedModel={AUTO_MODEL_ID}
+        models={models}
+        onSelect={onSelect}
+        isDarkMode={true}
+      />,
+    )
+
+    expect(screen.queryByText(taggedModel.name)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Other models' }))
+    const row = screen.getByRole('menuitemradio', { name: /GPT-OSS 120B/ })
+    expect(within(row).getByText('Experimental')).toBeVisible()
+    expect(within(row).getByText('Deprecated')).toBeVisible()
+    expect(
+      within(row).getByText('Best for quick reasoning tasks'),
+    ).toBeVisible()
+    expect(screen.queryByText('API only')).not.toBeInTheDocument()
+    fireEvent.click(row)
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith(taggedModel.modelName)
+  })
+
+  it('does not inherit tags from candidates when Auto is selected', () => {
+    render(
+      <ModelSelectorTriggerLabel
+        selectedModel={AUTO_MODEL_ID}
+        models={[{ ...MODEL, experimental: true, deprecated: true }]}
+        autoIntelligence="high"
+        isOpen={false}
+      />,
+    )
+    expect(screen.getByText('Auto · High')).toBeVisible()
+    expect(screen.queryByText('Experimental')).not.toBeInTheDocument()
+    expect(screen.queryByText('Deprecated')).not.toBeInTheDocument()
+  })
+
+  it('renders no trigger label for an unavailable model', () => {
+    const { container } = render(
+      <ModelSelectorTriggerLabel
+        selectedModel={MODEL.modelName}
+        models={[]}
+        autoIntelligence="high"
+        isOpen={false}
+      />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/tests/components/chat/model-selector.test.tsx
+++ b/tests/components/chat/model-selector.test.tsx
@@ -170,7 +170,7 @@ describe('model lifecycle tags', () => {
       tooltip: 'This model will be taken offline on 2026-10-01.',
     },
   ])(
-    'shows the $label explanation on hover without selecting the model',
+    'shows the $label explanation immediately on hover without selecting the model',
     async ({ flags, label, tooltip }) => {
       vi.useFakeTimers()
       const onSelect = vi.fn()
@@ -190,9 +190,11 @@ describe('model lifecycle tags', () => {
       expect(within(badge).getByText(`: ${tooltip}`)).toHaveClass('sr-only')
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
 
+      // Advancing by 0ms flushes Radix's zero-delay open timer but would leave a
+      // real hover delay pending, so this fails if one is reintroduced.
       await act(async () => {
         fireEvent.pointerMove(badge, { pointerType: 'mouse' })
-        await vi.runOnlyPendingTimersAsync()
+        await vi.advanceTimersByTimeAsync(0)
       })
       const content = screen.getByRole('tooltip')
       expect(content).toHaveTextContent(tooltip)


### PR DESCRIPTION
Show Experimental and Deprecated labels below model names in the model menu, using the controlplane lifecycle flags. Keep the collapsed selector limited to the model name and chevron.

Hover tooltips use the same explanations as marketing, including the offline date when provided. Labels support light and dark themes without changing model availability or routing.