### PR TITLE
refactor: use camelCase for model deprecation date field

### DIFF
--- a/src/components/chat/model-lifecycle-badges.tsx
+++ b/src/components/chat/model-lifecycle-badges.tsx
@@ -17,7 +17,7 @@ const DEPRECATION_TOOLTIP =
 export function ModelLifecycleBadges({
   model,
 }: {
-  model: Pick<BaseModel, 'experimental' | 'deprecated' | 'deprecationdate'>
+  model: Pick<BaseModel, 'experimental' | 'deprecated' | 'deprecationDate'>
 }) {
   if (model.experimental !== true && model.deprecated !== true) return null
 
@@ -36,8 +36,8 @@ export function ModelLifecycleBadges({
       ? [
           {
             label: 'Deprecated',
-            tooltip: model.deprecationdate
-              ? `This model will be taken offline on ${model.deprecationdate}.`
+            tooltip: model.deprecationDate
+              ? `This model will be taken offline on ${model.deprecationDate}.`
               : DEPRECATION_TOOLTIP,
             className:
               'bg-amber-500/10 text-amber-700 dark:bg-amber-400/15 dark:text-amber-300',

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -172,7 +172,7 @@ export type BaseModel = {
   toolCalling?: boolean
   experimental?: boolean
   deprecated?: boolean
-  deprecationdate?: string
+  deprecationDate?: string
   chatConfig?: ChatConfig
   /** True for the synthetic Auto picker entry; never a real backend model. */
   isAuto?: boolean

--- a/tests/components/chat/model-selector.test.tsx
+++ b/tests/components/chat/model-selector.test.tsx
@@ -30,7 +30,7 @@ describe('model lifecycle tags', () => {
   it.each([
     { flags: {}, experimental: false, deprecated: false },
     {
-      flags: { deprecationdate: '2026-10-01' },
+      flags: { deprecationDate: '2026-10-01' },
       experimental: false,
       deprecated: false,
     },
@@ -164,7 +164,7 @@ describe('model lifecycle tags', () => {
       flags: {
         experimental: true,
         deprecated: true,
-        deprecationdate: '2026-10-01',
+        deprecationDate: '2026-10-01',
       },
       label: 'Deprecated',
       tooltip: 'This model will be taken offline on 2026-10-01.',


### PR DESCRIPTION
Renames `deprecationdate` to `deprecationDate` on the model config type and lifecycle badge so it matches the camelCase convention of every other model field. Pairs with tinfoilsh/controlplane#723, which renames the key in the models API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames `deprecationdate` to `deprecationDate` on the model config type and lifecycle badge so it matches the camelCase convention of every other model field. This pairs with the models API change that renames the key in `tinfoilsh/controlplane`.

<sup>Written for commit 30d218b85d204917bd4ba92ec6db16c2d77aec2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

