### PR TITLE
fix: hide deprecated models from the model picker

### DIFF
--- a/src/components/chat/model-lifecycle-badges.tsx
+++ b/src/components/chat/model-lifecycle-badges.tsx
@@ -11,39 +11,21 @@ const BADGE_CLASS_NAME =
 
 const EXPERIMENTAL_TOOLTIP =
   'Support and availability are not guaranteed. This model can be deprecated at any time.'
-const DEPRECATION_TOOLTIP =
-  'This model is deprecated. An offline date has not been announced.'
 
 export function ModelLifecycleBadges({
   model,
 }: {
-  model: Pick<BaseModel, 'experimental' | 'deprecated' | 'deprecationdate'>
+  model: Pick<BaseModel, 'experimental'>
 }) {
-  if (model.experimental !== true && model.deprecated !== true) return null
+  if (model.experimental !== true) return null
 
   const badges = [
-    ...(model.experimental === true
-      ? [
-          {
-            label: 'Experimental',
-            tooltip: EXPERIMENTAL_TOOLTIP,
-            className:
-              'bg-blue-500/10 text-blue-600 dark:bg-blue-400/15 dark:text-blue-300',
-          },
-        ]
-      : []),
-    ...(model.deprecated === true
-      ? [
-          {
-            label: 'Deprecated',
-            tooltip: model.deprecationdate
-              ? `This model will be taken offline on ${model.deprecationdate}.`
-              : DEPRECATION_TOOLTIP,
-            className:
-              'bg-amber-500/10 text-amber-700 dark:bg-amber-400/15 dark:text-amber-300',
-          },
-        ]
-      : []),
+    {
+      label: 'Experimental',
+      tooltip: EXPERIMENTAL_TOOLTIP,
+      className:
+        'bg-blue-500/10 text-blue-600 dark:bg-blue-400/15 dark:text-blue-300',
+    },
   ]
 
   return (

--- a/src/components/chat/model-lifecycle-badges.tsx
+++ b/src/components/chat/model-lifecycle-badges.tsx
@@ -11,21 +11,39 @@ const BADGE_CLASS_NAME =
 
 const EXPERIMENTAL_TOOLTIP =
   'Support and availability are not guaranteed. This model can be deprecated at any time.'
+const DEPRECATION_TOOLTIP =
+  'This model is deprecated. An offline date has not been announced.'
 
 export function ModelLifecycleBadges({
   model,
 }: {
-  model: Pick<BaseModel, 'experimental'>
+  model: Pick<BaseModel, 'experimental' | 'deprecated' | 'deprecationdate'>
 }) {
-  if (model.experimental !== true) return null
+  if (model.experimental !== true && model.deprecated !== true) return null
 
   const badges = [
-    {
-      label: 'Experimental',
-      tooltip: EXPERIMENTAL_TOOLTIP,
-      className:
-        'bg-blue-500/10 text-blue-600 dark:bg-blue-400/15 dark:text-blue-300',
-    },
+    ...(model.experimental === true
+      ? [
+          {
+            label: 'Experimental',
+            tooltip: EXPERIMENTAL_TOOLTIP,
+            className:
+              'bg-blue-500/10 text-blue-600 dark:bg-blue-400/15 dark:text-blue-300',
+          },
+        ]
+      : []),
+    ...(model.deprecated === true
+      ? [
+          {
+            label: 'Deprecated',
+            tooltip: model.deprecationdate
+              ? `This model will be taken offline on ${model.deprecationdate}.`
+              : DEPRECATION_TOOLTIP,
+            className:
+              'bg-amber-500/10 text-amber-700 dark:bg-amber-400/15 dark:text-amber-300',
+          },
+        ]
+      : []),
   ]
 
   return (

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -316,11 +316,13 @@ export function ModelSelector({
   const currentEffort =
     EFFORT_OPTIONS.find((o) => o.value === reasoningEffort) ?? EFFORT_OPTIONS[1]
 
+  // A deprecated model stays visible while it is the active selection so the
+  // menu agrees with the trigger label for chats that already use it.
   const displayModels = models.filter(
     (model) =>
       (model.type === 'chat' || model.type === 'code') &&
       model.chat === true &&
-      model.deprecated !== true,
+      (model.deprecated !== true || model.modelName === selectedModel),
   )
 
   const availableHeight = Number.parseInt(dynamicStyles.maxHeight, 10) || 0

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -318,7 +318,9 @@ export function ModelSelector({
 
   const displayModels = models.filter(
     (model) =>
-      (model.type === 'chat' || model.type === 'code') && model.chat === true,
+      (model.type === 'chat' || model.type === 'code') &&
+      model.chat === true &&
+      model.deprecated !== true,
   )
 
   const availableHeight = Number.parseInt(dynamicStyles.maxHeight, 10) || 0

--- a/tests/components/chat/model-selector.test.tsx
+++ b/tests/components/chat/model-selector.test.tsx
@@ -28,71 +28,71 @@ afterEach(() => {
 
 describe('model lifecycle tags', () => {
   it.each([
-    { flags: {}, experimental: false, deprecated: false },
-    {
-      flags: { deprecationdate: '2026-10-01' },
-      experimental: false,
-      deprecated: false,
-    },
-    {
-      flags: { experimental: false, deprecated: false },
-      experimental: false,
-      deprecated: false,
-    },
-    { flags: { experimental: true }, experimental: true, deprecated: false },
-    { flags: { deprecated: true }, experimental: false, deprecated: true },
-    {
-      flags: { experimental: true, deprecated: true },
-      experimental: true,
-      deprecated: true,
-    },
-  ])(
-    'renders the flags $flags only in the menu',
-    ({ flags, experimental, deprecated }) => {
-      const model = { ...MODEL, ...flags }
-      const onSelect = vi.fn()
-      render(
-        <>
-          <button type="button" data-testid="trigger">
-            <ModelSelectorTriggerLabel
-              selectedModel={model.modelName}
-              models={[model]}
-              autoIntelligence="high"
-              isOpen={true}
-            />
-          </button>
-          <ModelSelector
+    { flags: {}, experimental: false },
+    { flags: { experimental: false }, experimental: false },
+    { flags: { experimental: true }, experimental: true },
+  ])('renders the flags $flags only in the menu', ({ flags, experimental }) => {
+    const model = { ...MODEL, ...flags }
+    const onSelect = vi.fn()
+    render(
+      <>
+        <button type="button" data-testid="trigger">
+          <ModelSelectorTriggerLabel
             selectedModel={model.modelName}
             models={[model]}
-            onSelect={onSelect}
-            isDarkMode={false}
+            autoIntelligence="high"
+            isOpen={true}
           />
-        </>,
-      )
+        </button>
+        <ModelSelector
+          selectedModel={model.modelName}
+          models={[model]}
+          onSelect={onSelect}
+          isDarkMode={false}
+        />
+      </>,
+    )
 
-      const row = screen.getByRole('menuitemradio', { name: /GPT-OSS 120B/ })
-      const trigger = screen.getByTestId('trigger')
-      expect(
-        within(trigger).queryByText('Experimental'),
-      ).not.toBeInTheDocument()
-      expect(within(trigger).queryByText('Deprecated')).not.toBeInTheDocument()
-      expect(within(trigger).getByText(model.name)).toBeVisible()
-      expect(within(row).queryByText('Experimental') !== null).toBe(
-        experimental,
-      )
-      expect(within(row).queryByText('Deprecated') !== null).toBe(deprecated)
-      expect(within(row).getByText(model.name)).toBeVisible()
-      expect(row).toHaveAttribute('aria-checked', 'true')
-      fireEvent.click(row)
-      expect(onSelect).toHaveBeenCalledExactlyOnceWith(model.modelName)
-    },
-  )
+    const row = screen.getByRole('menuitemradio', { name: /GPT-OSS 120B/ })
+    const trigger = screen.getByTestId('trigger')
+    expect(within(trigger).queryByText('Experimental')).not.toBeInTheDocument()
+    expect(within(trigger).getByText(model.name)).toBeVisible()
+    expect(within(row).queryByText('Experimental') !== null).toBe(experimental)
+    expect(within(row).getByText(model.name)).toBeVisible()
+    expect(row).toHaveAttribute('aria-checked', 'true')
+    fireEvent.click(row)
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith(model.modelName)
+  })
+
+  it('hides deprecated models from the menu', () => {
+    const models: BaseModel[] = [
+      { ...MODEL, modelName: 'old-top', name: 'Old top', deprecated: true },
+      ...Array.from({ length: 20 }, (_, index) => ({
+        ...MODEL,
+        modelName: `chat-${index}`,
+        name: `Chat ${index}`,
+      })),
+      { ...MODEL, modelName: 'old-other', name: 'Old other', deprecated: true },
+    ]
+    render(
+      <ModelSelector
+        selectedModel={AUTO_MODEL_ID}
+        models={models}
+        onSelect={vi.fn()}
+        isDarkMode={false}
+      />,
+    )
+    expect(screen.getByText('Chat 0')).toBeVisible()
+    expect(screen.queryByText('Old top')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Other models' }))
+    expect(screen.getByText('Chat 19')).toBeVisible()
+    expect(screen.queryByText('Old other')).not.toBeInTheDocument()
+  })
 
   it('shows tags with a description under Other models without exposing API-only models', () => {
     const taggedModel: BaseModel = {
       ...MODEL,
       experimental: true,
-      deprecated: true,
       chatConfig: { descriptionShort: 'Best for quick reasoning tasks' },
     }
     const models: BaseModel[] = [
@@ -118,7 +118,6 @@ describe('model lifecycle tags', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Other models' }))
     const row = screen.getByRole('menuitemradio', { name: /GPT-OSS 120B/ })
     expect(within(row).getByText('Experimental')).toBeVisible()
-    expect(within(row).getByText('Deprecated')).toBeVisible()
     const name = within(row).getByText(taggedModel.name)
     const description = within(row).getByText('Best for quick reasoning tasks')
     const badgeRow = within(row).getByText('Experimental').parentElement
@@ -137,14 +136,13 @@ describe('model lifecycle tags', () => {
     render(
       <ModelSelectorTriggerLabel
         selectedModel={AUTO_MODEL_ID}
-        models={[{ ...MODEL, experimental: true, deprecated: true }]}
+        models={[{ ...MODEL, experimental: true }]}
         autoIntelligence="high"
         isOpen={false}
       />,
     )
     expect(screen.getByText('Auto · High')).toBeVisible()
     expect(screen.queryByText('Experimental')).not.toBeInTheDocument()
-    expect(screen.queryByText('Deprecated')).not.toBeInTheDocument()
   })
 
   it.each([
@@ -153,21 +151,6 @@ describe('model lifecycle tags', () => {
       label: 'Experimental',
       tooltip:
         'Support and availability are not guaranteed. This model can be deprecated at any time.',
-    },
-    {
-      flags: { deprecated: true },
-      label: 'Deprecated',
-      tooltip:
-        'This model is deprecated. An offline date has not been announced.',
-    },
-    {
-      flags: {
-        experimental: true,
-        deprecated: true,
-        deprecationdate: '2026-10-01',
-      },
-      label: 'Deprecated',
-      tooltip: 'This model will be taken offline on 2026-10-01.',
     },
   ])(
     'shows the $label explanation immediately on hover without selecting the model',

--- a/tests/components/chat/model-selector.test.tsx
+++ b/tests/components/chat/model-selector.test.tsx
@@ -28,43 +28,73 @@ afterEach(() => {
 
 describe('model lifecycle tags', () => {
   it.each([
-    { flags: {}, experimental: false },
-    { flags: { experimental: false }, experimental: false },
-    { flags: { experimental: true }, experimental: true },
-  ])('renders the flags $flags only in the menu', ({ flags, experimental }) => {
-    const model = { ...MODEL, ...flags }
-    const onSelect = vi.fn()
-    render(
-      <>
-        <button type="button" data-testid="trigger">
-          <ModelSelectorTriggerLabel
+    { flags: {}, experimental: false, deprecated: false },
+    {
+      flags: { deprecationdate: '2026-10-01' },
+      experimental: false,
+      deprecated: false,
+    },
+    {
+      flags: { experimental: false, deprecated: false },
+      experimental: false,
+      deprecated: false,
+    },
+    { flags: { experimental: true }, experimental: true, deprecated: false },
+    { flags: { deprecated: true }, experimental: false, deprecated: true },
+    {
+      flags: { experimental: true, deprecated: true },
+      experimental: true,
+      deprecated: true,
+    },
+  ])(
+    'renders the flags $flags only in the menu',
+    ({ flags, experimental, deprecated }) => {
+      const model = { ...MODEL, ...flags }
+      const onSelect = vi.fn()
+      render(
+        <>
+          <button type="button" data-testid="trigger">
+            <ModelSelectorTriggerLabel
+              selectedModel={model.modelName}
+              models={[model]}
+              autoIntelligence="high"
+              isOpen={true}
+            />
+          </button>
+          <ModelSelector
             selectedModel={model.modelName}
             models={[model]}
-            autoIntelligence="high"
-            isOpen={true}
+            onSelect={onSelect}
+            isDarkMode={false}
           />
-        </button>
-        <ModelSelector
-          selectedModel={model.modelName}
-          models={[model]}
-          onSelect={onSelect}
-          isDarkMode={false}
-        />
-      </>,
-    )
+        </>,
+      )
 
-    const row = screen.getByRole('menuitemradio', { name: /GPT-OSS 120B/ })
-    const trigger = screen.getByTestId('trigger')
-    expect(within(trigger).queryByText('Experimental')).not.toBeInTheDocument()
-    expect(within(trigger).getByText(model.name)).toBeVisible()
-    expect(within(row).queryByText('Experimental') !== null).toBe(experimental)
-    expect(within(row).getByText(model.name)).toBeVisible()
-    expect(row).toHaveAttribute('aria-checked', 'true')
-    fireEvent.click(row)
-    expect(onSelect).toHaveBeenCalledExactlyOnceWith(model.modelName)
-  })
+      const row = screen.getByRole('menuitemradio', { name: /GPT-OSS 120B/ })
+      const trigger = screen.getByTestId('trigger')
+      expect(
+        within(trigger).queryByText('Experimental'),
+      ).not.toBeInTheDocument()
+      expect(within(trigger).queryByText('Deprecated')).not.toBeInTheDocument()
+      expect(within(trigger).getByText(model.name)).toBeVisible()
+      expect(within(row).queryByText('Experimental') !== null).toBe(
+        experimental,
+      )
+      expect(within(row).queryByText('Deprecated') !== null).toBe(deprecated)
+      expect(within(row).getByText(model.name)).toBeVisible()
+      expect(row).toHaveAttribute('aria-checked', 'true')
+      fireEvent.click(row)
+      expect(onSelect).toHaveBeenCalledExactlyOnceWith(model.modelName)
+    },
+  )
 
-  it('hides deprecated models from the menu', () => {
+  it('hides deprecated models unless one is the current selection', () => {
+    const selectedDeprecated: BaseModel = {
+      ...MODEL,
+      modelName: 'old-selected',
+      name: 'Old selected',
+      deprecated: true,
+    }
     const models: BaseModel[] = [
       { ...MODEL, modelName: 'old-top', name: 'Old top', deprecated: true },
       ...Array.from({ length: 20 }, (_, index) => ({
@@ -72,27 +102,46 @@ describe('model lifecycle tags', () => {
         modelName: `chat-${index}`,
         name: `Chat ${index}`,
       })),
+      selectedDeprecated,
       { ...MODEL, modelName: 'old-other', name: 'Old other', deprecated: true },
     ]
     render(
-      <ModelSelector
-        selectedModel={AUTO_MODEL_ID}
-        models={models}
-        onSelect={vi.fn()}
-        isDarkMode={false}
-      />,
+      <>
+        <button type="button" data-testid="trigger">
+          <ModelSelectorTriggerLabel
+            selectedModel={selectedDeprecated.modelName}
+            models={models}
+            autoIntelligence="high"
+            isOpen={true}
+          />
+        </button>
+        <ModelSelector
+          selectedModel={selectedDeprecated.modelName}
+          models={models}
+          onSelect={vi.fn()}
+          isDarkMode={false}
+        />
+      </>,
     )
+    expect(
+      within(screen.getByTestId('trigger')).getByText('Old selected'),
+    ).toBeVisible()
     expect(screen.getByText('Chat 0')).toBeVisible()
     expect(screen.queryByText('Old top')).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Other models' }))
     expect(screen.getByText('Chat 19')).toBeVisible()
+    expect(screen.queryByText('Old top')).not.toBeInTheDocument()
     expect(screen.queryByText('Old other')).not.toBeInTheDocument()
+    const row = screen.getByRole('menuitemradio', { name: /Old selected/ })
+    expect(row).toHaveAttribute('aria-checked', 'true')
+    expect(within(row).getByText('Deprecated')).toBeVisible()
   })
 
   it('shows tags with a description under Other models without exposing API-only models', () => {
     const taggedModel: BaseModel = {
       ...MODEL,
       experimental: true,
+      deprecated: true,
       chatConfig: { descriptionShort: 'Best for quick reasoning tasks' },
     }
     const models: BaseModel[] = [
@@ -107,7 +156,7 @@ describe('model lifecycle tags', () => {
     const onSelect = vi.fn()
     render(
       <ModelSelector
-        selectedModel={AUTO_MODEL_ID}
+        selectedModel={taggedModel.modelName}
         models={models}
         onSelect={onSelect}
         isDarkMode={true}
@@ -118,6 +167,7 @@ describe('model lifecycle tags', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Other models' }))
     const row = screen.getByRole('menuitemradio', { name: /GPT-OSS 120B/ })
     expect(within(row).getByText('Experimental')).toBeVisible()
+    expect(within(row).getByText('Deprecated')).toBeVisible()
     const name = within(row).getByText(taggedModel.name)
     const description = within(row).getByText('Best for quick reasoning tasks')
     const badgeRow = within(row).getByText('Experimental').parentElement
@@ -136,13 +186,14 @@ describe('model lifecycle tags', () => {
     render(
       <ModelSelectorTriggerLabel
         selectedModel={AUTO_MODEL_ID}
-        models={[{ ...MODEL, experimental: true }]}
+        models={[{ ...MODEL, experimental: true, deprecated: true }]}
         autoIntelligence="high"
         isOpen={false}
       />,
     )
     expect(screen.getByText('Auto · High')).toBeVisible()
     expect(screen.queryByText('Experimental')).not.toBeInTheDocument()
+    expect(screen.queryByText('Deprecated')).not.toBeInTheDocument()
   })
 
   it.each([
@@ -152,6 +203,21 @@ describe('model lifecycle tags', () => {
       tooltip:
         'Support and availability are not guaranteed. This model can be deprecated at any time.',
     },
+    {
+      flags: { deprecated: true },
+      label: 'Deprecated',
+      tooltip:
+        'This model is deprecated. An offline date has not been announced.',
+    },
+    {
+      flags: {
+        experimental: true,
+        deprecated: true,
+        deprecationdate: '2026-10-01',
+      },
+      label: 'Deprecated',
+      tooltip: 'This model will be taken offline on 2026-10-01.',
+    },
   ])(
     'shows the $label explanation immediately on hover without selecting the model',
     async ({ flags, label, tooltip }) => {
@@ -159,7 +225,7 @@ describe('model lifecycle tags', () => {
       const onSelect = vi.fn()
       render(
         <ModelSelector
-          selectedModel={AUTO_MODEL_ID}
+          selectedModel={MODEL.modelName}
           models={[{ ...MODEL, ...flags }]}
           onSelect={onSelect}
           isDarkMode={false}


### PR DESCRIPTION
Deprecated models no longer appear in the model picker (both the top list and "Other models"). The one exception is a deprecated model that is the current selection: it stays listed and checked, with its Deprecated badge, so existing chats keep a consistent trigger and menu.